### PR TITLE
RBAC for DS and Pod Deployment of CCM

### DIFF
--- a/docs/deploying_cloud_provider_vsphere_with_rbac.md
+++ b/docs/deploying_cloud_provider_vsphere_with_rbac.md
@@ -1,0 +1,108 @@
+# Deploying `cloud-provider-vsphere` with RBAC
+
+This document is designed to quickly get you up and running with the `cloud-provider-vsphere` external Cloud Controller Manager (CCM).
+
+## Deployment Overview
+
+Steps that will covered in deploying `cloud-provider-vpshere`:
+
+1. Set all your Kubernetes nodes to run using an external cloud controller manager.
+2. Configure your vsphere.conf file file and create a `configmap` you settings.
+3. Create the RBAC roles for `cloud-provider-vsphere`.
+4. Create the RBAC role bindings for `cloud-provider-vsphere`.
+5. Deploy `cloud-provider-vsphere` using either the Pod or DaemonSet YAML.
+
+## Deploying `cloud-provider-vsphere`
+
+#### 1. Set the Kubernetes cluster to use an external Cloud Controller Manager
+
+This is already covered in the Kubernetes documentation. Please take a look at configuration guidelines located [here](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager).
+
+
+#### 2. Creating a `configmap` of your vSphere configuration
+
+An example [vsphere.conf](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/vsphere.conf) is located in the `cloud-provider-vsphere` repo in the [manifests/controller-manager](https://github.com/kubernetes/cloud-provider-vsphere/tree/master/manifests/controller-manager) directory.
+
+Example vsphere.conf contents:
+
+```
+[Global]
+# properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+
+user = "vCenter username for cloud provider"
+password = "password"        
+port = "443" #Optional
+insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
+datacenters = "list of datacenters where Kubernetes node VMs are present"
+
+[VirtualCenter "1.2.3.4"]
+# Override specific properties for this Virtual Center.
+        user = "vCenter username for cloud provider"
+        password = "password"
+        # port, insecure-flag, datacenters will be used from Global section.
+
+[VirtualCenter "1.2.3.5"]
+# Override specific properties for this Virtual Center.
+        port = "448"
+        insecure-flag = "0"
+        # user, password, datacenters will be used from Global section.
+
+[Network]
+        public-network = "Network Name to be used"
+```
+
+Configure your vsphere.conf file and create a `configmap` of your settings using the following command:
+
+```bash
+[k8suser@k8master ~]$ kubectl create configmap cloud-config --from-file=vsphere.conf --namespace=kube-system
+```
+
+#### 3. Create the RBAC roles
+
+You can find the RBAC roles required by the provider in [cloud-controller-manager-roles.yaml](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/cloud-controller-manager-roles.yaml).
+
+To apply them to your Kubernetes cluster, run the following command:
+
+```bash
+[k8suser@k8master ~]$ kubectl create -f cloud-controller-manager-roles.yaml
+```
+
+#### 4. Create the RBAC role bindings
+
+You can find the RBAC role bindings required by the provider in [cloud-controller-manager-role-bindings.yaml](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml).
+
+To apply them to your Kubernetes cluster, run the following command:
+
+```bash
+[k8suser@k8master ~]$ kubectl create -f cloud-controller-manager-role-bindings.yaml
+```
+
+#### 5. Deploy `cloud-provider-vsphere` CCM
+
+You have two options for deploying `cloud-provider-vsphere`. It can be deployed either as a simple Pod or in a DaemonSet. There really isn't much difference between the two other than the DaemonSet will do leader election and the Pod will just assume to be the leader.
+
+**IMPORTANT NOTE:** Deploy either as a Pod or in a DaemonSet, but *DO NOT* deploy both.
+
+##### Deploy `cloud-provider-vsphere` as a Pod
+
+The YAML to deploy `cloud-provider-vsphere` as a Pod can be found in [vsphere-cloud-controller-manager-pod.yaml](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml).
+
+The run the following command:
+
+```bash
+[k8suser@k8master ~]$ kubectl create -f vsphere-cloud-controller-manager-pod.yaml
+```
+
+##### Deploy `cloud-provider-vsphere` as a DaemonSet
+
+The YAML to deploy `cloud-provider-vsphere` as a DaemonSet can be found in [vsphere-cloud-controller-manager-ds.yaml](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml).
+
+The run the following command:
+
+```bash
+[k8suser@k8master ~]$ kubectl create -f vsphere-cloud-controller-manager-ds.yaml
+```
+
+## Wrapping Up
+
+That's it! Pretty straightforward. Questions, comments, concerns... please stop by the #sig-vmware channel at [kubernetes.slack.com](https://kubernetes.slack.com).

--- a/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+++ b/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-node-controller
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-node-controller
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-node-controller
+    namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:pvl-controller
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:pvl-controller
+  subjects:
+  - kind: ServiceAccount
+    name: pvl-controller
+    namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-controller-manager
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-controller-manager
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+kind: List
+metadata: {}

--- a/manifests/controller-manager/cloud-controller-manager-roles.yaml
+++ b/manifests/controller-manager/cloud-controller-manager-roles.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:cloud-controller-manager
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumes
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+    - list
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:cloud-node-controller
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - delete
+    - get
+    - patch
+    - update
+    - list
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:pvl-controller
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+kind: List
+metadata: {}

--- a/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
@@ -21,7 +21,7 @@ spec:
       image: docker.io/vmware/vsphere-cloud-controller-manager:latest
       args:
         - /bin/vsphere-cloud-controller-manager
-        - --v=4
+        - --v=2
         - --cloud-config=/etc/cloud/vsphere.conf
         - --cloud-provider=vsphere
         - --use-service-account-credentials=true

--- a/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    component: cloud-controller-manager
+    tier: control-plane
+  name: vsphere-cloud-controller-manager
+  namespace: kube-system
+spec:
+  containers:
+    - name: vsphere-cloud-controller-manager
+      image: docker.io/vmware/vsphere-cloud-controller-manager:latest
+      args:
+        - /bin/vsphere-cloud-controller-manager
+        - --v=4
+        - --cloud-config=/etc/cloud/vsphere.conf
+        - --cloud-provider=vsphere
+        - --use-service-account-credentials=true
+        - --address=127.0.0.1
+        - --kubeconfig=/etc/kubernetes/controller-manager.conf
+      volumeMounts:
+        - mountPath: /etc/kubernetes/pki
+          name: k8s-certs
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /etc/kubernetes/controller-manager.conf
+          name: kubeconfig
+          readOnly: true
+        - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+          name: flexvolume-dir
+        - mountPath: /etc/cloud
+          name: cloud-config-volume
+          readOnly: true
+      resources:
+        requests:
+          cpu: 200m
+  hostNetwork: true
+  securityContext:
+    runAsUser: 1001
+  serviceAccountName: cloud-controller-manager
+  volumes:
+  - hostPath:
+      path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+      type: DirectoryOrCreate
+    name: flexvolume-dir
+  - hostPath:
+      path: /etc/kubernetes/pki
+      type: DirectoryOrCreate
+    name: k8s-certs
+  - hostPath:
+      path: /etc/ssl/certs
+      type: DirectoryOrCreate
+    name: ca-certs
+  - hostPath:
+      path: /etc/kubernetes/controller-manager.conf
+      type: FileOrCreate
+    name: kubeconfig
+  - name: cloud-config-volume
+    configMap:
+      name: cloud-config


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a simple pod-based deployment instead of using a DaemonSet.
Provider roles and bindings for RBAC that support both the DS and POD deployment.

**Which issue this PR fixes**: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/5

**Special notes for your reviewer**: None
