### PR TITLE
Allow Pushing Images with Latest Tag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,18 +32,6 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  name = "github.com/cloudflare/cfssl"
-  packages = [
-    "crypto/pkcs7",
-    "errors",
-    "helpers",
-    "helpers/derhelpers",
-    "log"
-  ]
-  revision = "5d63dbd981b5c408effbb58c442d54761ff94fbd"
-  version = "1.3.2"
-
-[[projects]]
   name = "github.com/coreos/etcd"
   packages = [
     "auth/authpb",
@@ -59,8 +47,8 @@
     "pkg/types",
     "version"
   ]
-  revision = "932c3c01f9d67471d67ff82c38acca196847f039"
-  version = "v3.3.6"
+  revision = "33245c6b5b49130ca99280408fadfab01aac0e48"
+  version = "v3.3.8"
 
 [[projects]]
   name = "github.com/coreos/go-semver"
@@ -87,7 +75,7 @@
     "digestset",
     "reference"
   ]
-  revision = "f0cc927784781fa395c06317c58dea2841ece3a9"
+  revision = "749f6afb4572201e3c37325d0ffedb6f32be8950"
 
 [[projects]]
   name = "github.com/elazarl/go-bindata-assetfs"
@@ -182,21 +170,22 @@
   version = "v1.1.0"
 
 [[projects]]
-  name = "github.com/google/certificate-transparency-go"
-  packages = [
-    ".",
-    "asn1",
-    "tls",
-    "x509",
-    "x509/pkix"
-  ]
-  revision = "5ab67e519c93568ac3ee50fd6772a5bcf8aa460d"
+  branch = "master"
+  name = "github.com/google/btree"
+  packages = ["."]
+  revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
   branch = "master"
   name = "github.com/google/gofuzz"
   packages = ["."]
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+
+[[projects]]
+  name = "github.com/google/uuid"
+  packages = ["."]
+  revision = "064e2069ce9c359c118179501254f67d7d37ba24"
+  version = "0.2"
 
 [[projects]]
   name = "github.com/googleapis/gnostic"
@@ -210,6 +199,15 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/gregjones/httpcache"
+  packages = [
+    ".",
+    "diskcache"
+  ]
+  revision = "9cad4c3443a7200dd6400aef47183728de563a38"
+
+[[projects]]
+  branch = "master"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
@@ -218,16 +216,10 @@
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/howeyc/gopass"
-  packages = ["."]
-  revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
-
-[[projects]]
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "9d5f1277e9a8ed20c3684bda8fde67c05628518c"
-  version = "v0.3.4"
+  revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
+  version = "v0.3.5"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -238,8 +230,8 @@
 [[projects]]
   name = "github.com/json-iterator/go"
   packages = ["."]
-  revision = "ca39e5af3ece67bbcda3d0f4f56a8e24d9f2dad4"
-  version = "1.1.3"
+  revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
+  version = "1.1.4"
 
 [[projects]]
   branch = "master"
@@ -249,7 +241,7 @@
     "jlexer",
     "jwriter"
   ]
-  revision = "9825584555aa620c53c265d4a09ace0df1346fd9"
+  revision = "3fdea8d05856a0c8df22ed4bc71b3219245e4485"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -266,8 +258,8 @@
 [[projects]]
   name = "github.com/modern-go/reflect2"
   packages = ["."]
-  revision = "1df9eeb2bb81f327b96228865c5687bc2194af3f"
-  version = "1.0.0"
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
 
 [[projects]]
   name = "github.com/opencontainers/go-digest"
@@ -280,6 +272,18 @@
   packages = ["."]
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/petar/GoLLRB"
+  packages = ["llrb"]
+  revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
+
+[[projects]]
+  name = "github.com/peterbourgon/diskv"
+  packages = ["."]
+  revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
+  version = "v2.0.1"
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
@@ -312,7 +316,7 @@
     "nfs",
     "xfs"
   ]
-  revision = "94663424ae5ae9856b40a9f170762b4197024661"
+  revision = "7d6f385de8bea29190f15ba9931442a0eaef9af7"
 
 [[projects]]
   name = "github.com/spf13/cobra"
@@ -333,11 +337,15 @@
   version = "v1.1.1"
 
 [[projects]]
+  branch = "master"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
     "find",
     "list",
+    "lookup",
+    "lookup/methods",
+    "lookup/types",
     "nfc",
     "object",
     "pbm",
@@ -345,6 +353,11 @@
     "pbm/types",
     "property",
     "session",
+    "simulator",
+    "simulator/esx",
+    "simulator/vpx",
+    "sts",
+    "sts/internal",
     "task",
     "vim25",
     "vim25/debug",
@@ -355,23 +368,17 @@
     "vim25/types",
     "vim25/xml"
   ]
-  revision = "e3a01f9611c32b2362366434bcd671516e78955d"
-  version = "v0.18.0"
+  revision = "0627a5e7a9dc71f6e02b25f781a9b82f5985b084"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = [
-    "cryptobyte",
-    "cryptobyte/asn1",
     "ed25519",
     "ed25519/internal/edwards25519",
-    "ocsp",
-    "pkcs12",
-    "pkcs12/internal/rc2",
     "ssh/terminal"
   ]
-  revision = "df8d4716b3472e4a531c33cedbe537dae921a1a9"
+  revision = "027cca12c2d63e3d62b670d901e8a2c95854feec"
 
 [[projects]]
   branch = "master"
@@ -386,7 +393,7 @@
     "trace",
     "websocket"
   ]
-  revision = "1e491301e022f8f977054da4c2d852decd59571f"
+  revision = "db08ff08e8622530d9ed3a0e8ac279f6d4c02196"
 
 [[projects]]
   branch = "master"
@@ -395,7 +402,7 @@
     "unix",
     "windows"
   ]
-  revision = "c11f84a56e43e20a78cee75a7c034031ecf57d1f"
+  revision = "f24d3d461d02f3f840cb4ff4ae1c6b3dd9f93db9"
 
 [[projects]]
   name = "golang.org/x/text"
@@ -429,7 +436,7 @@
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  revision = "81158efcc9f219c511e4d3c0d61a0e6e49c01a24"
+  revision = "32ee49c4dd805befd833990acba36cb75042378c"
 
 [[projects]]
   name = "google.golang.org/grpc"
@@ -460,8 +467,8 @@
     "tap",
     "transport"
   ]
-  revision = "41344da2231b913fa3d983840a57a6b1b7b631a1"
-  version = "v1.12.0"
+  revision = "7a6a684ca69eb4cae85ad0a484f2e531598c047b"
+  version = "v1.12.2"
 
 [[projects]]
   name = "gopkg.in/gcfg.v1"
@@ -537,21 +544,23 @@
     "rbac/v1alpha1",
     "rbac/v1beta1",
     "scheduling/v1alpha1",
+    "scheduling/v1beta1",
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
     "storage/v1beta1"
   ]
-  revision = "73d903622b7391f3312dcbac6483fed484e185f8"
-  version = "kubernetes-1.10.0"
+  revision = "072894a440bdee3a891dea811fe42902311cd2a3"
+  version = "kubernetes-1.11.0"
 
 [[projects]]
   branch = "master"
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/features"]
-  revision = "2ddc5e8fd0f5b3823edc16d3bf34f7518a16481f"
+  revision = "003acb65be70b07acafe3b5eb4f13a6d0fe47154"
 
 [[projects]]
+  branch = "release-1.11"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/equality",
@@ -560,9 +569,6 @@
     "pkg/api/resource",
     "pkg/api/validation",
     "pkg/api/validation/path",
-    "pkg/apimachinery",
-    "pkg/apimachinery/announced",
-    "pkg/apimachinery/registered",
     "pkg/apis/meta/internalversion",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
@@ -606,8 +612,7 @@
     "third_party/forked/golang/json",
     "third_party/forked/golang/reflect"
   ]
-  revision = "302974c03f7e50f16561ba237db776ab93594ef6"
-  version = "kubernetes-1.10.0"
+  revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
 
 [[projects]]
   name = "k8s.io/apiserver"
@@ -622,12 +627,12 @@
     "pkg/admission/plugin/webhook/config/apis/webhookadmission",
     "pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1",
     "pkg/admission/plugin/webhook/errors",
+    "pkg/admission/plugin/webhook/generic",
     "pkg/admission/plugin/webhook/mutating",
     "pkg/admission/plugin/webhook/namespace",
     "pkg/admission/plugin/webhook/request",
     "pkg/admission/plugin/webhook/rules",
     "pkg/admission/plugin/webhook/validating",
-    "pkg/admission/plugin/webhook/versioned",
     "pkg/apis/apiserver",
     "pkg/apis/apiserver/install",
     "pkg/apis/apiserver/v1alpha1",
@@ -691,17 +696,19 @@
     "pkg/util/flag",
     "pkg/util/flushwriter",
     "pkg/util/logs",
+    "pkg/util/openapi",
     "pkg/util/trace",
     "pkg/util/webhook",
     "pkg/util/wsstream",
     "plugin/pkg/audit/buffered",
     "plugin/pkg/audit/log",
+    "plugin/pkg/audit/truncate",
     "plugin/pkg/audit/webhook",
     "plugin/pkg/authenticator/token/webhook",
     "plugin/pkg/authorizer/webhook"
   ]
-  revision = "5ae41ac86efd753e2ba012f097b83a914b268236"
-  version = "kubernetes-1.10.0"
+  revision = "01459b68eb5fee2dcf5ca0e29df8bcac89ead47b"
+  version = "kubernetes-1.11.0"
 
 [[projects]]
   name = "k8s.io/client-go"
@@ -741,6 +748,7 @@
     "informers/rbac/v1beta1",
     "informers/scheduling",
     "informers/scheduling/v1alpha1",
+    "informers/scheduling/v1beta1",
     "informers/settings",
     "informers/settings/v1alpha1",
     "informers/storage",
@@ -773,6 +781,7 @@
     "kubernetes/typed/rbac/v1alpha1",
     "kubernetes/typed/rbac/v1beta1",
     "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/scheduling/v1beta1",
     "kubernetes/typed/settings/v1alpha1",
     "kubernetes/typed/storage/v1",
     "kubernetes/typed/storage/v1alpha1",
@@ -797,12 +806,14 @@
     "listers/rbac/v1alpha1",
     "listers/rbac/v1beta1",
     "listers/scheduling/v1alpha1",
+    "listers/scheduling/v1beta1",
     "listers/settings/v1alpha1",
     "listers/storage/v1",
     "listers/storage/v1alpha1",
     "listers/storage/v1beta1",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
+    "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
     "rest",
@@ -822,14 +833,15 @@
     "transport",
     "util/buffer",
     "util/cert",
+    "util/connrotation",
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
     "util/retry",
     "util/workqueue"
   ]
-  revision = "23781f4d6632d88e869066eaebb743857aa1ef9b"
-  version = "v7.0.0"
+  revision = "7d04d0e2a0a1a4d4a1cd6baa432a2301492e4e65"
+  version = "v8.0.0"
 
 [[projects]]
   branch = "master"
@@ -841,7 +853,7 @@
     "pkg/util",
     "pkg/util/proto"
   ]
-  revision = "8a9b82f00b3a86eac24681da3f9fe6c34c01cea2"
+  revision = "bf40560368791a7dddfeea9b3cfcf89b34139f44"
 
 [[projects]]
   name = "k8s.io/kubernetes"
@@ -857,6 +869,7 @@
     "pkg/api/v1/pod",
     "pkg/apis/autoscaling",
     "pkg/apis/componentconfig",
+    "pkg/apis/componentconfig/v1alpha1",
     "pkg/apis/core",
     "pkg/apis/core/helper",
     "pkg/apis/core/install",
@@ -866,27 +879,27 @@
     "pkg/apis/core/validation",
     "pkg/apis/extensions",
     "pkg/apis/networking",
+    "pkg/apis/policy",
     "pkg/apis/scheduling",
     "pkg/capabilities",
     "pkg/client/leaderelectionconfig",
     "pkg/client/metrics/prometheus",
     "pkg/cloudprovider",
-    "pkg/cloudprovider/providers/vsphere",
-    "pkg/cloudprovider/providers/vsphere/vclib",
-    "pkg/cloudprovider/providers/vsphere/vclib/diskmanagers",
     "pkg/controller",
     "pkg/controller/cloud",
     "pkg/controller/route",
     "pkg/controller/service",
+    "pkg/controller/util/node",
     "pkg/features",
     "pkg/fieldpath",
     "pkg/kubelet/apis",
     "pkg/kubelet/types",
+    "pkg/kubelet/util/format",
     "pkg/master/ports",
     "pkg/scheduler/algorithm",
     "pkg/scheduler/algorithm/priorities/util",
     "pkg/scheduler/api",
-    "pkg/scheduler/schedulercache",
+    "pkg/scheduler/cache",
     "pkg/scheduler/util",
     "pkg/security/apparmor",
     "pkg/serviceaccount",
@@ -900,17 +913,16 @@
     "pkg/util/parsers",
     "pkg/util/pointer",
     "pkg/util/taints",
-    "pkg/util/version",
     "pkg/version",
     "pkg/version/prometheus",
     "pkg/version/verflag"
   ]
-  revision = "2bba0127d85d5a46ab4b778548be28623b32d0b0"
-  version = "v1.10.3"
+  revision = "91e7b4fd31fcd3d5f436da26c980becec37ceefe"
+  version = "v1.11.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4ca0b297416042ef5edbd6d637f346900b86ea19a928814fe48b602b1f2d97d8"
+  inputs-digest = "6f77c9642b80bb51975001690eb2d83f18091969233cbfeb82f43c63fa2dcbc7"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,6 +21,14 @@ ignored = ["k8s.io/cloud-provider-vsphere"]
   branch = "master"
 
 [[override]]
+  name = "github.com/vmware/govmomi"
+  branch = "master"
+
+[[override]]
+  name = "github.com/json-iterator/go"
+  version = "1.1.4"
+
+[[override]]
   name = "github.com/spf13/cobra"
   version = "0.0.2"
 
@@ -38,23 +46,23 @@ ignored = ["k8s.io/cloud-provider-vsphere"]
 
 [[override]]
   name = "k8s.io/api"
-  version = "kubernetes-1.10.0"
+  version = "kubernetes-1.11.0"
 
 [[override]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.10.0"
+  version = "kubernetes-1.11.0"
 
 [[override]]
   name = "k8s.io/apiserver"
-  version = "kubernetes-1.10.0"
+  version = "kubernetes-1.11.0"
 
 [[override]]
   name = "k8s.io/client-go"
-  version = "kubernetes-1.10.0"
+  version = "kubernetes-1.11.0"
 
 [[override]]
   name = "k8s.io/kubernetes"
-  version = "1.10.0"
+  version = "1.11.0"
 
 [prune]
   go-tests = true

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ GOFLAGS   :=
 TAGS      :=
 LDFLAGS   := "-w -s -X 'main.version=${VERSION}'"
 REGISTRY ?= k8scloudprovider
+PUSH_LATEST ?= TRUE
 
 ifneq ("$(DEST)", "$(PWD)")
     $(error Please run 'make' from $(DEST). Current directory is $(PWD))
@@ -146,6 +147,9 @@ image-controller-manager: depend vsphere-cloud-controller-manager
 ifeq ($(GOOS),linux)
 	cp vsphere-cloud-controller-manager cluster/images/controller-manager
 	docker build -t $(REGISTRY)/vsphere-cloud-controller-manager:$(VERSION) cluster/images/controller-manager
+ifeq ("$(PUSH_LATEST)","TRUE")
+	docker tag $(REGISTRY)/vsphere-cloud-controller-manager:$(VERSION) $(REGISTRY)/vsphere-cloud-controller-manager:latest
+endif
 	rm cluster/images/controller-manager/vsphere-cloud-controller-manager
 else
 	$(error Please set GOOS=linux for building the image)
@@ -155,6 +159,9 @@ upload-images: images
 	@echo "push images to $(REGISTRY)"
 	docker login -u="$(DOCKER_USERNAME)" -p="$(DOCKER_PASSWORD)";
 	docker push $(REGISTRY)/vsphere-cloud-controller-manager:$(VERSION)
+ifeq ("$(PUSH_LATEST)","TRUE")
+	docker push $(REGISTRY)/vsphere-cloud-controller-manager:latest
+endif
 
 version:
 	@echo ${VERSION}

--- a/cmd/vsphere-cloud-controller-manager/main.go
+++ b/cmd/vsphere-cloud-controller-manager/main.go
@@ -36,7 +36,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -53,7 +53,11 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	goflag.CommandLine.Parse([]string{})
-	s := options.NewCloudControllerManagerOptions()
+	s, err := options.NewCloudControllerManagerOptions()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
 	command := &cobra.Command{
 		Use: "cloud-controller-manager",
 		Long: `The Cloud controller manager is a daemon that embeds
@@ -88,7 +92,7 @@ the cloud specific control loops shipped with Kubernetes.`,
 
 	glog.V(1).Infof("vsphere-cloud-controller-manager version: %s", version)
 
-	s.Generic.ComponentConfig.CloudProvider = vsphere.ProviderName
+	s.CloudProvider.Name = vsphere.ProviderName
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)

--- a/manifests/controller-manager/README.md
+++ b/manifests/controller-manager/README.md
@@ -1,0 +1,3 @@
+## To create configmap from vsphere.conf
+
+kubectl create configmap cloud-config --from-file=vsphere.conf -n kube-system

--- a/manifests/controller-manager/kubeadm.conf
+++ b/manifests/controller-manager/kubeadm.conf
@@ -1,0 +1,6 @@
+kind: MasterConfiguration
+apiVersion: kubeadm.k8s.io/v1alpha1
+kubernetesVersion: 1.11.0
+unifiedControlPlaneImage: "gcr.io/google_containers/hyperkube-amd64:v1.11.0"
+token: c21890.ef74a0d6ea143b61
+cloudProvider: external

--- a/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: vsphere-cloud-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: vsphere-cloud-controller-manager
+spec:
+  selector:
+    matchLabels:
+      k8s-app: vsphere-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: vsphere-cloud-controller-manager
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      securityContext:
+        runAsUser: 0
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: vsphere-cloud-controller-manager
+          image: docker.io/vmware/vsphere-cloud-controller-manager:latest
+          args:
+            - /bin/vsphere-cloud-controller-manager
+            - --v=4
+            - --cloud-provider=vsphere
+            - --cloud-config=/etc/cloud/vsphere.conf
+            - --kubeconfig=/etc/kubernetes/controller-manager.conf
+            - --address=127.0.0.1
+          volumeMounts:
+            - mountPath: /etc/kubernetes/pki
+              name: k8s-certs
+              readOnly: true
+            - mountPath: /etc/ssl/certs
+              name: ca-certs
+              readOnly: true
+            - mountPath: /etc/kubernetes/controller-manager.conf
+              name: kubeconfig
+              readOnly: true
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+              name: flexvolume-dir
+          resources:
+            requests:
+              cpu: 200m
+      hostNetwork: true
+      volumes:
+      - hostPath:
+          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+          type: DirectoryOrCreate
+        name: flexvolume-dir
+      - hostPath:
+          path: /etc/kubernetes/pki
+          type: DirectoryOrCreate
+        name: k8s-certs
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      - hostPath:
+          path: /etc/kubernetes/controller-manager.conf
+          type: FileOrCreate
+        name: kubeconfig
+      - name: vsphere-config-volume
+        configMap:
+          name: cloud-config

--- a/manifests/controller-manager/vsphere.conf
+++ b/manifests/controller-manager/vsphere.conf
@@ -1,0 +1,23 @@
+[Global]
+# properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+
+user = "vCenter username for cloud provider"
+password = "password"        
+port = "443" #Optional
+insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
+datacenters = "list of datacenters where Kubernetes node VMs are present"
+
+[VirtualCenter "1.2.3.4"]
+# Override specific properties for this Virtual Center.
+        user = "vCenter username for cloud provider"
+        password = "password"
+        # port, insecure-flag, datacenters will be used from Global section.
+
+[VirtualCenter "1.2.3.5"]
+# Override specific properties for this Virtual Center.
+        port = "448"
+        insecure-flag = "0"
+        # user, password, datacenters will be used from Global section.
+
+[Network]
+        public-network = "Network Name to be used"

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+
+	"github.com/golang/glog"
+
+	"gopkg.in/gcfg.v1"
+
+	"k8s.io/cloud-provider-vsphere/pkg/vclib"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/controller"
+)
+
+const (
+	MacOUIVCPrefix           string = "00:50:56"
+	MacOUIESXPrefix          string = "00:0c:29"
+	ProviderName             string = "vsphere"
+	RoundTripperDefaultCount uint   = 3
+)
+
+func init() {
+	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+		cfg, err := readConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		return newVSphere(cfg)
+
+	})
+}
+
+// Parses vSphere cloud config file and stores it into VSphereConfig.
+func readConfig(config io.Reader) (Config, error) {
+	if config == nil {
+		return Config{}, fmt.Errorf("no vSphere cloud provider config file given")
+	}
+
+	var cfg Config
+	err := gcfg.ReadInto(&cfg, config)
+	return cfg, err
+}
+
+// Creates new Controller node interface and returns
+func newVSphere(cfg Config) (*VSphere, error) {
+	vs, err := buildVSphereFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	runtime.SetFinalizer(vs, logout)
+	return vs, nil
+}
+
+func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) {
+}
+
+func (vs *VSphere) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	glog.V(1).Info("The vSphere cloud provider does not support load balancers")
+	return nil, false
+}
+
+func (vs *VSphere) Instances() (cloudprovider.Instances, bool) {
+	return vs.instances, true
+}
+
+func (vs *VSphere) Zones() (cloudprovider.Zones, bool) {
+	glog.V(1).Info("The vSphere cloud provider does not support zones")
+	return nil, false
+}
+
+func (vs *VSphere) Clusters() (cloudprovider.Clusters, bool) {
+	return nil, true
+}
+
+func (vs *VSphere) Routes() (cloudprovider.Routes, bool) {
+	glog.V(1).Info("The vSphere cloud provider does not support routes")
+	return nil, false
+}
+
+func (vs *VSphere) ProviderName() string {
+	return ProviderName
+}
+
+func (vs *VSphere) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nil, nil
+}
+
+func (vs *VSphere) HasClusterID() bool {
+	return true
+}
+
+// Initializes vSphere from vSphere CloudProvider Configuration
+func buildVSphereFromConfig(cfg Config) (*VSphere, error) {
+	// TODO(frapposelli): Look into using k8s secrets to store password
+
+	// isSecretInfoProvided := false
+	// if cfg.Global.SecretName != "" && cfg.Global.SecretNamespace != "" {
+	// 	isSecretInfoProvided = true
+	// }
+
+	if cfg.Global.RoundTripperCount == 0 {
+		cfg.Global.RoundTripperCount = RoundTripperDefaultCount
+	}
+
+	if cfg.Global.VCenterPort == "" {
+		cfg.Global.VCenterPort = "443"
+	}
+
+	vsphereInstanceMap, err := populateVsphereInstanceMap(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	nm := NodeManager{
+		vsphereInstanceMap: vsphereInstanceMap,
+		nodeInfoMap:        make(map[string]*NodeInfo),
+	}
+
+	vs := VSphere{
+		vsphereInstanceMap: vsphereInstanceMap,
+		nodeManager:        &nm,
+		instances:          newInstances(&nm),
+	}
+	return &vs, nil
+}
+
+func populateVsphereInstanceMap(cfg *Config) (map[string]*VSphereInstance, error) {
+	vsphereInstanceMap := make(map[string]*VSphereInstance)
+	isSecretInfoProvided := true
+
+	if cfg.Global.SecretName == "" || cfg.Global.SecretNamespace == "" {
+		glog.Warningf("SecretName and/or SecretNamespace is not provided. " +
+			"VCP will use username and password from config file")
+		isSecretInfoProvided = false
+	}
+
+	if isSecretInfoProvided {
+		if cfg.Global.User != "" {
+			glog.Warning("Global.User and Secret info provided. VCP will use secret to get credentials")
+			cfg.Global.User = ""
+		}
+		if cfg.Global.Password != "" {
+			glog.Warning("Global.Password and Secret info provided. VCP will use secret to get credentials")
+			cfg.Global.Password = ""
+		}
+	}
+
+	// vsphere.conf is no longer supported in the old format.
+	for vcServer, vcConfig := range cfg.VirtualCenter {
+		glog.V(4).Infof("Initializing vc server %s", vcServer)
+		if vcServer == "" {
+			glog.Error("vsphere.conf does not have the VirtualCenter IP address specified")
+			return nil, errors.New("vsphere.conf does not have the VirtualCenter IP address specified")
+		}
+
+		if !isSecretInfoProvided {
+			if vcConfig.User == "" {
+				vcConfig.User = cfg.Global.User
+				if vcConfig.User == "" {
+					glog.Errorf("vcConfig.User is empty for vc %s!", vcServer)
+					return nil, errors.New("Username is missing")
+				}
+			}
+			if vcConfig.Password == "" {
+				vcConfig.Password = cfg.Global.Password
+				if vcConfig.Password == "" {
+					glog.Errorf("vcConfig.Password is empty for vc %s!", vcServer)
+					return nil, errors.New("Password is missing")
+				}
+			}
+		} else {
+			if vcConfig.User != "" {
+				glog.Warningf("vcConfig.User for server %s and Secret info provided. VCP will use secret to get credentials", vcServer)
+				vcConfig.User = ""
+			}
+			if vcConfig.Password != "" {
+				glog.Warningf("vcConfig.Password for server %s and Secret info provided. VCP will use secret to get credentials", vcServer)
+				vcConfig.Password = ""
+			}
+		}
+
+		if vcConfig.VCenterPort == "" {
+			vcConfig.VCenterPort = cfg.Global.VCenterPort
+		}
+
+		if vcConfig.Datacenters == "" {
+			if cfg.Global.Datacenters != "" {
+				vcConfig.Datacenters = cfg.Global.Datacenters
+			}
+		}
+		if vcConfig.RoundTripperCount == 0 {
+			vcConfig.RoundTripperCount = cfg.Global.RoundTripperCount
+		}
+
+		// Note: If secrets info is provided username and password will be populated
+		// once secret is created.
+		vSphereConn := vclib.VSphereConnection{
+			Username:          vcConfig.User,
+			Password:          vcConfig.Password,
+			Hostname:          vcServer,
+			Insecure:          cfg.Global.InsecureFlag,
+			RoundTripperCount: vcConfig.RoundTripperCount,
+			Port:              vcConfig.VCenterPort,
+		}
+		vsphereIns := VSphereInstance{
+			conn: &vSphereConn,
+			cfg:  vcConfig,
+		}
+		vsphereInstanceMap[vcServer] = &vsphereIns
+	}
+
+	return vsphereInstanceMap, nil
+}
+
+func logout(vs *VSphere) {
+	for _, vsphereIns := range vs.vsphereInstanceMap {
+		if vsphereIns.conn.Client != nil {
+			vsphereIns.conn.Logout(context.TODO())
+		}
+	}
+}

--- a/pkg/cloudprovider/vsphere/credentialmanager.go
+++ b/pkg/cloudprovider/vsphere/credentialmanager.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/golang/glog"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// Error Messages
+const (
+	CredentialsNotFoundErrMsg = "Credentials not found"
+	CredentialMissingErrMsg   = "Username/Password is missing"
+	UnknownSecretKeyErrMsg    = "Unknown secret key"
+)
+
+// Error constants
+var (
+	ErrCredentialsNotFound = errors.New(CredentialsNotFoundErrMsg)
+	ErrCredentialMissing   = errors.New(CredentialMissingErrMsg)
+	ErrUnknownSecretKey    = errors.New(UnknownSecretKeyErrMsg)
+)
+
+// GetCredential returns credentials for the given vCenter Server.
+// GetCredential returns error if Secret is not added.
+// GetCredential return error is the secret doesn't contain any credentials.
+func (secretCredentialManager *SecretCredentialManager) GetCredential(server string) (*Credential, error) {
+	err := secretCredentialManager.updateCredentialsMap()
+	if err != nil {
+		statusErr, ok := err.(*apierrors.StatusError)
+		if (ok && statusErr.ErrStatus.Code != http.StatusNotFound) || !ok {
+			return nil, err
+		}
+		// Handle secrets deletion by finding credentials from cache
+		glog.Warningf("secret %q not found in namespace %q", secretCredentialManager.SecretName, secretCredentialManager.SecretNamespace)
+	}
+
+	credential, found := secretCredentialManager.Cache.GetCredential(server)
+	if !found {
+		glog.Errorf("credentials not found for server %q", server)
+		return nil, ErrCredentialsNotFound
+	}
+	return &credential, nil
+}
+
+func (secretCredentialManager *SecretCredentialManager) updateCredentialsMap() error {
+	if secretCredentialManager.SecretLister == nil {
+		return fmt.Errorf("SecretLister is not initialized")
+	}
+	secret, err := secretCredentialManager.SecretLister.Secrets(secretCredentialManager.SecretNamespace).Get(secretCredentialManager.SecretName)
+	if err != nil {
+		glog.Errorf("Cannot get secret %s in namespace %s. error: %q", secretCredentialManager.SecretName, secretCredentialManager.SecretNamespace, err)
+		return err
+	}
+	cacheSecret := secretCredentialManager.Cache.GetSecret()
+	if cacheSecret != nil &&
+		cacheSecret.GetResourceVersion() == secret.GetResourceVersion() {
+		glog.V(4).Infof("VCP SecretCredentialManager: Secret %q will not be updated in cache. Since, secrets have same resource version %q", secretCredentialManager.SecretName, cacheSecret.GetResourceVersion())
+		return nil
+	}
+	secretCredentialManager.Cache.UpdateSecret(secret)
+	return secretCredentialManager.Cache.parseSecret()
+}
+
+func (cache *SecretCache) GetSecret() *corev1.Secret {
+	cache.cacheLock.Lock()
+	defer cache.cacheLock.Unlock()
+	return cache.Secret
+}
+
+func (cache *SecretCache) UpdateSecret(secret *corev1.Secret) {
+	cache.cacheLock.Lock()
+	defer cache.cacheLock.Unlock()
+	cache.Secret = secret
+}
+
+func (cache *SecretCache) GetCredential(server string) (Credential, bool) {
+	cache.cacheLock.Lock()
+	defer cache.cacheLock.Unlock()
+	credential, found := cache.VirtualCenter[server]
+	if !found {
+		return Credential{}, found
+	}
+	return *credential, found
+}
+
+func (cache *SecretCache) parseSecret() error {
+	cache.cacheLock.Lock()
+	defer cache.cacheLock.Unlock()
+	return parseConfig(cache.Secret.Data, cache.VirtualCenter)
+}
+
+// parseConfig returns vCenter ip/fdqn mapping to its credentials viz. Username and Password.
+func parseConfig(data map[string][]byte, config map[string]*Credential) error {
+	if len(data) == 0 {
+		return ErrCredentialMissing
+	}
+	for credentialKey, credentialValue := range data {
+		credentialKey = strings.ToLower(credentialKey)
+		vcServer := ""
+		if strings.HasSuffix(credentialKey, "password") {
+			vcServer = strings.Split(credentialKey, ".password")[0]
+			if _, ok := config[vcServer]; !ok {
+				config[vcServer] = &Credential{}
+			}
+			config[vcServer].Password = string(credentialValue)
+		} else if strings.HasSuffix(credentialKey, "username") {
+			vcServer = strings.Split(credentialKey, ".username")[0]
+			if _, ok := config[vcServer]; !ok {
+				config[vcServer] = &Credential{}
+			}
+			config[vcServer].User = string(credentialValue)
+		} else {
+			glog.Errorf("Unknown secret key %s", credentialKey)
+			return ErrUnknownSecretKey
+		}
+	}
+	for vcServer, credential := range config {
+		if credential.User == "" || credential.Password == "" {
+			glog.Errorf("Username/Password is missing for server %s", vcServer)
+			return ErrCredentialMissing
+		}
+	}
+	return nil
+}

--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -1,0 +1,568 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+
+	"k8s.io/cloud-provider-vsphere/pkg/vclib"
+)
+
+const (
+	POOL_SIZE      int    = 8
+	QUEUE_SIZE     int    = POOL_SIZE * 10
+	ProviderPrefix string = "vsphere://"
+)
+
+func newInstances(nodeManager *NodeManager) cloudprovider.Instances {
+	return &instances{nodeManager}
+}
+
+// NodeAddresses returns all the valid addresses of the instance identified by
+// nodeName. Only the public/private IPv4 addresses are considered for now.
+//
+// When nodeName identifies more than one instance, only the first will be
+// considered.
+func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v1.NodeAddress, error) {
+	glog.V(4).Info("vsphere.instances.NodeAddresses() called")
+
+	// Check if node has been discovered already
+	if node, ok := i.nodeManager.nodeInfoMap[string(nodeName)]; ok {
+		return node.NodeAddresses, nil
+	}
+
+	if err := i.nodeDiscoveryByName(ctx, nodeName); err != nil {
+		return []v1.NodeAddress{}, err
+	}
+
+	return i.nodeManager.nodeInfoMap[string(nodeName)].NodeAddresses, nil
+}
+
+// NodeAddressesByProviderID returns all the valid addresses of the instance
+// identified by providerID. Only the public/private IPv4 addresses will be
+// considered for now.
+func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
+	glog.V(4).Info("vsphere.instances.NodeAddressesByProviderID() called")
+	return i.NodeAddresses(ctx, types.NodeName(providerID))
+}
+
+// ExternalID returns the cloud provider ID of the instance identified by
+// nodeName. If the instance does not exist or is no longer running, the
+// returned error will be cloudprovider.InstanceNotFound.
+//
+// When nodeName identifies more than one instance, only the first will be
+// considered.
+func (i *instances) ExternalID(ctx context.Context, nodeName types.NodeName) (string, error) {
+	glog.V(4).Info("vsphere.instances.ExternalID() called")
+	return i.InstanceID(ctx, nodeName)
+}
+
+// InstanceID returns the cloud provider ID of the instance identified by nodeName.
+func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
+	glog.V(4).Info("vsphere.instances.InstanceID() called")
+
+	// Check if node has been discovered already
+	if node, ok := i.nodeManager.nodeInfoMap[string(nodeName)]; ok {
+		return node.UUID, nil
+	}
+
+	if err := i.nodeDiscoveryByName(ctx, nodeName); err != nil {
+		return "", err
+	}
+
+	return i.nodeManager.nodeInfoMap[string(nodeName)].UUID, nil
+
+}
+
+// InstanceType returns the type of the instance identified by name.
+func (i *instances) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
+	glog.V(4).Info("vsphere.instances.InstanceType() called")
+	return "vsphere-vm", nil
+}
+
+// InstanceTypeByProviderID returns the type of the instance identified by providerID.
+func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
+	glog.V(4).Info("vsphere.instances.InstanceTypeByProviderID() called")
+	return "vsphere-vm", nil
+}
+
+// AddSSHKeyToAllInstances is not implemented; it always returns an error.
+func (i *instances) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
+	glog.V(4).Info("vsphere.instances.AddSSHKeyToAllInstances() called")
+	return cloudprovider.NotImplemented
+}
+
+// CurrentNodeName returns hostname as a NodeName value.
+func (i *instances) CurrentNodeName(ctx context.Context, hostname string) (types.NodeName, error) {
+	glog.V(4).Info("vsphere.instances.CurrentNodeName() called")
+	return types.NodeName(hostname), nil
+}
+
+// InstanceExistsByProviderID returns true if the instance identified by
+// providerID is running.
+func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
+	glog.V(4).Info("vsphere.instances.InstanceExistsByProviderID() called")
+
+	// Check if node has been discovered already
+	if _, ok := i.nodeManager.nodeInfoMap[providerID]; !ok {
+		if err := i.nodeDiscoveryByProviderID(ctx, providerID); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	return true, nil
+}
+
+// InstanceShutdownByProviderID returns true if the instance is in safe state to detach volumes
+func (i *instances) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
+	return false, cloudprovider.NotImplemented
+}
+
+// PRIVATE
+
+func (i *instances) nodeDiscoveryByName(ctx context.Context, nodeName types.NodeName) error {
+	glog.V(4).Info("vsphere.instances.nodeDiscovery() called")
+
+	type VmSearch struct {
+		vc         string
+		datacenter *vclib.Datacenter
+	}
+
+	var mutex = &sync.Mutex{}
+	var globalErrMutex = &sync.Mutex{}
+	var queueChannel chan *VmSearch
+	var wg sync.WaitGroup
+	var globalErr *error
+
+	queueChannel = make(chan *VmSearch, QUEUE_SIZE)
+
+	glog.V(4).Infof("Discovering node %s with name %s", string(nodeName), string(nodeName))
+
+	vmFound := false
+	globalErr = nil
+
+	setGlobalErr := func(err error) {
+		globalErrMutex.Lock()
+		globalErr = &err
+		globalErrMutex.Unlock()
+	}
+
+	setVMFound := func(found bool) {
+		mutex.Lock()
+		vmFound = found
+		mutex.Unlock()
+	}
+
+	getVMFound := func() bool {
+		mutex.Lock()
+		found := vmFound
+		mutex.Unlock()
+		return found
+	}
+
+	go func() {
+		var datacenterObjs []*vclib.Datacenter
+		for vc, vsi := range i.nodeManager.vsphereInstanceMap {
+
+			found := getVMFound()
+			if found == true {
+				break
+			}
+
+			// Create context
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := i.vcConnect(ctx, vsi)
+			if err != nil {
+				glog.V(4).Info("Discovering node error vc:", err)
+				setGlobalErr(err)
+				continue
+			}
+
+			if vsi.cfg.Datacenters == "" {
+				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.conn)
+				if err != nil {
+					glog.V(4).Info("Discovering node error dc:", err)
+					setGlobalErr(err)
+					continue
+				}
+			} else {
+				datacenters := strings.Split(vsi.cfg.Datacenters, ",")
+				for _, dc := range datacenters {
+					dc = strings.TrimSpace(dc)
+					if dc == "" {
+						continue
+					}
+					datacenterObj, err := vclib.GetDatacenter(ctx, vsi.conn, dc)
+					if err != nil {
+						glog.V(4).Info("Discovering node error dc:", err)
+						setGlobalErr(err)
+						continue
+					}
+					datacenterObjs = append(datacenterObjs, datacenterObj)
+				}
+			}
+
+			for _, datacenterObj := range datacenterObjs {
+				found := getVMFound()
+				if found == true {
+					break
+				}
+
+				glog.V(4).Infof("Finding node %s in vc=%s and datacenter=%s", nodeName, vc, datacenterObj.Name())
+				queueChannel <- &VmSearch{
+					vc:         vc,
+					datacenter: datacenterObj,
+				}
+			}
+		}
+		close(queueChannel)
+	}()
+
+	for j := 0; j < POOL_SIZE; j++ {
+		go func() {
+			for res := range queueChannel {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				// vm, err := res.datacenter.GetVMByUUID(ctx, nodeUUID)
+				vm, err := res.datacenter.GetVMByDNSName(ctx, string(nodeName))
+				if err != nil {
+					glog.V(4).Infof("Error %q while looking for vm=%+v in vc=%s and datacenter=%s",
+						err, nodeName, vm, res.vc, res.datacenter.Name())
+					if err != vclib.ErrNoVMFound {
+						setGlobalErr(err)
+					} else {
+						glog.V(4).Infof("Did not find node %s in vc=%s and datacenter=%s",
+							nodeName, res.vc, res.datacenter.Name(), err)
+					}
+					continue
+				}
+				if vm != nil {
+					glog.V(4).Infof("Found node %s as vm=%+v in vc=%s and datacenter=%s",
+						nodeName, vm, res.vc, res.datacenter.Name())
+
+					nodeUUID, err := vm.GetVMUUID()
+					if err != nil {
+						glog.V(4).Infof("Did not find UUID node %s in vc=%s and datacenter=%s",
+							nodeName, res.vc, res.datacenter.Name(), err)
+					}
+
+					addrs := []v1.NodeAddress{}
+					vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*vclib.VirtualMachine{vm}, []string{"guest.net"})
+					if err != nil {
+						glog.Errorf("Failed to get VM Managed object with property guest.net for node: %q. err: +%v", string(nodeName), err)
+						// return nil, err
+					}
+					// retrieve VM's ip(s)
+					for _, v := range vmMoList[0].Guest.Net {
+						// if vsi.cfg.Network.PublicNetwork == v.Network {
+						for _, ip := range v.IpAddress {
+							if net.ParseIP(ip).To4() != nil {
+								v1helper.AddToNodeAddresses(&addrs,
+									v1.NodeAddress{
+										Type:    v1.NodeExternalIP,
+										Address: ip,
+									}, v1.NodeAddress{
+										Type:    v1.NodeInternalIP,
+										Address: ip,
+									},
+								)
+							}
+						}
+						// }
+					}
+
+					nodeInfo := &NodeInfo{
+						dataCenter:    res.datacenter,
+						vm:            vm,
+						vcServer:      res.vc,
+						UUID:          nodeUUID,
+						NodeName:      string(nodeName),
+						NodeAddresses: addrs,
+					}
+
+					i.nodeManager.nodeInfoLock.Lock()
+					i.nodeManager.nodeInfoMap[string(nodeName)] = nodeInfo
+					i.nodeManager.nodeInfoMap[ProviderPrefix+nodeUUID] = nodeInfo
+					i.nodeManager.nodeInfoLock.Unlock()
+
+					for range queueChannel {
+					}
+					setVMFound(true)
+					break
+				}
+			}
+			wg.Done()
+		}()
+		wg.Add(1)
+	}
+	wg.Wait()
+	if vmFound {
+		return nil
+	}
+	if globalErr != nil {
+		return *globalErr
+	}
+
+	glog.V(4).Infof("Discovery Node: %q vm not found", nodeName)
+	return vclib.ErrNoVMFound
+
+}
+
+// TODO(frapposelli): FIX THIS CODE DUPLICATION
+// TODO(frapposelli): THIS SHOULD BE DONE WITH PROPERTYCOLLECTOR
+func (i *instances) nodeDiscoveryByProviderID(ctx context.Context, providerID string) error {
+	glog.V(4).Info("vsphere.instances.nodeDiscovery() called")
+
+	type VmSearch struct {
+		vc         string
+		datacenter *vclib.Datacenter
+	}
+
+	var mutex = &sync.Mutex{}
+	var globalErrMutex = &sync.Mutex{}
+	var queueChannel chan *VmSearch
+	var wg sync.WaitGroup
+	var globalErr *error
+
+	queueChannel = make(chan *VmSearch, QUEUE_SIZE)
+
+	glog.V(4).Infof("Discovering node with providerID %s", providerID)
+
+	vmFound := false
+	globalErr = nil
+
+	setGlobalErr := func(err error) {
+		globalErrMutex.Lock()
+		globalErr = &err
+		globalErrMutex.Unlock()
+	}
+
+	setVMFound := func(found bool) {
+		mutex.Lock()
+		vmFound = found
+		mutex.Unlock()
+	}
+
+	getVMFound := func() bool {
+		mutex.Lock()
+		found := vmFound
+		mutex.Unlock()
+		return found
+	}
+
+	go func() {
+		var datacenterObjs []*vclib.Datacenter
+		for vc, vsi := range i.nodeManager.vsphereInstanceMap {
+
+			found := getVMFound()
+			if found == true {
+				break
+			}
+
+			// Create context
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := i.vcConnect(ctx, vsi)
+			if err != nil {
+				glog.V(4).Info("Discovering node error vc:", err)
+				setGlobalErr(err)
+				continue
+			}
+
+			if vsi.cfg.Datacenters == "" {
+				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.conn)
+				if err != nil {
+					glog.V(4).Info("Discovering node error dc:", err)
+					setGlobalErr(err)
+					continue
+				}
+			} else {
+				datacenters := strings.Split(vsi.cfg.Datacenters, ",")
+				for _, dc := range datacenters {
+					dc = strings.TrimSpace(dc)
+					if dc == "" {
+						continue
+					}
+					datacenterObj, err := vclib.GetDatacenter(ctx, vsi.conn, dc)
+					if err != nil {
+						glog.V(4).Info("Discovering node error dc:", err)
+						setGlobalErr(err)
+						continue
+					}
+					datacenterObjs = append(datacenterObjs, datacenterObj)
+				}
+			}
+
+			for _, datacenterObj := range datacenterObjs {
+				found := getVMFound()
+				if found == true {
+					break
+				}
+
+				glog.V(4).Infof("Finding providerID %s in vc=%s and datacenter=%s", providerID, vc, datacenterObj.Name())
+				queueChannel <- &VmSearch{
+					vc:         vc,
+					datacenter: datacenterObj,
+				}
+			}
+		}
+		close(queueChannel)
+	}()
+
+	for j := 0; j < POOL_SIZE; j++ {
+		go func() {
+			for res := range queueChannel {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				nodeUUID := i.GetUUIDFromProviderID(providerID)
+				vm, err := res.datacenter.GetVMByUUID(ctx, nodeUUID)
+				if err != nil {
+					glog.V(4).Infof("Error %q while looking for vm=%+v in vc=%s and datacenter=%s",
+						err, nodeUUID, vm, res.vc, res.datacenter.Name())
+					if err != vclib.ErrNoVMFound {
+						setGlobalErr(err)
+					} else {
+						glog.V(4).Infof("Did not find node %s in vc=%s and datacenter=%s",
+							nodeUUID, res.vc, res.datacenter.Name(), err)
+					}
+					continue
+				}
+				if vm != nil {
+					nodeName, err := vm.GetVMNodeName()
+					if err != nil {
+						glog.V(4).Infof("Did not find NodeName node %s in vc=%s and datacenter=%s",
+							nodeName, res.vc, res.datacenter.Name(), err)
+					}
+
+					glog.V(4).Infof("Found node %s as vm=%+v in vc=%s and datacenter=%s",
+						nodeName, vm, res.vc, res.datacenter.Name())
+
+					addrs := []v1.NodeAddress{}
+					vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*vclib.VirtualMachine{vm}, []string{"guest.net"})
+					if err != nil {
+						glog.Errorf("Failed to get VM Managed object with property guest.net for node: %q. err: +%v", string(nodeName), err)
+						// return nil, err
+					}
+					// retrieve VM's ip(s)
+					for _, v := range vmMoList[0].Guest.Net {
+						// if vsi.cfg.Network.PublicNetwork == v.Network {
+						for _, ip := range v.IpAddress {
+							if net.ParseIP(ip).To4() != nil {
+								v1helper.AddToNodeAddresses(&addrs,
+									v1.NodeAddress{
+										Type:    v1.NodeExternalIP,
+										Address: ip,
+									}, v1.NodeAddress{
+										Type:    v1.NodeInternalIP,
+										Address: ip,
+									},
+								)
+							}
+						}
+						// }
+					}
+
+					nodeInfo := &NodeInfo{
+						dataCenter:    res.datacenter,
+						vm:            vm,
+						vcServer:      res.vc,
+						UUID:          nodeUUID,
+						NodeName:      string(nodeName),
+						NodeAddresses: addrs,
+					}
+
+					i.nodeManager.nodeInfoLock.Lock()
+					i.nodeManager.nodeInfoMap[string(nodeName)] = nodeInfo
+					i.nodeManager.nodeInfoMap[ProviderPrefix+nodeUUID] = nodeInfo
+					i.nodeManager.nodeInfoLock.Unlock()
+
+					for range queueChannel {
+					}
+					setVMFound(true)
+					break
+				}
+			}
+			wg.Done()
+		}()
+		wg.Add(1)
+	}
+	wg.Wait()
+	if vmFound {
+		return nil
+	}
+	if globalErr != nil {
+		return *globalErr
+	}
+
+	glog.V(4).Infof("Discovery providerID: %q vm not found", providerID)
+	return vclib.ErrNoVMFound
+
+}
+
+func (i *instances) vcConnect(ctx context.Context, vsphereInstance *VSphereInstance) error {
+	err := vsphereInstance.conn.Connect(ctx)
+	if err == nil {
+		return nil
+	}
+
+	credentialManager := i.CredentialManager()
+	if !vclib.IsInvalidCredentialsError(err) || credentialManager == nil {
+		glog.Errorf("Cannot connect to vCenter with err: %v", err)
+		return err
+	}
+
+	glog.V(4).Infof("Invalid credentials. Cannot connect to server %q. "+
+		"Fetching credentials from secrets.", vsphereInstance.conn.Hostname)
+
+	// Get latest credentials from SecretCredentialManager
+	credentials, err := credentialManager.GetCredential(vsphereInstance.conn.Hostname)
+	if err != nil {
+		glog.Errorf("Failed to get credentials from Secret Credential Manager with err: %v", err)
+		return err
+	}
+	vsphereInstance.conn.UpdateCredentials(credentials.User, credentials.Password)
+	return vsphereInstance.conn.Connect(ctx)
+}
+
+func (i *instances) CredentialManager() *SecretCredentialManager {
+	i.nodeManager.credentialManagerLock.Lock()
+	defer i.nodeManager.credentialManagerLock.Unlock()
+	return i.nodeManager.credentialManager
+}
+
+func (i *instances) UpdateCredentialManager(credentialManager *SecretCredentialManager) {
+	i.nodeManager.credentialManagerLock.Lock()
+	defer i.nodeManager.credentialManagerLock.Unlock()
+	i.nodeManager.credentialManager = credentialManager
+}
+
+func (i *instances) GetUUIDFromProviderID(providerID string) string {
+	return strings.TrimPrefix(providerID, ProviderPrefix)
+}

--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"sync"
+
+	"k8s.io/api/core/v1"
+	clientv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/cloud-provider-vsphere/pkg/vclib"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+// VSphere is an implementation of cloud provider Interface for VSphere.
+type VSphere struct {
+	// client        *godo.Client
+	// cfg                *Config
+	vsphereInstanceMap map[string]*VSphereInstance
+	nodeManager        *NodeManager
+	instances          cloudprovider.Instances
+}
+
+// Config is used to read and store information from the cloud configuration file
+type Config struct {
+	Global struct {
+		// vCenter username.
+		User string `gcfg:"user"`
+		// vCenter password in clear text.
+		Password string `gcfg:"password"`
+		// Deprecated. Use VirtualCenter to specify multiple vCenter Servers.
+		// vCenter IP.
+		VCenterIP string `gcfg:"server"`
+		// vCenter port.
+		VCenterPort string `gcfg:"port"`
+		// True if vCenter uses self-signed cert.
+		InsecureFlag bool `gcfg:"insecure-flag"`
+		// Datacenter in which VMs are located.
+		Datacenters string `gcfg:"datacenters"`
+		// Soap round tripper count (retries = RoundTripper - 1)
+		RoundTripperCount uint `gcfg:"soap-roundtrip-count"`
+		// Name of the secret were vCenter credentials are present.
+		SecretName string `gcfg:"secret-name"`
+		// Secret Namespace where secret will be present that has vCenter credentials.
+		SecretNamespace string `gcfg:"secret-namespace"`
+	}
+	VirtualCenter map[string]*VirtualCenterConfig
+
+	Network struct {
+		// PublicNetwork is name of the network the VMs are joined to.
+		PublicNetwork string `gcfg:"public-network"`
+	}
+}
+
+// Represents a vSphere instance where one or more kubernetes nodes are running.
+type VSphereInstance struct {
+	conn *vclib.VSphereConnection
+	cfg  *VirtualCenterConfig
+}
+
+// Structure that represents Virtual Center configuration
+type VirtualCenterConfig struct {
+	// vCenter username.
+	User string `gcfg:"user"`
+	// vCenter password in clear text.
+	Password string `gcfg:"password"`
+	// vCenter port.
+	VCenterPort string `gcfg:"port"`
+	// Datacenter in which VMs are located.
+	Datacenters string `gcfg:"datacenters"`
+	// Soap round tripper count (retries = RoundTripper - 1)
+	RoundTripperCount uint `gcfg:"soap-roundtrip-count"`
+	// PublicNetwork is name of the network the VMs are joined to.
+	PublicNetwork string `gcfg:"public-network"`
+}
+
+// Stores info about the kubernetes node
+type NodeInfo struct {
+	dataCenter    *vclib.Datacenter
+	vm            *vclib.VirtualMachine
+	vcServer      string
+	UUID          string
+	NodeName      string
+	NodeAddresses []v1.NodeAddress
+}
+
+type NodeManager struct {
+	// TODO: replace map with concurrent map when k8s supports go v1.9
+
+	// Maps the VC server to VSphereInstance
+	vsphereInstanceMap map[string]*VSphereInstance
+	// Maps node name to node info.
+	nodeInfoMap map[string]*NodeInfo
+	//CredentialsManager
+	credentialManager *SecretCredentialManager
+
+	// Mutexes
+	nodeInfoLock          sync.RWMutex
+	credentialManagerLock sync.Mutex
+}
+
+type NodeDetails struct {
+	NodeName string
+	vm       *vclib.VirtualMachine
+	UUID     string
+}
+
+type SecretCache struct {
+	cacheLock     sync.Mutex
+	VirtualCenter map[string]*Credential
+	Secret        *v1.Secret
+}
+
+type Credential struct {
+	User     string `gcfg:"user"`
+	Password string `gcfg:"password"`
+}
+
+type SecretCredentialManager struct {
+	SecretName      string
+	SecretNamespace string
+	SecretLister    clientv1.SecretLister
+	Cache           *SecretCache
+}
+
+type instances struct {
+	nodeManager *NodeManager
+}

--- a/pkg/vclib/connection.go
+++ b/pkg/vclib/connection.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/pem"
+	"net"
+	neturl "net/url"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// VSphereConnection contains information for connecting to vCenter
+type VSphereConnection struct {
+	Client            *vim25.Client
+	Username          string
+	Password          string
+	Hostname          string
+	Port              string
+	Insecure          bool
+	RoundTripperCount uint
+	credentialsLock   sync.Mutex
+}
+
+var (
+	clientLock sync.Mutex
+)
+
+// Connect makes connection to vCenter and sets VSphereConnection.Client.
+// If connection.Client is already set, it obtains the existing user session.
+// if user session is not valid, connection.Client will be set to the new client.
+func (connection *VSphereConnection) Connect(ctx context.Context) error {
+	var err error
+	clientLock.Lock()
+	defer clientLock.Unlock()
+
+	if connection.Client == nil {
+		connection.Client, err = connection.NewClient(ctx)
+		if err != nil {
+			glog.Errorf("Failed to create govmomi client. err: %+v", err)
+			return err
+		}
+		return nil
+	}
+	m := session.NewManager(connection.Client)
+	userSession, err := m.UserSession(ctx)
+	if err != nil {
+		glog.Errorf("Error while obtaining user session. err: %+v", err)
+		return err
+	}
+	if userSession != nil {
+		return nil
+	}
+	glog.Warningf("Creating new client session since the existing session is not valid or not authenticated")
+
+	connection.Client, err = connection.NewClient(ctx)
+	if err != nil {
+		glog.Errorf("Failed to create govmomi client. err: %+v", err)
+		return err
+	}
+	return nil
+}
+
+// login calls SessionManager.LoginByToken if certificate and private key are configured,
+// otherwise calls SessionManager.Login with user and password.
+func (connection *VSphereConnection) login(ctx context.Context, client *vim25.Client) error {
+	m := session.NewManager(client)
+	connection.credentialsLock.Lock()
+	defer connection.credentialsLock.Unlock()
+
+	// TODO: Add separate fields for certificate and private-key.
+	// For now we can leave the config structs and validation as-is and
+	// decide to use LoginByToken if the username value is PEM encoded.
+	b, _ := pem.Decode([]byte(connection.Username))
+	if b == nil {
+		glog.V(3).Infof("SessionManager.Login with username '%s'", connection.Username)
+		return m.Login(ctx, neturl.UserPassword(connection.Username, connection.Password))
+	}
+
+	glog.V(3).Infof("SessionManager.LoginByToken with certificate '%s'", connection.Username)
+
+	cert, err := tls.X509KeyPair([]byte(connection.Username), []byte(connection.Password))
+	if err != nil {
+		glog.Errorf("Failed to load X509 key pair. err: %+v", err)
+		return err
+	}
+
+	tokens, err := sts.NewClient(ctx, client)
+	if err != nil {
+		glog.Errorf("Failed to create STS client. err: %+v", err)
+		return err
+	}
+
+	req := sts.TokenRequest{
+		Certificate: &cert,
+	}
+
+	signer, err := tokens.Issue(ctx, req)
+	if err != nil {
+		glog.Errorf("Failed to issue SAML token. err: %+v", err)
+		return err
+	}
+
+	header := soap.Header{Security: signer}
+
+	return m.LoginByToken(client.WithHeader(ctx, header))
+}
+
+// Logout calls SessionManager.Logout for the given connection.
+func (connection *VSphereConnection) Logout(ctx context.Context) {
+	m := session.NewManager(connection.Client)
+	if err := m.Logout(ctx); err != nil {
+		glog.Errorf("Logout failed: %s", err)
+	}
+}
+
+// NewClient creates a new govmomi client for the VSphereConnection obj
+func (connection *VSphereConnection) NewClient(ctx context.Context) (*vim25.Client, error) {
+	url, err := soap.ParseURL(net.JoinHostPort(connection.Hostname, connection.Port))
+	if err != nil {
+		glog.Errorf("Failed to parse URL: %s. err: %+v", url, err)
+		return nil, err
+	}
+
+	sc := soap.NewClient(url, connection.Insecure)
+	client, err := vim25.NewClient(ctx, sc)
+	if err != nil {
+		glog.Errorf("Failed to create new client. err: %+v", err)
+		return nil, err
+	}
+	err = connection.login(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	if glog.V(3) {
+		s, err := session.NewManager(client).UserSession(ctx)
+		if err == nil {
+			glog.Infof("New session ID for '%s' = %s", s.UserName, s.Key)
+		}
+	}
+
+	if connection.RoundTripperCount == 0 {
+		connection.RoundTripperCount = RoundTripperDefaultCount
+	}
+	client.RoundTripper = vim25.Retry(client.RoundTripper, vim25.TemporaryNetworkError(int(connection.RoundTripperCount)))
+	return client, nil
+}
+
+// UpdateCredentials updates username and password.
+// Note: Updated username and password will be used when there is no session active
+func (connection *VSphereConnection) UpdateCredentials(username string, password string) {
+	connection.credentialsLock.Lock()
+	defer connection.credentialsLock.Unlock()
+	connection.Username = username
+	connection.Password = password
+}

--- a/pkg/vclib/constants.go
+++ b/pkg/vclib/constants.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+// Volume Constnts
+const (
+	ThinDiskType             = "thin"
+	PreallocatedDiskType     = "preallocated"
+	EagerZeroedThickDiskType = "eagerZeroedThick"
+	ZeroedThickDiskType      = "zeroedThick"
+)
+
+// Controller Constants
+const (
+	SCSIControllerLimit       = 4
+	SCSIControllerDeviceLimit = 15
+	SCSIDeviceSlots           = 16
+	SCSIReservedSlot          = 7
+
+	SCSIControllerType        = "scsi"
+	LSILogicControllerType    = "lsiLogic"
+	BusLogicControllerType    = "busLogic"
+	LSILogicSASControllerType = "lsiLogic-sas"
+	PVSCSIControllerType      = "pvscsi"
+)
+
+// Other Constants
+const (
+	LogLevel                 = 4
+	DatastoreProperty        = "datastore"
+	ResourcePoolProperty     = "resourcePool"
+	DatastoreInfoProperty    = "info"
+	VirtualMachineType       = "VirtualMachine"
+	RoundTripperDefaultCount = 3
+	VSANDatastoreType        = "vsan"
+	DummyVMPrefixName        = "vsphere-k8s"
+	ActivePowerState         = "poweredOn"
+)
+
+// Test Constants
+const (
+	TestDefaultDatacenter = "DC0"
+	TestDefaultDatastore  = "LocalDS_0"
+	TestDefaultNetwork    = "VM Network"
+	testNameNotFound      = "enoent"
+)

--- a/pkg/vclib/custom_errors.go
+++ b/pkg/vclib/custom_errors.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import "errors"
+
+// Error Messages
+const (
+	FileAlreadyExistErrMsg     = "File requested already exist"
+	NoDiskUUIDFoundErrMsg      = "No disk UUID found"
+	NoDevicesFoundErrMsg       = "No devices found"
+	DiskNotFoundErrMsg         = "No vSphere disk ID found"
+	InvalidVolumeOptionsErrMsg = "VolumeOptions verification failed"
+	NoVMFoundErrMsg            = "No VM found"
+)
+
+// Error constants
+var (
+	ErrFileAlreadyExist     = errors.New(FileAlreadyExistErrMsg)
+	ErrNoDiskUUIDFound      = errors.New(NoDiskUUIDFoundErrMsg)
+	ErrNoDevicesFound       = errors.New(NoDevicesFoundErrMsg)
+	ErrNoDiskIDFound        = errors.New(DiskNotFoundErrMsg)
+	ErrInvalidVolumeOptions = errors.New(InvalidVolumeOptionsErrMsg)
+	ErrNoVMFound            = errors.New(NoVMFoundErrMsg)
+)

--- a/pkg/vclib/datacenter.go
+++ b/pkg/vclib/datacenter.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// Datacenter extends the govmomi Datacenter object
+type Datacenter struct {
+	*object.Datacenter
+}
+
+// GetDatacenter returns the DataCenter Object for the given datacenterPath
+// If datacenter is located in a folder, include full path to datacenter else just provide the datacenter name
+func GetDatacenter(ctx context.Context, connection *VSphereConnection, datacenterPath string) (*Datacenter, error) {
+	finder := find.NewFinder(connection.Client, false)
+	datacenter, err := finder.Datacenter(ctx, datacenterPath)
+	if err != nil {
+		glog.Errorf("Failed to find the datacenter: %s. err: %+v", datacenterPath, err)
+		return nil, err
+	}
+	dc := Datacenter{datacenter}
+	return &dc, nil
+}
+
+// GetAllDatacenter returns all the DataCenter Objects
+func GetAllDatacenter(ctx context.Context, connection *VSphereConnection) ([]*Datacenter, error) {
+	var dc []*Datacenter
+	finder := find.NewFinder(connection.Client, false)
+	datacenters, err := finder.DatacenterList(ctx, "*")
+	if err != nil {
+		glog.Errorf("Failed to find the datacenter. err: %+v", err)
+		return nil, err
+	}
+	for _, datacenter := range datacenters {
+		dc = append(dc, &(Datacenter{datacenter}))
+	}
+
+	return dc, nil
+}
+
+// GetVMByDNSName gets the VM object from the given dns name
+func (dc *Datacenter) GetVMByDNSName(ctx context.Context, dnsName string) (*VirtualMachine, error) {
+	s := object.NewSearchIndex(dc.Client())
+	dnsName = strings.ToLower(strings.TrimSpace(dnsName))
+	svm, err := s.FindByDnsName(ctx, dc.Datacenter, dnsName, true)
+	if err != nil {
+		glog.Errorf("Failed to find VM by DNS Name. VM DNS Name: %s, err: %+v", dnsName, err)
+		return nil, err
+	}
+	if svm == nil {
+		glog.Errorf("Unable to find VM by DNS Name. VM DNS Name: %s", dnsName)
+		return nil, ErrNoVMFound
+	}
+	virtualMachine := VirtualMachine{object.NewVirtualMachine(dc.Client(), svm.Reference()), dc}
+	return &virtualMachine, nil
+}
+
+// GetVMByUUID gets the VM object from the given vmUUID
+func (dc *Datacenter) GetVMByUUID(ctx context.Context, vmUUID string) (*VirtualMachine, error) {
+	s := object.NewSearchIndex(dc.Client())
+	vmUUID = strings.ToLower(strings.TrimSpace(vmUUID))
+	svm, err := s.FindByUuid(ctx, dc.Datacenter, vmUUID, true, nil)
+	if err != nil {
+		glog.Errorf("Failed to find VM by UUID. VM UUID: %s, err: %+v", vmUUID, err)
+		return nil, err
+	}
+	if svm == nil {
+		glog.Errorf("Unable to find VM by UUID. VM UUID: %s", vmUUID)
+		return nil, ErrNoVMFound
+	}
+	virtualMachine := VirtualMachine{object.NewVirtualMachine(dc.Client(), svm.Reference()), dc}
+	return &virtualMachine, nil
+}
+
+// GetVMByPath gets the VM object from the given vmPath
+// vmPath should be the full path to VM and not just the name
+func (dc *Datacenter) GetVMByPath(ctx context.Context, vmPath string) (*VirtualMachine, error) {
+	finder := getFinder(dc)
+	vm, err := finder.VirtualMachine(ctx, vmPath)
+	if err != nil {
+		glog.Errorf("Failed to find VM by Path. VM Path: %s, err: %+v", vmPath, err)
+		return nil, err
+	}
+	virtualMachine := VirtualMachine{vm, dc}
+	return &virtualMachine, nil
+}
+
+// GetAllDatastores gets the datastore URL to DatastoreInfo map for all the datastores in
+// the datacenter.
+func (dc *Datacenter) GetAllDatastores(ctx context.Context) (map[string]*DatastoreInfo, error) {
+	finder := getFinder(dc)
+	datastores, err := finder.DatastoreList(ctx, "*")
+	if err != nil {
+		glog.Errorf("Failed to get all the datastores. err: %+v", err)
+		return nil, err
+	}
+	var dsList []types.ManagedObjectReference
+	for _, ds := range datastores {
+		dsList = append(dsList, ds.Reference())
+	}
+
+	var dsMoList []mo.Datastore
+	pc := property.DefaultCollector(dc.Client())
+	properties := []string{DatastoreInfoProperty}
+	err = pc.Retrieve(ctx, dsList, properties, &dsMoList)
+	if err != nil {
+		glog.Errorf("Failed to get Datastore managed objects from datastore objects."+
+			" dsObjList: %+v, properties: %+v, err: %v", dsList, properties, err)
+		return nil, err
+	}
+
+	dsURLInfoMap := make(map[string]*DatastoreInfo)
+	for _, dsMo := range dsMoList {
+		dsURLInfoMap[dsMo.Info.GetDatastoreInfo().Url] = &DatastoreInfo{
+			&Datastore{object.NewDatastore(dc.Client(), dsMo.Reference()),
+				dc},
+			dsMo.Info.GetDatastoreInfo()}
+	}
+	glog.V(9).Infof("dsURLInfoMap : %+v", dsURLInfoMap)
+	return dsURLInfoMap, nil
+}
+
+// GetDatastoreByPath gets the Datastore object from the given vmDiskPath
+func (dc *Datacenter) GetDatastoreByPath(ctx context.Context, vmDiskPath string) (*Datastore, error) {
+	datastorePathObj := new(object.DatastorePath)
+	isSuccess := datastorePathObj.FromString(vmDiskPath)
+	if !isSuccess {
+		glog.Errorf("Failed to parse vmDiskPath: %s", vmDiskPath)
+		return nil, errors.New("Failed to parse vmDiskPath")
+	}
+
+	return dc.GetDatastoreByName(ctx, datastorePathObj.Datastore)
+}
+
+// GetDatastoreByName gets the Datastore object for the given datastore name
+func (dc *Datacenter) GetDatastoreByName(ctx context.Context, name string) (*Datastore, error) {
+	finder := getFinder(dc)
+	ds, err := finder.Datastore(ctx, name)
+	if err != nil {
+		glog.Errorf("Failed while searching for datastore: %s. err: %+v", name, err)
+		return nil, err
+	}
+	datastore := Datastore{ds, dc}
+	return &datastore, nil
+}
+
+// GetResourcePool gets the resource pool for the given path
+func (dc *Datacenter) GetResourcePool(ctx context.Context, computePath string) (*object.ResourcePool, error) {
+	finder := getFinder(dc)
+	var computeResource *object.ComputeResource
+	var err error
+	if computePath == "" {
+		computeResource, err = finder.DefaultComputeResource(ctx)
+	} else {
+		computeResource, err = finder.ComputeResource(ctx, computePath)
+	}
+	if err != nil {
+		glog.Errorf("Failed to get the ResourcePool for computePath '%s'. err: %+v", computePath, err)
+		return nil, err
+	}
+	return computeResource.ResourcePool(ctx)
+}
+
+// GetFolderByPath gets the Folder Object from the given folder path
+// folderPath should be the full path to folder
+func (dc *Datacenter) GetFolderByPath(ctx context.Context, folderPath string) (*Folder, error) {
+	finder := getFinder(dc)
+	vmFolder, err := finder.Folder(ctx, folderPath)
+	if err != nil {
+		glog.Errorf("Failed to get the folder reference for %s. err: %+v", folderPath, err)
+		return nil, err
+	}
+	folder := Folder{vmFolder, dc}
+	return &folder, nil
+}
+
+// GetVMMoList gets the VM Managed Objects with the given properties from the VM object
+func (dc *Datacenter) GetVMMoList(ctx context.Context, vmObjList []*VirtualMachine, properties []string) ([]mo.VirtualMachine, error) {
+	var vmMoList []mo.VirtualMachine
+	var vmRefs []types.ManagedObjectReference
+	if len(vmObjList) < 1 {
+		glog.Errorf("VirtualMachine Object list is empty")
+		return nil, fmt.Errorf("VirtualMachine Object list is empty")
+	}
+
+	for _, vmObj := range vmObjList {
+		vmRefs = append(vmRefs, vmObj.Reference())
+	}
+	pc := property.DefaultCollector(dc.Client())
+	err := pc.Retrieve(ctx, vmRefs, properties, &vmMoList)
+	if err != nil {
+		glog.Errorf("Failed to get VM managed objects from VM objects. vmObjList: %+v, properties: %+v, err: %v", vmObjList, properties, err)
+		return nil, err
+	}
+	return vmMoList, nil
+}
+
+// GetVirtualDiskPage83Data gets the virtual disk UUID by diskPath
+func (dc *Datacenter) GetVirtualDiskPage83Data(ctx context.Context, diskPath string) (string, error) {
+	if len(diskPath) > 0 && filepath.Ext(diskPath) != ".vmdk" {
+		diskPath += ".vmdk"
+	}
+	vdm := object.NewVirtualDiskManager(dc.Client())
+	// Returns uuid of vmdk virtual disk
+	diskUUID, err := vdm.QueryVirtualDiskUuid(ctx, diskPath, dc.Datacenter)
+
+	if err != nil {
+		glog.Warningf("QueryVirtualDiskUuid failed for diskPath: %q. err: %+v", diskPath, err)
+		return "", err
+	}
+	diskUUID = formatVirtualDiskUUID(diskUUID)
+	return diskUUID, nil
+}
+
+// GetDatastoreMoList gets the Datastore Managed Objects with the given properties from the datastore objects
+func (dc *Datacenter) GetDatastoreMoList(ctx context.Context, dsObjList []*Datastore, properties []string) ([]mo.Datastore, error) {
+	var dsMoList []mo.Datastore
+	var dsRefs []types.ManagedObjectReference
+	if len(dsObjList) < 1 {
+		glog.Errorf("Datastore Object list is empty")
+		return nil, fmt.Errorf("Datastore Object list is empty")
+	}
+
+	for _, dsObj := range dsObjList {
+		dsRefs = append(dsRefs, dsObj.Reference())
+	}
+	pc := property.DefaultCollector(dc.Client())
+	err := pc.Retrieve(ctx, dsRefs, properties, &dsMoList)
+	if err != nil {
+		glog.Errorf("Failed to get Datastore managed objects from datastore objects. dsObjList: %+v, properties: %+v, err: %v", dsObjList, properties, err)
+		return nil, err
+	}
+	return dsMoList, nil
+}
+
+// CheckDisksAttached checks if the disk is attached to node.
+// This is done by comparing the volume path with the backing.FilePath on the VM Virtual disk devices.
+func (dc *Datacenter) CheckDisksAttached(ctx context.Context, nodeVolumes map[string][]string) (map[string]map[string]bool, error) {
+	attached := make(map[string]map[string]bool)
+	var vmList []*VirtualMachine
+	for nodeName, volPaths := range nodeVolumes {
+		for _, volPath := range volPaths {
+			setNodeVolumeMap(attached, volPath, nodeName, false)
+		}
+		vm, err := dc.GetVMByPath(ctx, nodeName)
+		if err != nil {
+			if IsNotFound(err) {
+				glog.Warningf("Node %q does not exist, vSphere CP will assume disks %v are not attached to it.", nodeName, volPaths)
+			}
+			continue
+		}
+		vmList = append(vmList, vm)
+	}
+	if len(vmList) == 0 {
+		glog.V(2).Infof("vSphere CP will assume no disks are attached to any node.")
+		return attached, nil
+	}
+	vmMoList, err := dc.GetVMMoList(ctx, vmList, []string{"config.hardware.device", "name"})
+	if err != nil {
+		// When there is an error fetching instance information
+		// it is safer to return nil and let volume information not be touched.
+		glog.Errorf("Failed to get VM Managed object for nodes: %+v. err: +%v", vmList, err)
+		return nil, err
+	}
+
+	for _, vmMo := range vmMoList {
+		if vmMo.Config == nil {
+			glog.Errorf("Config is not available for VM: %q", vmMo.Name)
+			continue
+		}
+		for nodeName, volPaths := range nodeVolumes {
+			if nodeName == vmMo.Name {
+				verifyVolumePathsForVM(vmMo, volPaths, attached)
+			}
+		}
+	}
+	return attached, nil
+}
+
+// VerifyVolumePathsForVM verifies if the volume paths (volPaths) are attached to VM.
+func verifyVolumePathsForVM(vmMo mo.VirtualMachine, volPaths []string, nodeVolumeMap map[string]map[string]bool) {
+	// Verify if the volume paths are present on the VM backing virtual disk devices
+	for _, volPath := range volPaths {
+		vmDevices := object.VirtualDeviceList(vmMo.Config.Hardware.Device)
+		for _, device := range vmDevices {
+			if vmDevices.TypeName(device) == "VirtualDisk" {
+				virtualDevice := device.GetVirtualDevice()
+				if backing, ok := virtualDevice.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
+					if backing.FileName == volPath {
+						setNodeVolumeMap(nodeVolumeMap, volPath, vmMo.Name, true)
+					}
+				}
+			}
+		}
+	}
+}
+
+func setNodeVolumeMap(
+	nodeVolumeMap map[string]map[string]bool,
+	volumePath string,
+	nodeName string,
+	check bool) {
+	volumeMap := nodeVolumeMap[nodeName]
+	if volumeMap == nil {
+		volumeMap = make(map[string]bool)
+		nodeVolumeMap[nodeName] = volumeMap
+	}
+	volumeMap[volumePath] = check
+}

--- a/pkg/vclib/datacenter_test.go
+++ b/pkg/vclib/datacenter_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+)
+
+func TestDatacenter(t *testing.T) {
+	ctx := context.Background()
+
+	// vCenter model + initial set of objects (cluster, hosts, VMs, network, datastore, etc)
+	model := simulator.VPX()
+
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	avm := simulator.Map.Any(VirtualMachineType).(*simulator.VirtualMachine)
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vc := &VSphereConnection{Client: c.Client}
+
+	_, err = GetDatacenter(ctx, vc, testNameNotFound)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	dc, err := GetDatacenter(ctx, vc, TestDefaultDatacenter)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = dc.GetVMByUUID(ctx, testNameNotFound)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	_, err = dc.GetVMByUUID(ctx, avm.Summary.Config.Uuid)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = dc.GetVMByPath(ctx, testNameNotFound)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	vm, err := dc.GetVMByPath(ctx, TestDefaultDatacenter+"/vm/"+avm.Name)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = dc.GetDatastoreByPath(ctx, testNameNotFound) // invalid format
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	invalidPath := object.DatastorePath{
+		Datastore: testNameNotFound,
+		Path:      testNameNotFound,
+	}
+	_, err = dc.GetDatastoreByPath(ctx, invalidPath.String())
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	_, err = dc.GetDatastoreByPath(ctx, avm.Summary.Config.VmPathName)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = dc.GetDatastoreByName(ctx, testNameNotFound)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	ds, err := dc.GetDatastoreByName(ctx, TestDefaultDatastore)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = dc.GetFolderByPath(ctx, testNameNotFound)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	_, err = dc.GetFolderByPath(ctx, TestDefaultDatacenter+"/vm")
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = dc.GetVMMoList(ctx, nil, nil)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	_, err = dc.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{testNameNotFound}) // invalid property
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	_, err = dc.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{"summary"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	diskPath := ds.Path(avm.Name + "/disk1.vmdk")
+
+	_, err = dc.GetVirtualDiskPage83Data(ctx, diskPath+testNameNotFound)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	_, err = dc.GetVirtualDiskPage83Data(ctx, diskPath)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = dc.GetDatastoreMoList(ctx, nil, nil)
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	_, err = dc.GetDatastoreMoList(ctx, []*Datastore{ds}, []string{testNameNotFound}) // invalid property
+	if err == nil {
+		t.Error("expected error")
+	}
+
+	_, err = dc.GetDatastoreMoList(ctx, []*Datastore{ds}, []string{DatastoreInfoProperty})
+	if err != nil {
+		t.Error(err)
+	}
+
+	nodeVolumes := map[string][]string{
+		avm.Name: {testNameNotFound, diskPath},
+	}
+
+	attached, err := dc.CheckDisksAttached(ctx, nodeVolumes)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if attached[avm.Name][testNameNotFound] {
+		t.Error("should not be attached")
+	}
+
+	if !attached[avm.Name][diskPath] {
+		t.Errorf("%s should be attached", diskPath)
+	}
+}

--- a/pkg/vclib/datastore.go
+++ b/pkg/vclib/datastore.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// Datastore extends the govmomi Datastore object
+type Datastore struct {
+	*object.Datastore
+	Datacenter *Datacenter
+}
+
+// DatastoreInfo is a structure to store the Datastore and it's Info.
+type DatastoreInfo struct {
+	*Datastore
+	Info *types.DatastoreInfo
+}
+
+func (di DatastoreInfo) String() string {
+	return fmt.Sprintf("Datastore: %+v, datastore URL: %s", di.Datastore, di.Info.Url)
+}
+
+// CreateDirectory creates the directory at location specified by directoryPath.
+// If the intermediate level folders do not exist, and the parameter createParents is true, all the non-existent folders are created.
+// directoryPath must be in the format "[vsanDatastore] kubevols"
+func (ds *Datastore) CreateDirectory(ctx context.Context, directoryPath string, createParents bool) error {
+	fileManager := object.NewFileManager(ds.Client())
+	err := fileManager.MakeDirectory(ctx, directoryPath, ds.Datacenter.Datacenter, createParents)
+	if err != nil {
+		if soap.IsSoapFault(err) {
+			soapFault := soap.ToSoapFault(err)
+			if _, ok := soapFault.VimFault().(types.FileAlreadyExists); ok {
+				return ErrFileAlreadyExist
+			}
+		}
+		return err
+	}
+	glog.V(LogLevel).Infof("Created dir with path as %+q", directoryPath)
+	return nil
+}
+
+// GetType returns the type of datastore
+func (ds *Datastore) GetType(ctx context.Context) (string, error) {
+	var dsMo mo.Datastore
+	pc := property.DefaultCollector(ds.Client())
+	err := pc.RetrieveOne(ctx, ds.Datastore.Reference(), []string{"summary"}, &dsMo)
+	if err != nil {
+		glog.Errorf("Failed to retrieve datastore summary property. err: %v", err)
+		return "", err
+	}
+	return dsMo.Summary.Type, nil
+}
+
+// IsCompatibleWithStoragePolicy returns true if datastore is compatible with given storage policy else return false
+// for not compatible datastore, fault message is also returned
+func (ds *Datastore) IsCompatibleWithStoragePolicy(ctx context.Context, storagePolicyID string) (bool, string, error) {
+	pbmClient, err := NewPbmClient(ctx, ds.Client())
+	if err != nil {
+		glog.Errorf("Failed to get new PbmClient Object. err: %v", err)
+		return false, "", err
+	}
+	return pbmClient.IsDatastoreCompatible(ctx, storagePolicyID, ds)
+}

--- a/pkg/vclib/datastore_test.go
+++ b/pkg/vclib/datastore_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator"
+)
+
+func TestDatastore(t *testing.T) {
+	ctx := context.Background()
+
+	// vCenter model + initial set of objects (cluster, hosts, VMs, network, datastore, etc)
+	model := simulator.VPX()
+
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vc := &VSphereConnection{Client: c.Client}
+
+	dc, err := GetDatacenter(ctx, vc, TestDefaultDatacenter)
+	if err != nil {
+		t.Error(err)
+	}
+
+	all, err := dc.GetAllDatastores(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, info := range all {
+		ds := info.Datastore
+		kind, cerr := ds.GetType(ctx)
+		if cerr != nil {
+			t.Error(err)
+		}
+		if kind == "" {
+			t.Error("empty Datastore type")
+		}
+
+		dir := object.DatastorePath{
+			Datastore: info.Info.Name,
+			Path:      "kubevols",
+		}
+
+		// TODO: test Datastore.IsCompatibleWithStoragePolicy (vcsim needs PBM support)
+
+		for _, fail := range []bool{false, true} {
+			cerr = ds.CreateDirectory(ctx, dir.String(), false)
+			if fail {
+				if cerr != ErrFileAlreadyExist {
+					t.Errorf("expected %s, got: %s", ErrFileAlreadyExist, cerr)
+				}
+				continue
+			}
+
+			if cerr != nil {
+				t.Error(err)
+			}
+		}
+	}
+}

--- a/pkg/vclib/diskmanagers/vdm.go
+++ b/pkg/vclib/diskmanagers/vdm.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diskmanagers
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	"k8s.io/cloud-provider-vsphere/pkg/vclib"
+)
+
+// virtualDiskManager implements VirtualDiskProvider Interface for creating and deleting volume using VirtualDiskManager
+type virtualDiskManager struct {
+	diskPath      string
+	volumeOptions *vclib.VolumeOptions
+}
+
+// Create implements Disk's Create interface
+// Contains implementation of virtualDiskManager based Provisioning
+func (diskManager virtualDiskManager) Create(ctx context.Context, datastore *vclib.Datastore) (canonicalDiskPath string, err error) {
+	if diskManager.volumeOptions.SCSIControllerType == "" {
+		diskManager.volumeOptions.SCSIControllerType = vclib.LSILogicControllerType
+	}
+	// Create virtual disk
+	diskFormat := vclib.DiskFormatValidType[diskManager.volumeOptions.DiskFormat]
+	// Create a virtual disk manager
+	vdm := object.NewVirtualDiskManager(datastore.Client())
+	// Create specification for new virtual disk
+	vmDiskSpec := &types.FileBackedVirtualDiskSpec{
+		VirtualDiskSpec: types.VirtualDiskSpec{
+			AdapterType: diskManager.volumeOptions.SCSIControllerType,
+			DiskType:    diskFormat,
+		},
+		CapacityKb: int64(diskManager.volumeOptions.CapacityKB),
+	}
+	requestTime := time.Now()
+	// Create virtual disk
+	task, err := vdm.CreateVirtualDisk(ctx, diskManager.diskPath, datastore.Datacenter.Datacenter, vmDiskSpec)
+	if err != nil {
+		vclib.RecordvSphereMetric(vclib.APICreateVolume, requestTime, err)
+		glog.Errorf("Failed to create virtual disk: %s. err: %+v", diskManager.diskPath, err)
+		return "", err
+	}
+	taskInfo, err := task.WaitForResult(ctx, nil)
+	vclib.RecordvSphereMetric(vclib.APICreateVolume, requestTime, err)
+	if err != nil {
+		glog.Errorf("Failed to complete virtual disk creation: %s. err: %+v", diskManager.diskPath, err)
+		return "", err
+	}
+	canonicalDiskPath = taskInfo.Result.(string)
+	return canonicalDiskPath, nil
+}
+
+// Delete implements Disk's Delete interface
+func (diskManager virtualDiskManager) Delete(ctx context.Context, datacenter *vclib.Datacenter) error {
+	// Create a virtual disk manager
+	virtualDiskManager := object.NewVirtualDiskManager(datacenter.Client())
+	diskPath := vclib.RemoveStorageClusterORFolderNameFromVDiskPath(diskManager.diskPath)
+	requestTime := time.Now()
+	// Delete virtual disk
+	task, err := virtualDiskManager.DeleteVirtualDisk(ctx, diskPath, datacenter.Datacenter)
+	if err != nil {
+		glog.Errorf("Failed to delete virtual disk. err: %v", err)
+		vclib.RecordvSphereMetric(vclib.APIDeleteVolume, requestTime, err)
+		return err
+	}
+	err = task.Wait(ctx)
+	vclib.RecordvSphereMetric(vclib.APIDeleteVolume, requestTime, err)
+	if err != nil {
+		glog.Errorf("Failed to delete virtual disk. err: %v", err)
+		return err
+	}
+	return nil
+}

--- a/pkg/vclib/diskmanagers/virtualdisk.go
+++ b/pkg/vclib/diskmanagers/virtualdisk.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diskmanagers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	"k8s.io/cloud-provider-vsphere/pkg/vclib"
+)
+
+// VirtualDisk is for the Disk Management
+type VirtualDisk struct {
+	DiskPath      string
+	VolumeOptions *vclib.VolumeOptions
+	VMOptions     *vclib.VMOptions
+}
+
+// VirtualDisk Operations Const
+const (
+	VirtualDiskCreateOperation = "Create"
+	VirtualDiskDeleteOperation = "Delete"
+)
+
+// VirtualDiskProvider defines interfaces for creating disk
+type VirtualDiskProvider interface {
+	Create(ctx context.Context, datastore *vclib.Datastore) (string, error)
+	Delete(ctx context.Context, datacenter *vclib.Datacenter) error
+}
+
+// getDiskManager returns vmDiskManager or vdmDiskManager based on given volumeoptions
+func getDiskManager(disk *VirtualDisk, diskOperation string) VirtualDiskProvider {
+	var diskProvider VirtualDiskProvider
+	switch diskOperation {
+	case VirtualDiskDeleteOperation:
+		diskProvider = virtualDiskManager{disk.DiskPath, disk.VolumeOptions}
+	case VirtualDiskCreateOperation:
+		if disk.VolumeOptions.StoragePolicyName != "" || disk.VolumeOptions.VSANStorageProfileData != "" || disk.VolumeOptions.StoragePolicyID != "" {
+			diskProvider = vmDiskManager{disk.DiskPath, disk.VolumeOptions, disk.VMOptions}
+		} else {
+			diskProvider = virtualDiskManager{disk.DiskPath, disk.VolumeOptions}
+		}
+	}
+	return diskProvider
+}
+
+// Create gets appropriate disk manager and calls respective create method
+func (virtualDisk *VirtualDisk) Create(ctx context.Context, datastore *vclib.Datastore) (string, error) {
+	if virtualDisk.VolumeOptions.DiskFormat == "" {
+		virtualDisk.VolumeOptions.DiskFormat = vclib.ThinDiskType
+	}
+	if !virtualDisk.VolumeOptions.VerifyVolumeOptions() {
+		glog.Error("VolumeOptions verification failed. volumeOptions: ", virtualDisk.VolumeOptions)
+		return "", vclib.ErrInvalidVolumeOptions
+	}
+	if virtualDisk.VolumeOptions.StoragePolicyID != "" && virtualDisk.VolumeOptions.StoragePolicyName != "" {
+		return "", fmt.Errorf("Storage Policy ID and Storage Policy Name both set, Please set only one parameter")
+	}
+	return getDiskManager(virtualDisk, VirtualDiskCreateOperation).Create(ctx, datastore)
+}
+
+// Delete gets appropriate disk manager and calls respective delete method
+func (virtualDisk *VirtualDisk) Delete(ctx context.Context, datacenter *vclib.Datacenter) error {
+	return getDiskManager(virtualDisk, VirtualDiskDeleteOperation).Delete(ctx, datacenter)
+}

--- a/pkg/vclib/diskmanagers/vmdm.go
+++ b/pkg/vclib/diskmanagers/vmdm.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diskmanagers
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+	"k8s.io/cloud-provider-vsphere/pkg/vclib"
+)
+
+// vmDiskManager implements VirtualDiskProvider interface for creating volume using Virtual Machine Reconfigure approach
+type vmDiskManager struct {
+	diskPath      string
+	volumeOptions *vclib.VolumeOptions
+	vmOptions     *vclib.VMOptions
+}
+
+// Create implements Disk's Create interface
+// Contains implementation of VM based Provisioning to provision disk with SPBM Policy or VSANStorageProfileData
+func (vmdisk vmDiskManager) Create(ctx context.Context, datastore *vclib.Datastore) (canonicalDiskPath string, err error) {
+	if vmdisk.volumeOptions.SCSIControllerType == "" {
+		vmdisk.volumeOptions.SCSIControllerType = vclib.PVSCSIControllerType
+	}
+	pbmClient, err := vclib.NewPbmClient(ctx, datastore.Client())
+	if err != nil {
+		glog.Errorf("Error occurred while creating new pbmClient, err: %+v", err)
+		return "", err
+	}
+
+	if vmdisk.volumeOptions.StoragePolicyID == "" && vmdisk.volumeOptions.StoragePolicyName != "" {
+		vmdisk.volumeOptions.StoragePolicyID, err = pbmClient.ProfileIDByName(ctx, vmdisk.volumeOptions.StoragePolicyName)
+		if err != nil {
+			glog.Errorf("Error occurred while getting Profile Id from Profile Name: %s, err: %+v", vmdisk.volumeOptions.StoragePolicyName, err)
+			return "", err
+		}
+	}
+	if vmdisk.volumeOptions.StoragePolicyID != "" {
+		compatible, faultMessage, err := datastore.IsCompatibleWithStoragePolicy(ctx, vmdisk.volumeOptions.StoragePolicyID)
+		if err != nil {
+			glog.Errorf("Error occurred while checking datastore compatibility with storage policy id: %s, err: %+v", vmdisk.volumeOptions.StoragePolicyID, err)
+			return "", err
+		}
+
+		if !compatible {
+			glog.Errorf("Datastore: %s is not compatible with Policy: %s", datastore.Name(), vmdisk.volumeOptions.StoragePolicyName)
+			return "", fmt.Errorf("User specified datastore is not compatible with the storagePolicy: %q. Failed with faults: %+q", vmdisk.volumeOptions.StoragePolicyName, faultMessage)
+		}
+	}
+
+	storageProfileSpec := &types.VirtualMachineDefinedProfileSpec{}
+	// Is PBM storage policy ID is present, set the storage spec profile ID,
+	// else, set raw the VSAN policy string.
+	if vmdisk.volumeOptions.StoragePolicyID != "" {
+		storageProfileSpec.ProfileId = vmdisk.volumeOptions.StoragePolicyID
+	} else if vmdisk.volumeOptions.VSANStorageProfileData != "" {
+		// Check Datastore type - VSANStorageProfileData is only applicable to vSAN Datastore
+		dsType, err := datastore.GetType(ctx)
+		if err != nil {
+			return "", err
+		}
+		if dsType != vclib.VSANDatastoreType {
+			glog.Errorf("The specified datastore: %q is not a VSAN datastore", datastore.Name())
+			return "", fmt.Errorf("The specified datastore: %q is not a VSAN datastore."+
+				" The policy parameters will work only with VSAN Datastore."+
+				" So, please specify a valid VSAN datastore in Storage class definition.", datastore.Name())
+		}
+		storageProfileSpec.ProfileId = ""
+		storageProfileSpec.ProfileData = &types.VirtualMachineProfileRawData{
+			ExtensionKey: "com.vmware.vim.sps",
+			ObjectData:   vmdisk.volumeOptions.VSANStorageProfileData,
+		}
+	} else {
+		glog.Errorf("Both volumeOptions.StoragePolicyID and volumeOptions.VSANStorageProfileData are not set. One of them should be set")
+		return "", fmt.Errorf("Both volumeOptions.StoragePolicyID and volumeOptions.VSANStorageProfileData are not set. One of them should be set")
+	}
+	var dummyVM *vclib.VirtualMachine
+	// Check if VM already exist in the folder.
+	// If VM is already present, use it, else create a new dummy VM.
+	fnvHash := fnv.New32a()
+	fnvHash.Write([]byte(vmdisk.volumeOptions.Name))
+	dummyVMFullName := vclib.DummyVMPrefixName + "-" + fmt.Sprint(fnvHash.Sum32())
+	dummyVM, err = datastore.Datacenter.GetVMByPath(ctx, vmdisk.vmOptions.VMFolder.InventoryPath+"/"+dummyVMFullName)
+	if err != nil {
+		// Create a dummy VM
+		glog.V(1).Info("Creating Dummy VM: %q", dummyVMFullName)
+		dummyVM, err = vmdisk.createDummyVM(ctx, datastore.Datacenter, dummyVMFullName)
+		if err != nil {
+			glog.Errorf("Failed to create Dummy VM. err: %v", err)
+			return "", err
+		}
+	}
+
+	// Reconfigure the VM to attach the disk with the VSAN policy configured
+	virtualMachineConfigSpec := types.VirtualMachineConfigSpec{}
+	disk, _, err := dummyVM.CreateDiskSpec(ctx, vmdisk.diskPath, datastore, vmdisk.volumeOptions)
+	if err != nil {
+		glog.Errorf("Failed to create Disk Spec. err: %v", err)
+		return "", err
+	}
+	deviceConfigSpec := &types.VirtualDeviceConfigSpec{
+		Device:        disk,
+		Operation:     types.VirtualDeviceConfigSpecOperationAdd,
+		FileOperation: types.VirtualDeviceConfigSpecFileOperationCreate,
+	}
+
+	deviceConfigSpec.Profile = append(deviceConfigSpec.Profile, storageProfileSpec)
+	virtualMachineConfigSpec.DeviceChange = append(virtualMachineConfigSpec.DeviceChange, deviceConfigSpec)
+	fileAlreadyExist := false
+	task, err := dummyVM.Reconfigure(ctx, virtualMachineConfigSpec)
+	err = task.Wait(ctx)
+	if err != nil {
+		fileAlreadyExist = isAlreadyExists(vmdisk.diskPath, err)
+		if fileAlreadyExist {
+			//Skip error and continue to detach the disk as the disk was already created on the datastore.
+			glog.V(vclib.LogLevel).Info("File: %v already exists", vmdisk.diskPath)
+		} else {
+			glog.Errorf("Failed to attach the disk to VM: %q with err: %+v", dummyVMFullName, err)
+			return "", err
+		}
+	}
+	// Detach the disk from the dummy VM.
+	err = dummyVM.DetachDisk(ctx, vmdisk.diskPath)
+	if err != nil {
+		if vclib.DiskNotFoundErrMsg == err.Error() && fileAlreadyExist {
+			// Skip error if disk was already detached from the dummy VM but still present on the datastore.
+			glog.V(vclib.LogLevel).Info("File: %v is already detached", vmdisk.diskPath)
+		} else {
+			glog.Errorf("Failed to detach the disk: %q from VM: %q with err: %+v", vmdisk.diskPath, dummyVMFullName, err)
+			return "", err
+		}
+	}
+	//  Delete the dummy VM
+	err = dummyVM.DeleteVM(ctx)
+	if err != nil {
+		glog.Errorf("Failed to destroy the vm: %q with err: %+v", dummyVMFullName, err)
+	}
+	return vmdisk.diskPath, nil
+}
+
+func (vmdisk vmDiskManager) Delete(ctx context.Context, datacenter *vclib.Datacenter) error {
+	return fmt.Errorf("vmDiskManager.Delete is not supported")
+}
+
+// CreateDummyVM create a Dummy VM at specified location with given name.
+func (vmdisk vmDiskManager) createDummyVM(ctx context.Context, datacenter *vclib.Datacenter, vmName string) (*vclib.VirtualMachine, error) {
+	// Create a virtual machine config spec with 1 SCSI adapter.
+	virtualMachineConfigSpec := types.VirtualMachineConfigSpec{
+		Name: vmName,
+		Files: &types.VirtualMachineFileInfo{
+			VmPathName: "[" + vmdisk.volumeOptions.Datastore + "]",
+		},
+		NumCPUs:  1,
+		MemoryMB: 4,
+		DeviceChange: []types.BaseVirtualDeviceConfigSpec{
+			&types.VirtualDeviceConfigSpec{
+				Operation: types.VirtualDeviceConfigSpecOperationAdd,
+				Device: &types.ParaVirtualSCSIController{
+					VirtualSCSIController: types.VirtualSCSIController{
+						SharedBus: types.VirtualSCSISharingNoSharing,
+						VirtualController: types.VirtualController{
+							BusNumber: 0,
+							VirtualDevice: types.VirtualDevice{
+								Key: 1000,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	task, err := vmdisk.vmOptions.VMFolder.CreateVM(ctx, virtualMachineConfigSpec, vmdisk.vmOptions.VMResourcePool, nil)
+	if err != nil {
+		glog.Errorf("Failed to create VM. err: %+v", err)
+		return nil, err
+	}
+
+	dummyVMTaskInfo, err := task.WaitForResult(ctx, nil)
+	if err != nil {
+		glog.Errorf("Error occurred while waiting for create VM task result. err: %+v", err)
+		return nil, err
+	}
+
+	vmRef := dummyVMTaskInfo.Result.(object.Reference)
+	dummyVM := object.NewVirtualMachine(datacenter.Client(), vmRef.Reference())
+	return &vclib.VirtualMachine{VirtualMachine: dummyVM, Datacenter: datacenter}, nil
+}
+
+// CleanUpDummyVMs deletes stale dummyVM's
+func CleanUpDummyVMs(ctx context.Context, folder *vclib.Folder, dc *vclib.Datacenter) error {
+	vmList, err := folder.GetVirtualMachines(ctx)
+	if err != nil {
+		glog.V(4).Infof("Failed to get virtual machines in the kubernetes cluster: %s, err: %+v", folder.InventoryPath, err)
+		return err
+	}
+	if vmList == nil || len(vmList) == 0 {
+		glog.Errorf("No virtual machines found in the kubernetes cluster: %s", folder.InventoryPath)
+		return fmt.Errorf("No virtual machines found in the kubernetes cluster: %s", folder.InventoryPath)
+	}
+	var dummyVMList []*vclib.VirtualMachine
+	// Loop through VM's in the Kubernetes cluster to find dummy VM's
+	for _, vm := range vmList {
+		vmName, err := vm.ObjectName(ctx)
+		if err != nil {
+			glog.V(4).Infof("Unable to get name from VM with err: %+v", err)
+			continue
+		}
+		if strings.HasPrefix(vmName, vclib.DummyVMPrefixName) {
+			vmObj := vclib.VirtualMachine{VirtualMachine: object.NewVirtualMachine(dc.Client(), vm.Reference()), Datacenter: dc}
+			dummyVMList = append(dummyVMList, &vmObj)
+		}
+	}
+	for _, vm := range dummyVMList {
+		err = vm.DeleteVM(ctx)
+		if err != nil {
+			glog.V(4).Infof("Unable to delete dummy VM with err: %+v", err)
+			continue
+		}
+	}
+	return nil
+}
+
+func isAlreadyExists(path string, err error) bool {
+	errorMessage := fmt.Sprintf("Cannot complete the operation because the file or folder %s already exists", path)
+	if errorMessage == err.Error() {
+		return true
+	}
+	return false
+}

--- a/pkg/vclib/folder.go
+++ b/pkg/vclib/folder.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/object"
+)
+
+// Folder extends the govmomi Folder object
+type Folder struct {
+	*object.Folder
+	Datacenter *Datacenter
+}
+
+// GetVirtualMachines returns list of VirtualMachine inside a folder.
+func (folder *Folder) GetVirtualMachines(ctx context.Context) ([]*VirtualMachine, error) {
+	vmFolders, err := folder.Children(ctx)
+	if err != nil {
+		glog.Errorf("Failed to get children from Folder: %s. err: %+v", folder.InventoryPath, err)
+		return nil, err
+	}
+	var vmObjList []*VirtualMachine
+	for _, vmFolder := range vmFolders {
+		if vmFolder.Reference().Type == VirtualMachineType {
+			vmObj := VirtualMachine{object.NewVirtualMachine(folder.Client(), vmFolder.Reference()), folder.Datacenter}
+			vmObjList = append(vmObjList, &vmObj)
+		}
+	}
+	return vmObjList, nil
+}

--- a/pkg/vclib/folder_test.go
+++ b/pkg/vclib/folder_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+)
+
+func TestFolder(t *testing.T) {
+	ctx := context.Background()
+
+	model := simulator.VPX()
+	// Child folder "F0" will be created under the root folder and datacenter folders,
+	// and all resources are created within the "F0" child folders.
+	model.Folder = 1
+
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vc := &VSphereConnection{Client: c.Client}
+
+	dc, err := GetDatacenter(ctx, vc, TestDefaultDatacenter)
+	if err != nil {
+		t.Error(err)
+	}
+
+	const folderName = "F0"
+	vmFolder := path.Join("/", folderName, dc.Name(), "vm")
+
+	tests := []struct {
+		folderPath string
+		expect     int
+	}{
+		{vmFolder, 0},
+		{path.Join(vmFolder, folderName), (model.Host + model.Cluster) * model.Machine},
+	}
+
+	for i, test := range tests {
+		folder, cerr := dc.GetFolderByPath(ctx, test.folderPath)
+		if cerr != nil {
+			t.Fatal(cerr)
+		}
+
+		vms, cerr := folder.GetVirtualMachines(ctx)
+		if cerr != nil {
+			t.Fatalf("%d: %s", i, cerr)
+		}
+
+		if len(vms) != test.expect {
+			t.Errorf("%d: expected %d VMs, got: %d", i, test.expect, len(vms))
+		}
+	}
+}

--- a/pkg/vclib/pbm.go
+++ b/pkg/vclib/pbm.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/pbm"
+
+	pbmtypes "github.com/vmware/govmomi/pbm/types"
+	"github.com/vmware/govmomi/vim25"
+)
+
+// PbmClient is extending govmomi pbm, and provides functions to get compatible list of datastore for given policy
+type PbmClient struct {
+	*pbm.Client
+}
+
+// NewPbmClient returns a new PBM Client object
+func NewPbmClient(ctx context.Context, client *vim25.Client) (*PbmClient, error) {
+	pbmClient, err := pbm.NewClient(ctx, client)
+	if err != nil {
+		glog.Errorf("Failed to create new Pbm Client. err: %+v", err)
+		return nil, err
+	}
+	return &PbmClient{pbmClient}, nil
+}
+
+// IsDatastoreCompatible check if the datastores is compatible for given storage policy id
+// if datastore is not compatible with policy, fault message with the Datastore Name is returned
+func (pbmClient *PbmClient) IsDatastoreCompatible(ctx context.Context, storagePolicyID string, datastore *Datastore) (bool, string, error) {
+	faultMessage := ""
+	placementHub := pbmtypes.PbmPlacementHub{
+		HubType: datastore.Reference().Type,
+		HubId:   datastore.Reference().Value,
+	}
+	hubs := []pbmtypes.PbmPlacementHub{placementHub}
+	req := []pbmtypes.BasePbmPlacementRequirement{
+		&pbmtypes.PbmPlacementCapabilityProfileRequirement{
+			ProfileId: pbmtypes.PbmProfileId{
+				UniqueId: storagePolicyID,
+			},
+		},
+	}
+	compatibilityResult, err := pbmClient.CheckRequirements(ctx, hubs, nil, req)
+	if err != nil {
+		glog.Errorf("Error occurred for CheckRequirements call. err %+v", err)
+		return false, "", err
+	}
+	if compatibilityResult != nil && len(compatibilityResult) > 0 {
+		compatibleHubs := compatibilityResult.CompatibleDatastores()
+		if compatibleHubs != nil && len(compatibleHubs) > 0 {
+			return true, "", nil
+		}
+		dsName, err := datastore.ObjectName(ctx)
+		if err != nil {
+			glog.Errorf("Failed to get datastore ObjectName")
+			return false, "", err
+		}
+		if compatibilityResult[0].Error[0].LocalizedMessage == "" {
+			faultMessage = "Datastore: " + dsName + " is not compatible with the storage policy."
+		} else {
+			faultMessage = "Datastore: " + dsName + " is not compatible with the storage policy. LocalizedMessage: " + compatibilityResult[0].Error[0].LocalizedMessage + "\n"
+		}
+		return false, faultMessage, nil
+	}
+	return false, "", fmt.Errorf("compatibilityResult is nil or empty")
+}
+
+// GetCompatibleDatastores filters and returns compatible list of datastores for given storage policy id
+// For Non Compatible Datastores, fault message with the Datastore Name is also returned
+func (pbmClient *PbmClient) GetCompatibleDatastores(ctx context.Context, dc *Datacenter, storagePolicyID string, datastores []*DatastoreInfo) ([]*DatastoreInfo, string, error) {
+	var (
+		dsMorNameMap                                = getDsMorNameMap(ctx, datastores)
+		localizedMessagesForNotCompatibleDatastores = ""
+	)
+	compatibilityResult, err := pbmClient.GetPlacementCompatibilityResult(ctx, storagePolicyID, datastores)
+	if err != nil {
+		glog.Errorf("Error occurred while retrieving placement compatibility result for datastores: %+v with storagePolicyID: %s. err: %+v", datastores, storagePolicyID, err)
+		return nil, "", err
+	}
+	compatibleHubs := compatibilityResult.CompatibleDatastores()
+	var compatibleDatastoreList []*DatastoreInfo
+	for _, hub := range compatibleHubs {
+		compatibleDatastoreList = append(compatibleDatastoreList, getDatastoreFromPlacementHub(datastores, hub))
+	}
+	for _, res := range compatibilityResult {
+		for _, err := range res.Error {
+			dsName := dsMorNameMap[res.Hub.HubId]
+			localizedMessage := ""
+			if err.LocalizedMessage != "" {
+				localizedMessage = "Datastore: " + dsName + " not compatible with the storage policy. LocalizedMessage: " + err.LocalizedMessage + "\n"
+			} else {
+				localizedMessage = "Datastore: " + dsName + " not compatible with the storage policy. \n"
+			}
+			localizedMessagesForNotCompatibleDatastores += localizedMessage
+		}
+	}
+	// Return an error if there are no compatible datastores.
+	if len(compatibleHubs) < 1 {
+		glog.Errorf("No compatible datastores found that satisfy the storage policy requirements: %s", storagePolicyID)
+		return nil, localizedMessagesForNotCompatibleDatastores, fmt.Errorf("No compatible datastores found that satisfy the storage policy requirements")
+	}
+	return compatibleDatastoreList, localizedMessagesForNotCompatibleDatastores, nil
+}
+
+// GetPlacementCompatibilityResult gets placement compatibility result based on storage policy requirements.
+func (pbmClient *PbmClient) GetPlacementCompatibilityResult(ctx context.Context, storagePolicyID string, datastore []*DatastoreInfo) (pbm.PlacementCompatibilityResult, error) {
+	var hubs []pbmtypes.PbmPlacementHub
+	for _, ds := range datastore {
+		hubs = append(hubs, pbmtypes.PbmPlacementHub{
+			HubType: ds.Reference().Type,
+			HubId:   ds.Reference().Value,
+		})
+	}
+	req := []pbmtypes.BasePbmPlacementRequirement{
+		&pbmtypes.PbmPlacementCapabilityProfileRequirement{
+			ProfileId: pbmtypes.PbmProfileId{
+				UniqueId: storagePolicyID,
+			},
+		},
+	}
+	res, err := pbmClient.CheckRequirements(ctx, hubs, nil, req)
+	if err != nil {
+		glog.Errorf("Error occurred for CheckRequirements call. err: %+v", err)
+		return nil, err
+	}
+	return res, nil
+}
+
+// getDataStoreForPlacementHub returns matching datastore associated with given pbmPlacementHub
+func getDatastoreFromPlacementHub(datastore []*DatastoreInfo, pbmPlacementHub pbmtypes.PbmPlacementHub) *DatastoreInfo {
+	for _, ds := range datastore {
+		if ds.Reference().Type == pbmPlacementHub.HubType && ds.Reference().Value == pbmPlacementHub.HubId {
+			return ds
+		}
+	}
+	return nil
+}
+
+// getDsMorNameMap returns map of ds Mor and Datastore Object Name
+func getDsMorNameMap(ctx context.Context, datastores []*DatastoreInfo) map[string]string {
+	dsMorNameMap := make(map[string]string)
+	for _, ds := range datastores {
+		dsObjectName, err := ds.ObjectName(ctx)
+		if err == nil {
+			dsMorNameMap[ds.Reference().Value] = dsObjectName
+		} else {
+			glog.Errorf("Error occurred while getting datastore object name. err: %+v", err)
+		}
+	}
+	return dsMorNameMap
+}

--- a/pkg/vclib/utils.go
+++ b/pkg/vclib/utils.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// IsNotFound return true if err is NotFoundError or DefaultNotFoundError
+func IsNotFound(err error) bool {
+	_, ok := err.(*find.NotFoundError)
+	if ok {
+		return true
+	}
+
+	_, ok = err.(*find.DefaultNotFoundError)
+	if ok {
+		return true
+	}
+
+	return false
+}
+
+func getFinder(dc *Datacenter) *find.Finder {
+	finder := find.NewFinder(dc.Client(), false)
+	finder.SetDatacenter(dc.Datacenter)
+	return finder
+}
+
+// formatVirtualDiskUUID removes any spaces and hyphens in UUID
+// Example UUID input is 42375390-71f9-43a3-a770-56803bcd7baa and output after format is 4237539071f943a3a77056803bcd7baa
+func formatVirtualDiskUUID(uuid string) string {
+	uuidwithNoSpace := strings.Replace(uuid, " ", "", -1)
+	uuidWithNoHypens := strings.Replace(uuidwithNoSpace, "-", "", -1)
+	return strings.ToLower(uuidWithNoHypens)
+}
+
+// getSCSIControllersOfType filters specific type of Controller device from given list of Virtual Machine Devices
+func getSCSIControllersOfType(vmDevices object.VirtualDeviceList, scsiType string) []*types.VirtualController {
+	// get virtual scsi controllers of passed argument type
+	var scsiControllers []*types.VirtualController
+	for _, device := range vmDevices {
+		devType := vmDevices.Type(device)
+		if devType == scsiType {
+			if c, ok := device.(types.BaseVirtualController); ok {
+				scsiControllers = append(scsiControllers, c.GetVirtualController())
+			}
+		}
+	}
+	return scsiControllers
+}
+
+// getAvailableSCSIController gets available SCSI Controller from list of given controllers, which has less than 15 disk devices.
+func getAvailableSCSIController(scsiControllers []*types.VirtualController) *types.VirtualController {
+	// get SCSI controller which has space for adding more devices
+	for _, controller := range scsiControllers {
+		if len(controller.Device) < SCSIControllerDeviceLimit {
+			return controller
+		}
+	}
+	return nil
+}
+
+// getNextUnitNumber gets the next available SCSI controller unit number from given list of Controller Device List
+func getNextUnitNumber(devices object.VirtualDeviceList, c types.BaseVirtualController) (int32, error) {
+	var takenUnitNumbers [SCSIDeviceSlots]bool
+	takenUnitNumbers[SCSIReservedSlot] = true
+	key := c.GetVirtualController().Key
+
+	for _, device := range devices {
+		d := device.GetVirtualDevice()
+		if d.ControllerKey == key {
+			if d.UnitNumber != nil {
+				takenUnitNumbers[*d.UnitNumber] = true
+			}
+		}
+	}
+	for unitNumber, takenUnitNumber := range takenUnitNumbers {
+		if !takenUnitNumber {
+			return int32(unitNumber), nil
+		}
+	}
+	return -1, fmt.Errorf("SCSI Controller with key=%d does not have any available slots", key)
+}
+
+// getSCSIControllers filters and return list of Controller Devices from given list of Virtual Machine Devices.
+func getSCSIControllers(vmDevices object.VirtualDeviceList) []*types.VirtualController {
+	// get all virtual scsi controllers
+	var scsiControllers []*types.VirtualController
+	for _, device := range vmDevices {
+		devType := vmDevices.Type(device)
+		switch devType {
+		case SCSIControllerType, strings.ToLower(LSILogicControllerType), strings.ToLower(BusLogicControllerType), PVSCSIControllerType, strings.ToLower(LSILogicSASControllerType):
+			if c, ok := device.(types.BaseVirtualController); ok {
+				scsiControllers = append(scsiControllers, c.GetVirtualController())
+			}
+		}
+	}
+	return scsiControllers
+}
+
+// RemoveStorageClusterORFolderNameFromVDiskPath removes the cluster or folder path from the vDiskPath
+// for vDiskPath [DatastoreCluster/sharedVmfs-0] kubevols/e2e-vmdk-1234.vmdk, return value is [sharedVmfs-0] kubevols/e2e-vmdk-1234.vmdk
+// for vDiskPath [sharedVmfs-0] kubevols/e2e-vmdk-1234.vmdk, return value remains same [sharedVmfs-0] kubevols/e2e-vmdk-1234.vmdk
+func RemoveStorageClusterORFolderNameFromVDiskPath(vDiskPath string) string {
+	datastore := regexp.MustCompile("\\[(.*?)\\]").FindStringSubmatch(vDiskPath)[1]
+	if filepath.Base(datastore) != datastore {
+		vDiskPath = strings.Replace(vDiskPath, datastore, filepath.Base(datastore), 1)
+	}
+	return vDiskPath
+}
+
+// GetPathFromVMDiskPath retrieves the path from VM Disk Path.
+// Example: For vmDiskPath - [vsanDatastore] kubevols/volume.vmdk, the path is kubevols/volume.vmdk
+func GetPathFromVMDiskPath(vmDiskPath string) string {
+	datastorePathObj := new(object.DatastorePath)
+	isSuccess := datastorePathObj.FromString(vmDiskPath)
+	if !isSuccess {
+		glog.Errorf("Failed to parse vmDiskPath: %s", vmDiskPath)
+		return ""
+	}
+	return datastorePathObj.Path
+}
+
+//GetDatastorePathObjFromVMDiskPath gets the datastorePathObj from VM disk path.
+func GetDatastorePathObjFromVMDiskPath(vmDiskPath string) (*object.DatastorePath, error) {
+	datastorePathObj := new(object.DatastorePath)
+	isSuccess := datastorePathObj.FromString(vmDiskPath)
+	if !isSuccess {
+		glog.Errorf("Failed to parse volPath: %s", vmDiskPath)
+		return nil, fmt.Errorf("Failed to parse volPath: %s", vmDiskPath)
+	}
+	return datastorePathObj, nil
+}
+
+//IsValidUUID checks if the string is a valid UUID.
+func IsValidUUID(uuid string) bool {
+	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
+	return r.MatchString(uuid)
+}
+
+// IsManagedObjectNotFoundError returns true if error is of type ManagedObjectNotFound
+func IsManagedObjectNotFoundError(err error) bool {
+	isManagedObjectNotFoundError := false
+	if soap.IsSoapFault(err) {
+		_, isManagedObjectNotFoundError = soap.ToSoapFault(err).VimFault().(types.ManagedObjectNotFound)
+	}
+	return isManagedObjectNotFoundError
+}
+
+// IsInvalidCredentialsError returns true if error is of type InvalidLogin
+func IsInvalidCredentialsError(err error) bool {
+	isInvalidCredentialsError := false
+	if soap.IsSoapFault(err) {
+		_, isInvalidCredentialsError = soap.ToSoapFault(err).VimFault().(types.InvalidLogin)
+	}
+	return isInvalidCredentialsError
+}
+
+// VerifyVolumePathsForVM verifies if the volume paths (volPaths) are attached to VM.
+func VerifyVolumePathsForVM(vmMo mo.VirtualMachine, volPaths []string, nodeName string, nodeVolumeMap map[string]map[string]bool) {
+	// Verify if the volume paths are present on the VM backing virtual disk devices
+	vmDevices := object.VirtualDeviceList(vmMo.Config.Hardware.Device)
+	VerifyVolumePathsForVMDevices(vmDevices, volPaths, nodeName, nodeVolumeMap)
+
+}
+
+// VerifyVolumePathsForVMDevices verifies if the volume paths (volPaths) are attached to VM.
+func VerifyVolumePathsForVMDevices(vmDevices object.VirtualDeviceList, volPaths []string, nodeName string, nodeVolumeMap map[string]map[string]bool) {
+	volPathsMap := make(map[string]bool)
+	for _, volPath := range volPaths {
+		volPathsMap[volPath] = true
+	}
+	// Verify if the volume paths are present on the VM backing virtual disk devices
+	for _, device := range vmDevices {
+		if vmDevices.TypeName(device) == "VirtualDisk" {
+			virtualDevice := device.GetVirtualDevice()
+			if backing, ok := virtualDevice.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
+				if volPathsMap[backing.FileName] {
+					setNodeVolumeMap(nodeVolumeMap, backing.FileName, nodeName, true)
+				}
+			}
+		}
+	}
+
+}

--- a/pkg/vclib/utils_test.go
+++ b/pkg/vclib/utils_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+)
+
+func TestUtils(t *testing.T) {
+	ctx := context.Background()
+
+	model := simulator.VPX()
+	// Child folder "F0" will be created under the root folder and datacenter folders,
+	// and all resources are created within the "F0" child folders.
+	model.Folder = 1
+
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vc := &VSphereConnection{Client: c.Client}
+
+	dc, err := GetDatacenter(ctx, vc, TestDefaultDatacenter)
+	if err != nil {
+		t.Error(err)
+	}
+
+	finder := getFinder(dc)
+	datastores, err := finder.DatastoreList(ctx, "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	count := model.Count()
+	if count.Datastore != len(datastores) {
+		t.Errorf("got %d Datastores, expected: %d", len(datastores), count.Datastore)
+	}
+
+	_, err = finder.Datastore(ctx, testNameNotFound)
+	if !IsNotFound(err) {
+		t.Errorf("unexpected error: %s", err)
+	}
+}

--- a/pkg/vclib/virtualmachine.go
+++ b/pkg/vclib/virtualmachine.go
@@ -1,0 +1,432 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// VirtualMachine extends the govmomi VirtualMachine object
+type VirtualMachine struct {
+	*object.VirtualMachine
+	Datacenter *Datacenter
+}
+
+// IsDiskAttached checks if disk is attached to the VM.
+func (vm *VirtualMachine) IsDiskAttached(ctx context.Context, diskPath string) (bool, error) {
+	device, err := vm.getVirtualDeviceByPath(ctx, diskPath)
+	if err != nil {
+		return false, err
+	}
+	if device != nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+// DeleteVM deletes the VM.
+func (vm *VirtualMachine) DeleteVM(ctx context.Context) error {
+	destroyTask, err := vm.Destroy(ctx)
+	if err != nil {
+		glog.Errorf("Failed to delete the VM: %q. err: %+v", vm.InventoryPath, err)
+		return err
+	}
+	return destroyTask.Wait(ctx)
+}
+
+// AttachDisk attaches the disk at location - vmDiskPath from Datastore - dsObj to the Virtual Machine
+// Additionally the disk can be configured with SPBM policy if volumeOptions.StoragePolicyID is non-empty.
+func (vm *VirtualMachine) AttachDisk(ctx context.Context, vmDiskPath string, volumeOptions *VolumeOptions) (string, error) {
+	// Check if the diskControllerType is valid
+	if !CheckControllerSupported(volumeOptions.SCSIControllerType) {
+		return "", fmt.Errorf("Not a valid SCSI Controller Type. Valid options are %q", SCSIControllerTypeValidOptions())
+	}
+	vmDiskPathCopy := vmDiskPath
+	vmDiskPath = RemoveStorageClusterORFolderNameFromVDiskPath(vmDiskPath)
+	attached, err := vm.IsDiskAttached(ctx, vmDiskPath)
+	if err != nil {
+		glog.Errorf("Error occurred while checking if disk is attached on VM: %q. vmDiskPath: %q, err: %+v", vm.InventoryPath, vmDiskPath, err)
+		return "", err
+	}
+	// If disk is already attached, return the disk UUID
+	if attached {
+		diskUUID, _ := vm.Datacenter.GetVirtualDiskPage83Data(ctx, vmDiskPath)
+		return diskUUID, nil
+	}
+
+	if volumeOptions.StoragePolicyName != "" {
+		pbmClient, err := NewPbmClient(ctx, vm.Client())
+		if err != nil {
+			glog.Errorf("Error occurred while creating new pbmClient. err: %+v", err)
+			return "", err
+		}
+
+		volumeOptions.StoragePolicyID, err = pbmClient.ProfileIDByName(ctx, volumeOptions.StoragePolicyName)
+		if err != nil {
+			glog.Errorf("Failed to get Profile ID by name: %s. err: %+v", volumeOptions.StoragePolicyName, err)
+			return "", err
+		}
+	}
+
+	dsObj, err := vm.Datacenter.GetDatastoreByPath(ctx, vmDiskPathCopy)
+	if err != nil {
+		glog.Errorf("Failed to get datastore from vmDiskPath: %q. err: %+v", vmDiskPath, err)
+		return "", err
+	}
+	// If disk is not attached, create a disk spec for disk to be attached to the VM.
+	disk, newSCSIController, err := vm.CreateDiskSpec(ctx, vmDiskPath, dsObj, volumeOptions)
+	if err != nil {
+		glog.Errorf("Error occurred while creating disk spec. err: %+v", err)
+		return "", err
+	}
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		glog.Errorf("Failed to retrieve VM devices for VM: %q. err: %+v", vm.InventoryPath, err)
+		return "", err
+	}
+	virtualMachineConfigSpec := types.VirtualMachineConfigSpec{}
+	deviceConfigSpec := &types.VirtualDeviceConfigSpec{
+		Device:    disk,
+		Operation: types.VirtualDeviceConfigSpecOperationAdd,
+	}
+	// Configure the disk with the SPBM profile only if ProfileID is not empty.
+	if volumeOptions.StoragePolicyID != "" {
+		profileSpec := &types.VirtualMachineDefinedProfileSpec{
+			ProfileId: volumeOptions.StoragePolicyID,
+		}
+		deviceConfigSpec.Profile = append(deviceConfigSpec.Profile, profileSpec)
+	}
+	virtualMachineConfigSpec.DeviceChange = append(virtualMachineConfigSpec.DeviceChange, deviceConfigSpec)
+	requestTime := time.Now()
+	task, err := vm.Reconfigure(ctx, virtualMachineConfigSpec)
+	if err != nil {
+		RecordvSphereMetric(APIAttachVolume, requestTime, err)
+		glog.Errorf("Failed to attach the disk with storagePolicy: %q on VM: %q. err - %+v", volumeOptions.StoragePolicyID, vm.InventoryPath, err)
+		if newSCSIController != nil {
+			vm.deleteController(ctx, newSCSIController, vmDevices)
+		}
+		return "", err
+	}
+	err = task.Wait(ctx)
+	RecordvSphereMetric(APIAttachVolume, requestTime, err)
+	if err != nil {
+		glog.Errorf("Failed to attach the disk with storagePolicy: %+q on VM: %q. err - %+v", volumeOptions.StoragePolicyID, vm.InventoryPath, err)
+		if newSCSIController != nil {
+			vm.deleteController(ctx, newSCSIController, vmDevices)
+		}
+		return "", err
+	}
+
+	// Once disk is attached, get the disk UUID.
+	diskUUID, err := vm.Datacenter.GetVirtualDiskPage83Data(ctx, vmDiskPath)
+	if err != nil {
+		glog.Errorf("Error occurred while getting Disk Info from VM: %q. err: %v", vm.InventoryPath, err)
+		vm.DetachDisk(ctx, vmDiskPath)
+		if newSCSIController != nil {
+			vm.deleteController(ctx, newSCSIController, vmDevices)
+		}
+		return "", err
+	}
+	return diskUUID, nil
+}
+
+// DetachDisk detaches the disk specified by vmDiskPath
+func (vm *VirtualMachine) DetachDisk(ctx context.Context, vmDiskPath string) error {
+	vmDiskPath = RemoveStorageClusterORFolderNameFromVDiskPath(vmDiskPath)
+	device, err := vm.getVirtualDeviceByPath(ctx, vmDiskPath)
+	if err != nil {
+		glog.Errorf("Disk ID not found for VM: %q with diskPath: %q", vm.InventoryPath, vmDiskPath)
+		return err
+	}
+	if device == nil {
+		glog.Errorf("No virtual device found with diskPath: %q on VM: %q", vmDiskPath, vm.InventoryPath)
+		return fmt.Errorf("No virtual device found with diskPath: %q on VM: %q", vmDiskPath, vm.InventoryPath)
+	}
+	// Detach disk from VM
+	requestTime := time.Now()
+	err = vm.RemoveDevice(ctx, true, device)
+	RecordvSphereMetric(APIDetachVolume, requestTime, err)
+	if err != nil {
+		glog.Errorf("Error occurred while removing disk device for VM: %q. err: %v", vm.InventoryPath, err)
+		return err
+	}
+	return nil
+}
+
+// GetResourcePool gets the resource pool for VM.
+func (vm *VirtualMachine) GetResourcePool(ctx context.Context) (*object.ResourcePool, error) {
+	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{"resourcePool"})
+	if err != nil {
+		glog.Errorf("Failed to get resource pool from VM: %q. err: %+v", vm.InventoryPath, err)
+		return nil, err
+	}
+	return object.NewResourcePool(vm.Client(), vmMoList[0].ResourcePool.Reference()), nil
+}
+
+// IsActive checks if the VM is active.
+// Returns true if VM is in poweredOn state.
+func (vm *VirtualMachine) IsActive(ctx context.Context) (bool, error) {
+	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{"summary"})
+	if err != nil {
+		glog.Errorf("Failed to get VM Managed object with property summary. err: +%v", err)
+		return false, err
+	}
+	if vmMoList[0].Summary.Runtime.PowerState == ActivePowerState {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// GetAllAccessibleDatastores gets the list of accessible Datastores for the given Virtual Machine
+func (vm *VirtualMachine) GetAllAccessibleDatastores(ctx context.Context) ([]*DatastoreInfo, error) {
+	host, err := vm.HostSystem(ctx)
+	if err != nil {
+		glog.Errorf("Failed to get host system for VM: %q. err: %+v", vm.InventoryPath, err)
+		return nil, err
+	}
+	var hostSystemMo mo.HostSystem
+	s := object.NewSearchIndex(vm.Client())
+	err = s.Properties(ctx, host.Reference(), []string{DatastoreProperty}, &hostSystemMo)
+	if err != nil {
+		glog.Errorf("Failed to retrieve datastores for host: %+v. err: %+v", host, err)
+		return nil, err
+	}
+	var dsRefList []types.ManagedObjectReference
+	for _, dsRef := range hostSystemMo.Datastore {
+		dsRefList = append(dsRefList, dsRef)
+	}
+
+	var dsMoList []mo.Datastore
+	pc := property.DefaultCollector(vm.Client())
+	properties := []string{DatastoreInfoProperty}
+	err = pc.Retrieve(ctx, dsRefList, properties, &dsMoList)
+	if err != nil {
+		glog.Errorf("Failed to get Datastore managed objects from datastore objects."+
+			" dsObjList: %+v, properties: %+v, err: %v", dsRefList, properties, err)
+		return nil, err
+	}
+	glog.V(9).Infof("Result dsMoList: %+v", dsMoList)
+	var dsObjList []*DatastoreInfo
+	for _, dsMo := range dsMoList {
+		dsObjList = append(dsObjList,
+			&DatastoreInfo{
+				&Datastore{object.NewDatastore(vm.Client(), dsMo.Reference()),
+					vm.Datacenter},
+				dsMo.Info.GetDatastoreInfo()})
+	}
+	return dsObjList, nil
+}
+
+// CreateDiskSpec creates a disk spec for disk
+func (vm *VirtualMachine) CreateDiskSpec(ctx context.Context, diskPath string, dsObj *Datastore, volumeOptions *VolumeOptions) (*types.VirtualDisk, types.BaseVirtualDevice, error) {
+	var newSCSIController types.BaseVirtualDevice
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		glog.Errorf("Failed to retrieve VM devices. err: %+v", err)
+		return nil, nil, err
+	}
+	// find SCSI controller of particular type from VM devices
+	scsiControllersOfRequiredType := getSCSIControllersOfType(vmDevices, volumeOptions.SCSIControllerType)
+	scsiController := getAvailableSCSIController(scsiControllersOfRequiredType)
+	if scsiController == nil {
+		newSCSIController, err = vm.createAndAttachSCSIController(ctx, volumeOptions.SCSIControllerType)
+		if err != nil {
+			glog.Errorf("Failed to create SCSI controller for VM :%q with err: %+v", vm.InventoryPath, err)
+			return nil, nil, err
+		}
+		// Get VM device list
+		vmDevices, err := vm.Device(ctx)
+		if err != nil {
+			glog.Errorf("Failed to retrieve VM devices. err: %v", err)
+			return nil, nil, err
+		}
+		// verify scsi controller in virtual machine
+		scsiControllersOfRequiredType := getSCSIControllersOfType(vmDevices, volumeOptions.SCSIControllerType)
+		scsiController = getAvailableSCSIController(scsiControllersOfRequiredType)
+		if scsiController == nil {
+			glog.Errorf("Cannot find SCSI controller of type: %q in VM", volumeOptions.SCSIControllerType)
+			// attempt clean up of scsi controller
+			vm.deleteController(ctx, newSCSIController, vmDevices)
+			return nil, nil, fmt.Errorf("Cannot find SCSI controller of type: %q in VM", volumeOptions.SCSIControllerType)
+		}
+	}
+	disk := vmDevices.CreateDisk(scsiController, dsObj.Reference(), diskPath)
+	unitNumber, err := getNextUnitNumber(vmDevices, scsiController)
+	if err != nil {
+		glog.Errorf("Cannot attach disk to VM, unitNumber limit reached - %+v.", err)
+		return nil, nil, err
+	}
+	*disk.UnitNumber = unitNumber
+	backing := disk.Backing.(*types.VirtualDiskFlatVer2BackingInfo)
+	backing.DiskMode = string(types.VirtualDiskModeIndependent_persistent)
+
+	if volumeOptions.CapacityKB != 0 {
+		disk.CapacityInKB = int64(volumeOptions.CapacityKB)
+	}
+	if volumeOptions.DiskFormat != "" {
+		var diskFormat string
+		diskFormat = DiskFormatValidType[volumeOptions.DiskFormat]
+		switch diskFormat {
+		case ThinDiskType:
+			backing.ThinProvisioned = types.NewBool(true)
+		case EagerZeroedThickDiskType:
+			backing.EagerlyScrub = types.NewBool(true)
+		default:
+			backing.ThinProvisioned = types.NewBool(false)
+		}
+	}
+	return disk, newSCSIController, nil
+}
+
+// GetVirtualDiskPath gets the first available virtual disk devicePath from the VM
+func (vm *VirtualMachine) GetVirtualDiskPath(ctx context.Context) (string, error) {
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		glog.Errorf("Failed to get the devices for VM: %q. err: %+v", vm.InventoryPath, err)
+		return "", err
+	}
+	// filter vm devices to retrieve device for the given vmdk file identified by disk path
+	for _, device := range vmDevices {
+		if vmDevices.TypeName(device) == "VirtualDisk" {
+			virtualDevice := device.GetVirtualDevice()
+			if backing, ok := virtualDevice.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
+				return backing.FileName, nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// createAndAttachSCSIController creates and attachs the SCSI controller to the VM.
+func (vm *VirtualMachine) createAndAttachSCSIController(ctx context.Context, diskControllerType string) (types.BaseVirtualDevice, error) {
+	// Get VM device list
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		glog.Errorf("Failed to retrieve VM devices for VM: %q. err: %+v", vm.InventoryPath, err)
+		return nil, err
+	}
+	allSCSIControllers := getSCSIControllers(vmDevices)
+	if len(allSCSIControllers) >= SCSIControllerLimit {
+		// we reached the maximum number of controllers we can attach
+		glog.Errorf("SCSI Controller Limit of %d has been reached, cannot create another SCSI controller", SCSIControllerLimit)
+		return nil, fmt.Errorf("SCSI Controller Limit of %d has been reached, cannot create another SCSI controller", SCSIControllerLimit)
+	}
+	newSCSIController, err := vmDevices.CreateSCSIController(diskControllerType)
+	if err != nil {
+		glog.Errorf("Failed to create new SCSI controller on VM: %q. err: %+v", vm.InventoryPath, err)
+		return nil, err
+	}
+	configNewSCSIController := newSCSIController.(types.BaseVirtualSCSIController).GetVirtualSCSIController()
+	hotAndRemove := true
+	configNewSCSIController.HotAddRemove = &hotAndRemove
+	configNewSCSIController.SharedBus = types.VirtualSCSISharing(types.VirtualSCSISharingNoSharing)
+
+	// add the scsi controller to virtual machine
+	err = vm.AddDevice(context.TODO(), newSCSIController)
+	if err != nil {
+		glog.V(LogLevel).Infof("Cannot add SCSI controller to VM: %q. err: %+v", vm.InventoryPath, err)
+		// attempt clean up of scsi controller
+		vm.deleteController(ctx, newSCSIController, vmDevices)
+		return nil, err
+	}
+	return newSCSIController, nil
+}
+
+// getVirtualDeviceByPath gets the virtual device by path
+func (vm *VirtualMachine) getVirtualDeviceByPath(ctx context.Context, diskPath string) (types.BaseVirtualDevice, error) {
+	vmDevices, err := vm.Device(ctx)
+	if err != nil {
+		glog.Errorf("Failed to get the devices for VM: %q. err: %+v", vm.InventoryPath, err)
+		return nil, err
+	}
+
+	// filter vm devices to retrieve device for the given vmdk file identified by disk path
+	for _, device := range vmDevices {
+		if vmDevices.TypeName(device) == "VirtualDisk" {
+			virtualDevice := device.GetVirtualDevice()
+			if backing, ok := virtualDevice.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
+				if matchVirtualDiskAndVolPath(backing.FileName, diskPath) {
+					glog.V(LogLevel).Infof("Found VirtualDisk backing with filename %q for diskPath %q", backing.FileName, diskPath)
+					return device, nil
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (vm *VirtualMachine) GetVMUUID() (string, error) {
+	var o mo.VirtualMachine
+
+	err := vm.Properties(context.TODO(), vm.Reference(), []string{"config.uuid"}, &o)
+	if err != nil {
+		return "", err
+	}
+
+	return o.Config.Uuid, nil
+}
+
+func (vm *VirtualMachine) GetVMNodeName() (string, error) {
+	var o mo.VirtualMachine
+
+	err := vm.Properties(context.TODO(), vm.Reference(), []string{"guest.hostName"}, &o)
+	if err != nil {
+		return "", err
+	}
+
+	return o.Guest.HostName, nil
+}
+
+func matchVirtualDiskAndVolPath(diskPath, volPath string) bool {
+	fileExt := ".vmdk"
+	diskPath = strings.TrimSuffix(diskPath, fileExt)
+	volPath = strings.TrimSuffix(volPath, fileExt)
+	return diskPath == volPath
+}
+
+// deleteController removes latest added SCSI controller from VM.
+func (vm *VirtualMachine) deleteController(ctx context.Context, controllerDevice types.BaseVirtualDevice, vmDevices object.VirtualDeviceList) error {
+	controllerDeviceList := vmDevices.SelectByType(controllerDevice)
+	if len(controllerDeviceList) < 1 {
+		return ErrNoDevicesFound
+	}
+	device := controllerDeviceList[len(controllerDeviceList)-1]
+	err := vm.RemoveDevice(ctx, true, device)
+	if err != nil {
+		glog.Errorf("Error occurred while removing device on VM: %q. err: %+v", vm.InventoryPath, err)
+		return err
+	}
+	return nil
+}
+
+// RenewVM renews this virtual machine with new client connection.
+func (vm *VirtualMachine) RenewVM(client *vim25.Client) VirtualMachine {
+	dc := Datacenter{Datacenter: object.NewDatacenter(client, vm.Datacenter.Reference())}
+	newVM := object.NewVirtualMachine(client, vm.VirtualMachine.Reference())
+	return VirtualMachine{VirtualMachine: newVM, Datacenter: &dc}
+}

--- a/pkg/vclib/virtualmachine_test.go
+++ b/pkg/vclib/virtualmachine_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/simulator"
+)
+
+func TestVirtualMachine(t *testing.T) {
+	ctx := context.Background()
+
+	model := simulator.VPX()
+
+	defer model.Remove()
+	err := model.Create()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := model.Service.NewServer()
+	defer s.Close()
+
+	c, err := govmomi.NewClient(ctx, s.URL, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vc := &VSphereConnection{Client: c.Client}
+
+	dc, err := GetDatacenter(ctx, vc, TestDefaultDatacenter)
+	if err != nil {
+		t.Error(err)
+	}
+
+	folders, err := dc.Folders(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	folder, err := dc.GetFolderByPath(ctx, folders.VmFolder.InventoryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vms, err := folder.GetVirtualMachines(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(vms) == 0 {
+		t.Fatal("no VMs")
+	}
+
+	for _, vm := range vms {
+		all, err := vm.GetAllAccessibleDatastores(ctx)
+		if err != nil {
+			t.Error(err)
+		}
+		if len(all) == 0 {
+			t.Error("no accessible datastores")
+		}
+
+		_, err = vm.GetResourcePool(ctx)
+		if err != nil {
+			t.Error(err)
+		}
+
+		diskPath, err := vm.GetVirtualDiskPath(ctx)
+		if err != nil {
+			t.Error(err)
+		}
+
+		options := &VolumeOptions{SCSIControllerType: PVSCSIControllerType}
+
+		for _, expect := range []bool{true, false} {
+			attached, err := vm.IsDiskAttached(ctx, diskPath)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if attached != expect {
+				t.Errorf("attached=%t, expected=%t", attached, expect)
+			}
+
+			uuid, err := vm.AttachDisk(ctx, diskPath, options)
+			if err != nil {
+				t.Error(err)
+			}
+			if uuid == "" {
+				t.Error("missing uuid")
+			}
+
+			err = vm.DetachDisk(ctx, diskPath)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+
+		for _, expect := range []bool{true, false} {
+			active, err := vm.IsActive(ctx)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if active != expect {
+				t.Errorf("active=%t, expected=%t", active, expect)
+			}
+
+			if expect {
+				// Expecting to hit the error path since the VM is still powered on
+				err = vm.DeleteVM(ctx)
+				if err == nil {
+					t.Error("expected error")
+				}
+				_, _ = vm.PowerOff(ctx)
+				continue
+			}
+
+			// Should be able to delete now that VM power is off
+			err = vm.DeleteVM(ctx)
+			if err != nil {
+				t.Error(err)
+			}
+		}
+	}
+}

--- a/pkg/vclib/vmoptions.go
+++ b/pkg/vclib/vmoptions.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"github.com/vmware/govmomi/object"
+)
+
+// VMOptions provides helper objects for provisioning volume with SPBM Policy
+type VMOptions struct {
+	VMFolder       *Folder
+	VMResourcePool *object.ResourcePool
+}

--- a/pkg/vclib/volumeoptions.go
+++ b/pkg/vclib/volumeoptions.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// VolumeOptions specifies various options for a volume.
+type VolumeOptions struct {
+	CapacityKB             int
+	Tags                   map[string]string
+	Name                   string
+	DiskFormat             string
+	Datastore              string
+	VSANStorageProfileData string
+	StoragePolicyName      string
+	StoragePolicyID        string
+	SCSIControllerType     string
+}
+
+var (
+	// DiskFormatValidType specifies the valid disk formats
+	DiskFormatValidType = map[string]string{
+		ThinDiskType:                              ThinDiskType,
+		strings.ToLower(EagerZeroedThickDiskType): EagerZeroedThickDiskType,
+		strings.ToLower(ZeroedThickDiskType):      PreallocatedDiskType,
+	}
+	// SCSIControllerValidType specifies the supported SCSI controllers
+	SCSIControllerValidType = []string{LSILogicControllerType, LSILogicSASControllerType, PVSCSIControllerType}
+)
+
+// DiskformatValidOptions generates Valid Options for Diskformat
+func DiskformatValidOptions() string {
+	validopts := ""
+	for diskformat := range DiskFormatValidType {
+		validopts += diskformat + ", "
+	}
+	validopts = strings.TrimSuffix(validopts, ", ")
+	return validopts
+}
+
+// CheckDiskFormatSupported checks if the diskFormat is valid
+func CheckDiskFormatSupported(diskFormat string) bool {
+	if DiskFormatValidType[diskFormat] == "" {
+		glog.Errorf("Not a valid Disk Format. Valid options are %+q", DiskformatValidOptions())
+		return false
+	}
+	return true
+}
+
+// SCSIControllerTypeValidOptions generates valid options for SCSIControllerType
+func SCSIControllerTypeValidOptions() string {
+	validopts := ""
+	for _, controllerType := range SCSIControllerValidType {
+		validopts += (controllerType + ", ")
+	}
+	validopts = strings.TrimSuffix(validopts, ", ")
+	return validopts
+}
+
+// CheckControllerSupported checks if the given controller type is valid
+func CheckControllerSupported(ctrlType string) bool {
+	for _, c := range SCSIControllerValidType {
+		if ctrlType == c {
+			return true
+		}
+	}
+	glog.Errorf("Not a valid SCSI Controller Type. Valid options are %q", SCSIControllerTypeValidOptions())
+	return false
+}
+
+// VerifyVolumeOptions checks if volumeOptions.SCIControllerType is valid controller type
+func (volumeOptions VolumeOptions) VerifyVolumeOptions() bool {
+	// Validate only if SCSIControllerType is set by user.
+	// Default value is set later in virtualDiskManager.Create and vmDiskManager.Create
+	if volumeOptions.SCSIControllerType != "" {
+		isValid := CheckControllerSupported(volumeOptions.SCSIControllerType)
+		if !isValid {
+			return false
+		}
+	}
+	// ThinDiskType is the default, so skip the validation.
+	if volumeOptions.DiskFormat != ThinDiskType {
+		isValid := CheckDiskFormatSupported(volumeOptions.DiskFormat)
+		if !isValid {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/vclib/vsphere_metrics.go
+++ b/pkg/vclib/vsphere_metrics.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vclib
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Cloud Provider API constants
+const (
+	APICreateVolume = "CreateVolume"
+	APIDeleteVolume = "DeleteVolume"
+	APIAttachVolume = "AttachVolume"
+	APIDetachVolume = "DetachVolume"
+)
+
+// Cloud Provider Operation constants
+const (
+	OperationDeleteVolume                  = "DeleteVolumeOperation"
+	OperationAttachVolume                  = "AttachVolumeOperation"
+	OperationDetachVolume                  = "DetachVolumeOperation"
+	OperationDiskIsAttached                = "DiskIsAttachedOperation"
+	OperationDisksAreAttached              = "DisksAreAttachedOperation"
+	OperationCreateVolume                  = "CreateVolumeOperation"
+	OperationCreateVolumeWithPolicy        = "CreateVolumeWithPolicyOperation"
+	OperationCreateVolumeWithRawVSANPolicy = "CreateVolumeWithRawVSANPolicyOperation"
+)
+
+// vsphereAPIMetric is for recording latency of Single API Call.
+var vsphereAPIMetric = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name: "cloudprovider_vsphere_api_request_duration_seconds",
+		Help: "Latency of vsphere api call",
+	},
+	[]string{"request"},
+)
+
+var vsphereAPIErrorMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "cloudprovider_vsphere_api_request_errors",
+		Help: "vsphere Api errors",
+	},
+	[]string{"request"},
+)
+
+// vsphereOperationMetric is for recording latency of vSphere Operation which invokes multiple APIs to get the task done.
+var vsphereOperationMetric = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name: "cloudprovider_vsphere_operation_duration_seconds",
+		Help: "Latency of vsphere operation call",
+	},
+	[]string{"operation"},
+)
+
+var vsphereOperationErrorMetric = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "cloudprovider_vsphere_operation_errors",
+		Help: "vsphere operation errors",
+	},
+	[]string{"operation"},
+)
+
+// RegisterMetrics registers all the API and Operation metrics
+func RegisterMetrics() {
+	prometheus.MustRegister(vsphereAPIMetric)
+	prometheus.MustRegister(vsphereAPIErrorMetric)
+	prometheus.MustRegister(vsphereOperationMetric)
+	prometheus.MustRegister(vsphereOperationErrorMetric)
+}
+
+// RecordvSphereMetric records the vSphere API and Operation metrics
+func RecordvSphereMetric(actionName string, requestTime time.Time, err error) {
+	switch actionName {
+	case APICreateVolume, APIDeleteVolume, APIAttachVolume, APIDetachVolume:
+		recordvSphereAPIMetric(actionName, requestTime, err)
+	default:
+		recordvSphereOperationMetric(actionName, requestTime, err)
+	}
+}
+
+func recordvSphereAPIMetric(actionName string, requestTime time.Time, err error) {
+	if err != nil {
+		vsphereAPIErrorMetric.With(prometheus.Labels{"request": actionName}).Inc()
+	} else {
+		vsphereAPIMetric.With(prometheus.Labels{"request": actionName}).Observe(calculateTimeTaken(requestTime))
+	}
+}
+
+func recordvSphereOperationMetric(actionName string, requestTime time.Time, err error) {
+	if err != nil {
+		vsphereOperationErrorMetric.With(prometheus.Labels{"operation": actionName}).Inc()
+	} else {
+		vsphereOperationMetric.With(prometheus.Labels{"operation": actionName}).Observe(calculateTimeTaken(requestTime))
+	}
+}
+
+// RecordCreateVolumeMetric records the Create Volume metric
+func RecordCreateVolumeMetric(volumeOptions *VolumeOptions, requestTime time.Time, err error) {
+	var actionName string
+	if volumeOptions.StoragePolicyName != "" {
+		actionName = OperationCreateVolumeWithPolicy
+	} else if volumeOptions.VSANStorageProfileData != "" {
+		actionName = OperationCreateVolumeWithRawVSANPolicy
+	} else {
+		actionName = OperationCreateVolume
+	}
+	RecordvSphereMetric(actionName, requestTime, err)
+}
+
+func calculateTimeTaken(requestBeginTime time.Time) (timeTaken float64) {
+	if !requestBeginTime.IsZero() {
+		timeTaken = time.Since(requestBeginTime).Seconds()
+	} else {
+		timeTaken = 0
+	}
+	return timeTaken
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The reason why this is needed is because by not pushing with the latest tag means for each build I need to update my YAML to append the build tag (example 12a86808) to the image name (ie dvonthenen/vsphere-cloud-controller-manager:12a86808). Having latest allows users to deploy the latest cloud provider without having to modify the YAML file in the manifest directory every single time.

**Which issue this PR fixes**: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/17

**Special notes for your reviewer**: None
