### PR TITLE
fix: Sets Makefile default target to "all: build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # Follows the interface defined in the Golang CTI proposed
 # in https://review.openstack.org/410355
 
+all: build
 #REPO_VERSION?=$(shell git describe --tags)
 
 GIT_HOST = k8s.io


### PR DESCRIPTION
**What this PR does / why we need it**: This patch updates the default target in the Makefile to be "all" which depends on "build". This is a standard target graph in Makefiles.

Currently the `Makefile`'s default target is `$(GOBIN)` which is a directory path. For many reasons directory targets do not make the best Makefile targets *or* dependencies (unless order-only), but this is also not a user-friendly choice for the default target. Executing `make` should not yield `nothing to be done` on a clean system with an existing `$GOPATH/bin` directory.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: NA

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```