### PR TITLE
Removing dead code

### DIFF
--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -114,7 +114,6 @@ type NodeManager struct {
 
 type NodeDetails struct {
 	NodeName string
-	vm       *vclib.VirtualMachine
 	UUID     string
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: This patch fixes #23 and removes dead code. The following command was used to determine the code to remove:

```shell
$ gometalinter.v2 \
  --tests \
  --deadline=300s \
  --disable-all \
  --enable=deadcode \
  --enable=varcheck \
  --enable=structcheck \
  --enable=unparam \
  --enable=unused \
  $(for d in cluster cmd pkg; \
    do find "${d}" -type d; done | \
    sed 's~^~./~g' | tr '\n' ' ')
```

Please note that the above command does not use `./...` to imply all recursive packages. The `gometalinter` tool includes `vendor` when doing this, and that directory should be omitted. The output was as follows:

```shell
pkg/vclib/constants.go:55:1:warning: testNameNotFound is unused (deadcode)
pkg/cloudprovider/vsphere/types.go:117:2:warning: unused struct field k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere.NodeDetails.vm (structcheck)
pkg/cloudprovider/vsphere/instances.go:113:45:warning: parameter ctx is unused (unparam)
pkg/cloudprovider/vsphere/instances.go:113:66:warning: parameter user is unused (unparam)
pkg/cloudprovider/vsphere/instances.go:113:79:warning: parameter keyData is unused (unparam)
pkg/cloudprovider/vsphere/instances.go:119:37:warning: parameter ctx is unused (unparam)
pkg/cloudprovider/vsphere/instances.go:147:41:warning: parameter ctx is unused (unparam)
pkg/cloudprovider/vsphere/instances.go:339:47:warning: parameter ctx is unused (unparam)
pkg/vclib/pbm.go:88:74:warning: parameter dc is unused (unparam)
pkg/vclib/virtualmachine.go:413:143:warning: parameter result 0 (error) is never used (unparam)
pkg/cloudprovider/vsphere/types.go:117:2:warning: field vm is unused (U1000) (unused)
```

The following warnings were ignored as false-positives:

* `testNameNotFound` was listed as unused, but it **is** used in tests. The linters apparently do not all consider Go test sources.
* The `unparam` warnings were ignored because they refer to altering function signatures that are: required by interfaces but not yet implemented and thus the parameters are unused 
* Go contexts which may not always be used *yet*, but is good practice to include for the future. 

All in all one change was made:

1. The same issue was discovered twice by different tools:
    * `pkg/cloudprovider/vsphere/types.go:117:2:warning: unused struct field k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere.NodeDetails.vm (structcheck)`
    * `pkg/cloudprovider/vsphere/types.go:117:2:warning: field vm is unused (U1000) (unused)`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #23

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```