### PR TITLE
Updates for building the provider locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,36 @@ The vSphere cloud provider code locates at [Kubernetes repository directory](htt
 
 There is an ongoing work for refactoring cloud providers out of the upstream repository. For more details, please check [this KEP](https://github.com/kubernetes/community/blob/master/keps/sig-cloud-provider/0002-cloud-controller-manager.md).
 
-## Building Locally
+## Building the cloud provider
+
+This section outlines how to build the cloud provider with and without Docker.
+
+### Building locally
 
 Clone this repository to `$GOPATH/src/k8s.io/cloud-provider-vsphere`. Please note that this path is not the same as the project's location in GitHub. Failing to clone the repository to the prescribed path causes the Go dependency tool `dep` and builds to fail.
-
-Once the project is cloned locally, use the `Makefile` to build the cloud provider:
 
 ```shell
 $ make
 ```
 
+### Building with Docker
+
+It is also possible to build the cloud provider with Docker in order to ensure a clean build environment. When building with Docker this repository may be cloned anywhere in or out of the `$GOPATH`. For example, the following script clones and builds the cloud-provider using a temporary directory:
+
+**Note**: Python is used to resolve the temporary directory's real path. This step is required on macOS due to Docker's restrictions on which directories can be shared with a container. The script has been tested on Linux as well.
+
+```shell
+$ cd $(python -c "import os; print(os.path.realpath('$(mktemp -d)'))") && \
+  git clone https://github.com/kubernetes/cloud-provider-vsphere . && \
+  hack/make.sh
+```
+
 ### The dep tool hangs
-The `dep` tool may freeze when running it locally and not via the `hack/make.sh` command that uses the Docker image. If this happens, please check the following:
+
+The `dep` tool may freeze when running locally and not via the `hack/make.sh` command that uses the Docker image. If this happens, please check the following:
 
 1. The repository must be cloned to `$GOPATH/src/k8s.io/cloud-provider-vsphere`. This is not the same path as the project's location in GitHub, but rather reflects the project's Go packages' vanity import path.
-2. The Mercurial client `hg` must be installed in order to fetch the dependency `bitbucket.org/ww/goautoneg`. Otherwise `dep` freezes for no apparent reason.
+2. The Mercurial client `hg` must be installed in order to fetch the dependency `bitbucket.org/ww/goautoneg`. Otherwise `dep` will [hang](https://github.com/kubernetes/test-infra/blob/master/docs/dep.md#tips) indefinitely without any indication as to the reason.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Once the project is cloned locally, use the `Makefile` to build the cloud provid
 $ make
 ```
 
+### The dep tool hangs
+The `dep` tool may freeze when running it locally and not via the `hack/make.sh` command that uses the Docker image. If this happens, please check the following:
+
+1. The repository must be cloned to `$GOPATH/src/k8s.io/cloud-provider-vsphere`. This is not the same path as the project's location in GitHub, but rather reflects the project's Go packages' vanity import path.
+2. The Mercurial client `hg` must be installed in order to fetch the dependency `bitbucket.org/ww/goautoneg`. Otherwise `dep` freezes for no apparent reason.
+
 ## Contributing
 
 Please see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to contribute.

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -20,4 +20,4 @@
 # GOPATH and handle all of the Go ENV stuff for you.  All you need is Docker
 docker run -it -v "$PWD":/go/src/k8s.io/cloud-provider-vsphere:z \
 	-w /go/src/k8s.io/cloud-provider-vsphere \
-	golang:1.10 make $1
+	golang:1.10 make "$@"


### PR DESCRIPTION
**What this PR does / why we need it**: This PR includes three changes:

1. The `hack/make.sh` script has been updated to accept multiple targets
2. The `README` now includes information about why `dep` may hang and how to solve the issue
3. The `README` has been updated to include more detailed information about building the provider locally

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: NA

**Special notes for your reviewer**: Please note that the update to `hack/make.sh` was included in this PR due to not wanting to indicate in the build documentation that running `make` directly can accept multiple targets while using `hack/make.sh` did not.

**Release note**:
```release-note
* The "hack/make.sh" script now accepts multiple targets.
* The project's "README" now includes information about why the "dep" tool may hang and how to solve the issue.
```