### PR TITLE
Implement Kubernetes Secret for Storing vCenter Creds

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -923,6 +923,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6f77c9642b80bb51975001690eb2d83f18091969233cbfeb82f43c63fa2dcbc7"
+  inputs-digest = "5fe943d463d1e4e0d5b231279c15dca5aa05f015e39a927b7643352ed36babb4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docs/deploying_cloud_provider_vsphere_with_rbac.md
+++ b/docs/deploying_cloud_provider_vsphere_with_rbac.md
@@ -113,10 +113,10 @@ metadata:
   name: vccm
   namespace: kube-system
 data:
-  1.2.3.4.username: "Replace with out from `echo -n YOUR_VCENTER_USERNAME | base64`"
-  1.2.3.4.password: "Replace with out from `echo -n YOUR_VCENTER_PASSWORD | base64`"
-  10.0.0.1.username: "Replace with out from `echo -n YOUR_VCENTER_USERNAME | base64`"
-  10.0.0.1.password: "Replace with out from `echo -n YOUR_VCENTER_PASSWORD | base64`"
+  1.2.3.4.username: "Replace with output from `echo -n YOUR_VCENTER_USERNAME | base64`"
+  1.2.3.4.password: "Replace with output from `echo -n YOUR_VCENTER_PASSWORD | base64`"
+  10.0.0.1.username: "Replace with output from `echo -n YOUR_VCENTER_USERNAME | base64`"
+  10.0.0.1.password: "Replace with output from `echo -n YOUR_VCENTER_PASSWORD | base64`"
 ```
 
 Create the secret by running the folowing command:

--- a/docs/deploying_cloud_provider_vsphere_with_rbac.md
+++ b/docs/deploying_cloud_provider_vsphere_with_rbac.md
@@ -7,10 +7,11 @@ This document is designed to quickly get you up and running with the `cloud-prov
 Steps that will covered in deploying `cloud-provider-vpshere`:
 
 1. Set all your Kubernetes nodes to run using an external cloud controller manager.
-2. Configure your vsphere.conf file file and create a `configmap` you settings.
-3. Create the RBAC roles for `cloud-provider-vsphere`.
-4. Create the RBAC role bindings for `cloud-provider-vsphere`.
-5. Deploy `cloud-provider-vsphere` using either the Pod or DaemonSet YAML.
+2. Configure your vsphere.conf file and create a `configmap` you settings.
+3. (Optional, but recommended) Storing vCenter creds in a Kubernetes Secret
+4. Create the RBAC roles for `cloud-provider-vsphere`.
+5. Create the RBAC role bindings for `cloud-provider-vsphere`.
+6. Deploy `cloud-provider-vsphere` using either the Pod or DaemonSet YAML.
 
 ## Deploying `cloud-provider-vsphere`
 
@@ -18,19 +19,63 @@ Steps that will covered in deploying `cloud-provider-vpshere`:
 
 This is already covered in the Kubernetes documentation. Please take a look at configuration guidelines located [here](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager).
 
-
 #### 2. Creating a `configmap` of your vSphere configuration
 
-An example [vsphere.conf](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/vsphere.conf) is located in the `cloud-provider-vsphere` repo in the [manifests/controller-manager](https://github.com/kubernetes/cloud-provider-vsphere/tree/master/manifests/controller-manager) directory.
+There are 2 methods for configuring the `cloud-provider-vsphere`:
+- Using a Kubernetes Secret
+- Within the vsphere.conf
 
-Example vsphere.conf contents:
+It's highly recommended that you store your vCenter credentials in a Kubernetes secret for added security.
+
+An example [vsphere.conf](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/vsphere.conf) is located in the `cloud-provider-vsphere` repo in the [manifests/controller-manager](https://github.com/kubernetes/cloud-provider-vsphere/tree/master/manifests/controller-manager) directory for reference.
+
+##### Method 1: Storing vCenter Credentials in a Kubernetes Secret
+
+Example vsphere.conf contents if the vCenter credentials are going to be stored using a Kubernetes Secret:
+
+```
+[Global]
+# properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+
+secret-name = "Kubernetes Secret containing creds in the namespace below"
+secret-namespace = "Kubernetes namespace for CCM deploy"
+service-account = "Kubernetes service account used for CCM deploy" #Default: cloud-controller-manager
+
+port = "443" #Optional
+insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
+datacenters = "list of datacenters where Kubernetes node VMs are present"
+
+[VirtualCenter "1.2.3.4"]
+# Override specific properties for this Virtual Center.
+        datacenters = "list of datacenters where Kubernetes node VMs are present"
+        # port, insecure-flag will be used from Global section.
+
+[VirtualCenter "10.0.0.1"]
+# Override specific properties for this Virtual Center.
+        port = "448"
+        insecure-flag = "0"
+        # datacenters will be used from Global section.
+
+[Network]
+        public-network = "Network Name to be used"
+```
+
+Configure your vsphere.conf file and create a `configmap` of your settings using the following command:
+
+```bash
+[k8suser@k8master ~]$ kubectl create configmap cloud-config --from-file=vsphere.conf --namespace=kube-system
+```
+
+##### Method 2: Storing vCenter Credentials in the vsphere.conf File
+
+Example vsphere.conf contents if the vCenter credentials are going to be stored within the configuration file:
 
 ```
 [Global]
 # properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
 
 user = "vCenter username for cloud provider"
-password = "password"        
+password = "password"
 port = "443" #Optional
 insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
 datacenters = "list of datacenters where Kubernetes node VMs are present"
@@ -41,7 +86,7 @@ datacenters = "list of datacenters where Kubernetes node VMs are present"
         password = "password"
         # port, insecure-flag, datacenters will be used from Global section.
 
-[VirtualCenter "1.2.3.5"]
+[VirtualCenter "10.0.0.1"]
 # Override specific properties for this Virtual Center.
         port = "448"
         insecure-flag = "0"
@@ -57,7 +102,30 @@ Configure your vsphere.conf file and create a `configmap` of your settings using
 [k8suser@k8master ~]$ kubectl create configmap cloud-config --from-file=vsphere.conf --namespace=kube-system
 ```
 
-#### 3. Create the RBAC roles
+#### 3. (Optional, but recommended) Storing vCenter credentials in a Kubernetes Secret
+
+If you chose to store your vCenter credentials within a Kubernetes Secret (method 1 above), an example [Secrets YAML](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/vccm-secret.yaml) is provided for reference. Both the vCenter username and password is base64 encoded within the secret. If you have multiple vCenters (as in the example vsphere.conf file), your Kubernetes Secret YAML will look like the following:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vccm
+  namespace: kube-system
+data:
+  1.2.3.4.username: "Replace with out from `echo -n YOUR_VCENTER_USERNAME | base64`"
+  1.2.3.4.password: "Replace with out from `echo -n YOUR_VCENTER_PASSWORD | base64`"
+  10.0.0.1.username: "Replace with out from `echo -n YOUR_VCENTER_USERNAME | base64`"
+  10.0.0.1.password: "Replace with out from `echo -n YOUR_VCENTER_PASSWORD | base64`"
+```
+
+Create the secret by running the folowing command:
+
+```bash
+[k8suser@k8master ~]$ kubectl create -f vccm-secret.yaml
+```
+
+#### 4. Create the RBAC roles
 
 You can find the RBAC roles required by the provider in [cloud-controller-manager-roles.yaml](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/cloud-controller-manager-roles.yaml).
 
@@ -67,7 +135,7 @@ To apply them to your Kubernetes cluster, run the following command:
 [k8suser@k8master ~]$ kubectl create -f cloud-controller-manager-roles.yaml
 ```
 
-#### 4. Create the RBAC role bindings
+#### 5. Create the RBAC role bindings
 
 You can find the RBAC role bindings required by the provider in [cloud-controller-manager-role-bindings.yaml](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml).
 
@@ -77,7 +145,7 @@ To apply them to your Kubernetes cluster, run the following command:
 [k8suser@k8master ~]$ kubectl create -f cloud-controller-manager-role-bindings.yaml
 ```
 
-#### 5. Deploy `cloud-provider-vsphere` CCM
+#### 6. Deploy `cloud-provider-vsphere` CCM
 
 You have two options for deploying `cloud-provider-vsphere`. It can be deployed either as a simple Pod or in a DaemonSet. There really isn't much difference between the two other than the DaemonSet will do leader election and the Pod will just assume to be the leader.
 

--- a/manifests/controller-manager/vccm-secret.yaml
+++ b/manifests/controller-manager/vccm-secret.yaml
@@ -4,5 +4,5 @@ metadata:
   name: vccm
   namespace: kube-system
 data:
-  1.2.3.4.username: "Replace with out from `echo -n YOUR_VCENTER_USERNAME | base64`"
-  1.2.3.4.password: "Replace with out from `echo -n YOUR_VCENTER_PASSWORD | base64`"
+  1.2.3.4.username: "Replace with output from `echo -n YOUR_VCENTER_USERNAME | base64`"
+  1.2.3.4.password: "Replace with output from `echo -n YOUR_VCENTER_PASSWORD | base64`"

--- a/manifests/controller-manager/vccm-secret.yaml
+++ b/manifests/controller-manager/vccm-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vccm
+  namespace: kube-system
+data:
+  1.2.3.4.username: "Replace with out from `echo -n YOUR_VCENTER_USERNAME | base64`"
+  1.2.3.4.password: "Replace with out from `echo -n YOUR_VCENTER_PASSWORD | base64`"

--- a/manifests/controller-manager/vsphere.conf
+++ b/manifests/controller-manager/vsphere.conf
@@ -1,8 +1,14 @@
 [Global]
 # properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
 
+# If setting vCenter creds in a Kubernetes secret, set the following:
+secret-name = "Kubernetes Secret containing creds in the namespace below"
+secret-namespace = "Kubernetes namespace for CCM deploy"
+service-account = "Kubernetes service account used for CCM deploy" #Default: cloud-controller-manager
+# Otherwise, you can globally set vCenter creds below
 user = "vCenter username for cloud provider"
-password = "password"        
+password = "password"
+
 port = "443" #Optional
 insecure-flag = "1" #set to 1 if the vCenter uses a self-signed cert
 datacenters = "list of datacenters where Kubernetes node VMs are present"
@@ -13,7 +19,7 @@ datacenters = "list of datacenters where Kubernetes node VMs are present"
         password = "password"
         # port, insecure-flag, datacenters will be used from Global section.
 
-[VirtualCenter "1.2.3.5"]
+[VirtualCenter "10.0.0.1"]
 # Override specific properties for this Virtual Center.
         port = "448"
         insecure-flag = "0"

--- a/pkg/cloudprovider/vsphere/credentialmanager.go
+++ b/pkg/cloudprovider/vsphere/credentialmanager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/glog"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Error Messages
@@ -64,10 +65,10 @@ func (secretCredentialManager *SecretCredentialManager) GetCredential(server str
 }
 
 func (secretCredentialManager *SecretCredentialManager) updateCredentialsMap() error {
-	if secretCredentialManager.SecretLister == nil {
-		return fmt.Errorf("SecretLister is not initialized")
+	if secretCredentialManager.Client == nil {
+		return fmt.Errorf("Kubernetes Client is not initialized")
 	}
-	secret, err := secretCredentialManager.SecretLister.Secrets(secretCredentialManager.SecretNamespace).Get(secretCredentialManager.SecretName)
+	secret, err := secretCredentialManager.Client.CoreV1().Secrets(secretCredentialManager.SecretNamespace).Get(secretCredentialManager.SecretName, metav1.GetOptions{})
 	if err != nil {
 		glog.Errorf("Cannot get secret %s in namespace %s. error: %q", secretCredentialManager.SecretName, secretCredentialManager.SecretNamespace, err)
 		return err

--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -20,15 +20,14 @@ import (
 	"sync"
 
 	"k8s.io/api/core/v1"
-	clientv1 "k8s.io/client-go/listers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/cloud-provider-vsphere/pkg/vclib"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
 // VSphere is an implementation of cloud provider Interface for VSphere.
 type VSphere struct {
-	// client        *godo.Client
-	// cfg                *Config
+	cfg                *Config
 	vsphereInstanceMap map[string]*VSphereInstance
 	nodeManager        *NodeManager
 	instances          cloudprovider.Instances
@@ -56,6 +55,9 @@ type Config struct {
 		SecretName string `gcfg:"secret-name"`
 		// Secret Namespace where secret will be present that has vCenter credentials.
 		SecretNamespace string `gcfg:"secret-namespace"`
+		// The kubernetes service account used to launch the cloud controller manager.
+		// Default: cloud-controller-manager
+		ServiceAccount string `gcfg:"service-account"`
 	}
 	VirtualCenter map[string]*VirtualCenterConfig
 
@@ -131,7 +133,7 @@ type Credential struct {
 type SecretCredentialManager struct {
 	SecretName      string
 	SecretNamespace string
-	SecretLister    clientv1.SecretLister
+	Client          clientset.Interface
 	Cache           *SecretCache
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This implements the ability to store vCenter credentials (username and password) in a Kubernetes Secret. 
- Multiple vCenter creds are supported within the secret.
- Configurable service account supported for multiple cloud-provider-vsphere instances.
- To maintain backward compatibility, credentials are obtained in the following order: secret, vCenter unique creds, global setting. If the secret doesn't exist, the behavior is to fall back on the old method of conf file.
- Documentation updated to help the user deploy using a secret.

**Which issue this PR fixes**: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/6

**Special notes for your reviewer**:
Tested the following scenarios on a 1.11.1 Kubernetes cluster:
- Secret containing vCenter creds without setting creds in vsphere.conf
- Secret containing vCenter creds and also setting creds in vsphere.conf (made sure Secret is used)
- Secret does not contain vCenter creds but creds set in vsphere.conf (creds from config are used)
- No Secret set, vCenter creds set within [vcenter ip] block
- No Secret set, vCenter creds set using Global

**Release note**:
None