### PR TITLE
Implements NodeManager and Reconcile Based on UUID

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -79,12 +79,12 @@
   version = "v17"
 
 [[projects]]
-  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
+  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = "UT"
-  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
-  version = "v1.1.0"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"
@@ -95,7 +95,7 @@
     "reference",
   ]
   pruneopts = "UT"
-  revision = "9bf62ca7b3fcffe31d231196a069e6c4abff9065"
+  revision = "02bf4a2887a491eaa5333acae99e67bf8e68df1a"
 
 [[projects]]
   digest = "1:f4f6279cb37479954644babd8f8ef00584ff9fa63555d2c6718c1c3517170202"
@@ -202,7 +202,7 @@
   revision = "24b0969c4cb722950103eed87108c8d291a8df00"
 
 [[projects]]
-  digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
+  digest = "1:4c0989ca0bcd10799064318923b9bc2db6b4d6338dd75f3f2d86c3511aaaf5cf"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -212,8 +212,8 @@
     "ptypes/timestamp",
   ]
   pruneopts = "UT"
-  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
-  version = "v1.1.0"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -432,7 +432,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b11b873c6706833f99194ddce55cddb09798f3c3bcb3e8a4a99be8069bda3ada"
+  digest = "1:5af29ead924a0ecf7bf1ffa7ac9d4a02603719adda23ef323d6344f118bf86e9"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
@@ -466,7 +466,7 @@
     "vim25/xml",
   ]
   pruneopts = "UT"
-  revision = "badd514933ffc1d67c88e189fe16cb6d525be0d4"
+  revision = "22f74650cf39ba4649fba45e770df0f44df6f758"
 
 [[projects]]
   branch = "master"
@@ -479,11 +479,11 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
+  revision = "614d502a4dac94afa3a6ce146bd1736da82514c6"
 
 [[projects]]
   branch = "master"
-  digest = "1:4b9d48cb517d97552209bb55c52185e3fb5119607965b2f1c9123e606c500414"
+  digest = "1:9812eb354c055268a95354e388d47021483712b842f32ebd4cbceb144cb18488"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -496,18 +496,18 @@
     "websocket",
   ]
   pruneopts = "UT"
-  revision = "c39426892332e1bb5ec0a434a079bf82f5d30c54"
+  revision = "922f4815f713f213882e8ef45e0d315b164d705c"
 
 [[projects]]
   branch = "master"
-  digest = "1:26ec91f56010c7c9f74630771a35f12f07f3c1d077455ae6611fe58b21433146"
+  digest = "1:48774faa158e9eaee1ba45aad66434bb0345927b43756a24d4fe4c44ad79e307"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "14742f9018cd6651ec7364dc6ee08af0baaa1031"
+  revision = "3b58ed4ad3395d483fc92d5d14123ce2c3581fec"
 
 [[projects]]
   digest = "1:0c56024909189aee3364b7f21a95a27459f718aa7c199a5c111c36cfffd9eaef"
@@ -547,7 +547,7 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "d0a8f471bba2dbb160885b0000d814ee5d559bad"
+  revision = "c66870c02cf823ceb633bcd05be3c7cda29976f4"
 
 [[projects]]
   digest = "1:7ccedf0aab474a6aef9d7222cd2429a34fddb996bbd1f60ec0f9fe69d80b36ae"
@@ -688,7 +688,7 @@
   name = "k8s.io/apiextensions-apiserver"
   packages = ["pkg/features"]
   pruneopts = "UT"
-  revision = "4d05e43ad98c1edcf2f52291685bd9bbc12fd2cd"
+  revision = "b12c11a9bd7161c9a3d291caea157ca052ac4d49"
 
 [[projects]]
   digest = "1:c62c694b9145db32cd0d652b2ea1ba18b8a837075334f711cbf5bf3f7c06f1d8"
@@ -1093,6 +1093,14 @@
   revision = "bb9ffb1654d4a729bb4cec18ff088eacc153c239"
   version = "v1.11.2"
 
+[[projects]]
+  branch = "master"
+  digest = "1:e1fc4a624e8497252148125a50cec64b416d69ef69afc2244498e0c9b73060d5"
+  name = "k8s.io/sample-controller"
+  packages = ["pkg/signals"]
+  pruneopts = "UT"
+  revision = "be98dc6210ab86895825bb9ed212f9f60557c33e"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
@@ -1129,6 +1137,7 @@
     "k8s.io/client-go/informers",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/listers/core/v1",
+    "k8s.io/client-go/tools/cache",
     "k8s.io/kubernetes/cmd/cloud-controller-manager/app",
     "k8s.io/kubernetes/cmd/cloud-controller-manager/app/options",
     "k8s.io/kubernetes/pkg/apis/core/v1/helper",
@@ -1138,6 +1147,7 @@
     "k8s.io/kubernetes/pkg/util/flag",
     "k8s.io/kubernetes/pkg/version/prometheus",
     "k8s.io/kubernetes/pkg/version/verflag",
+    "k8s.io/sample-controller/pkg/signals",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -19,17 +19,12 @@ package vsphere
 import (
 	"context"
 	"errors"
-	"net"
 	"strings"
-	"sync"
 
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/cloudprovider"
-
-	"k8s.io/cloud-provider-vsphere/pkg/vclib"
 )
 
 const (
@@ -37,12 +32,14 @@ const (
 	QUEUE_SIZE     int    = POOL_SIZE * 10
 	ProviderPrefix string = "vsphere://"
 
-	CredentialManagerErrMsg = "The Credential Manager is not initialized"
+	//CredentialManagerErrMsg = "The Credential Manager is not initialized"
+	NodeNotFoundErrMsg = "Node not found"
 )
 
 // Error constants
 var (
-	ErrCredentialManager = errors.New(CredentialManagerErrMsg)
+	//ErrCredentialManager = errors.New(CredentialManagerErrMsg)
+	ErrNodeNotFound = errors.New(NodeNotFoundErrMsg)
 )
 
 func newInstances(nodeManager *NodeManager) cloudprovider.Instances {
@@ -55,26 +52,43 @@ func newInstances(nodeManager *NodeManager) cloudprovider.Instances {
 // When nodeName identifies more than one instance, only the first will be
 // considered.
 func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v1.NodeAddress, error) {
-	glog.V(4).Info("vsphere.instances.NodeAddresses() called")
+	glog.V(4).Info("instances.NodeAddresses() called with ", string(nodeName))
 
 	// Check if node has been discovered already
-	if node, ok := i.nodeManager.nodeInfoMap[string(nodeName)]; ok {
+	if node, ok := i.nodeManager.nodeNameMap[string(nodeName)]; ok {
+		glog.V(4).Info("instances.NodeAddresses() CACHED with ", string(nodeName))
 		return node.NodeAddresses, nil
 	}
 
-	if err := i.nodeDiscoveryByName(ctx, nodeName); err != nil {
-		return []v1.NodeAddress{}, err
+	if err := i.nodeManager.DiscoverNode(string(nodeName), FindVMByName); err != nil {
+		glog.V(4).Info("instances.NodeAddresses() FOUND with ", string(nodeName))
+		return i.nodeManager.nodeNameMap[string(nodeName)].NodeAddresses, nil
 	}
 
-	return i.nodeManager.nodeInfoMap[string(nodeName)].NodeAddresses, nil
+	glog.V(4).Info("instances.NodeAddresses() NOT FOUND with ", string(nodeName))
+	return []v1.NodeAddress{}, ErrNodeNotFound
 }
 
 // NodeAddressesByProviderID returns all the valid addresses of the instance
 // identified by providerID. Only the public/private IPv4 addresses will be
 // considered for now.
 func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
-	glog.V(4).Info("vsphere.instances.NodeAddressesByProviderID() called")
-	return i.NodeAddresses(ctx, types.NodeName(providerID))
+	glog.V(4).Info("instances.NodeAddressesByProviderID() called with ", providerID)
+
+	// Check if node has been discovered already
+	uid := i.getUUIDFromProviderID(providerID)
+	if node, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
+		glog.V(4).Info("instances.NodeAddressesByProviderID() CACHED with ", uid)
+		return node.NodeAddresses, nil
+	}
+
+	if err := i.nodeManager.DiscoverNode(uid, FindVMByUUID); err == nil {
+		glog.V(4).Info("instances.NodeAddressesByProviderID() FOUND with ", uid)
+		return i.nodeManager.nodeUUIDMap[uid].NodeAddresses, nil
+	}
+
+	glog.V(4).Info("instances.NodeAddressesByProviderID() NOT FOUND with ", uid)
+	return []v1.NodeAddress{}, ErrNodeNotFound
 }
 
 // ExternalID returns the cloud provider ID of the instance identified by
@@ -84,522 +98,80 @@ func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 // When nodeName identifies more than one instance, only the first will be
 // considered.
 func (i *instances) ExternalID(ctx context.Context, nodeName types.NodeName) (string, error) {
-	glog.V(4).Info("vsphere.instances.ExternalID() called")
+	glog.V(4).Info("instances.ExternalID() called with ", nodeName)
 	return i.InstanceID(ctx, nodeName)
 }
 
 // InstanceID returns the cloud provider ID of the instance identified by nodeName.
 func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
-	glog.V(4).Info("vsphere.instances.InstanceID() called")
+	glog.V(4).Info("instances.InstanceID() called with ", nodeName)
 
 	// Check if node has been discovered already
-	if node, ok := i.nodeManager.nodeInfoMap[string(nodeName)]; ok {
+	if node, ok := i.nodeManager.nodeNameMap[string(nodeName)]; ok {
+		glog.V(4).Info("instances.InstanceID() CACHED with ", string(nodeName))
 		return node.UUID, nil
 	}
 
-	if err := i.nodeDiscoveryByName(ctx, nodeName); err != nil {
-		return "", err
+	if err := i.nodeManager.DiscoverNode(string(nodeName), FindVMByName); err == nil {
+		glog.V(4).Info("instances.InstanceID() FOUND with ", string(nodeName))
+		return i.nodeManager.nodeNameMap[string(nodeName)].UUID, nil
 	}
 
-	return i.nodeManager.nodeInfoMap[string(nodeName)].UUID, nil
-
+	glog.V(4).Info("instances.InstanceID() NOT FOUND with ", string(nodeName))
+	return "", ErrNodeNotFound
 }
 
 // InstanceType returns the type of the instance identified by name.
 func (i *instances) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
-	glog.V(4).Info("vsphere.instances.InstanceType() called")
+	glog.V(4).Info("instances.InstanceType() called")
 	return "vsphere-vm", nil
 }
 
 // InstanceTypeByProviderID returns the type of the instance identified by providerID.
 func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
-	glog.V(4).Info("vsphere.instances.InstanceTypeByProviderID() called")
+	glog.V(4).Info("instances.InstanceTypeByProviderID() called")
 	return "vsphere-vm", nil
 }
 
 // AddSSHKeyToAllInstances is not implemented; it always returns an error.
 func (i *instances) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
-	glog.V(4).Info("vsphere.instances.AddSSHKeyToAllInstances() called")
+	glog.V(4).Info("instances.AddSSHKeyToAllInstances() called")
 	return cloudprovider.NotImplemented
 }
 
 // CurrentNodeName returns hostname as a NodeName value.
 func (i *instances) CurrentNodeName(ctx context.Context, hostname string) (types.NodeName, error) {
-	glog.V(4).Info("vsphere.instances.CurrentNodeName() called")
+	glog.V(4).Info("instances.CurrentNodeName() called")
 	return types.NodeName(hostname), nil
 }
 
 // InstanceExistsByProviderID returns true if the instance identified by
 // providerID is running.
 func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
-	glog.V(4).Info("vsphere.instances.InstanceExistsByProviderID() called")
+	glog.V(4).Info("instances.InstanceExistsByProviderID() called with ", providerID)
 
 	// Check if node has been discovered already
-	if _, ok := i.nodeManager.nodeInfoMap[providerID]; !ok {
-		if err := i.nodeDiscoveryByProviderID(ctx, providerID); err != nil {
-			return false, err
-		}
+	uid := i.getUUIDFromProviderID(providerID)
+	if _, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
+		glog.V(4).Info("instances.InstanceExistsByProviderID() CACHED with ", uid)
 		return true, nil
 	}
 
-	return true, nil
+	if err := i.nodeManager.DiscoverNode(uid, FindVMByUUID); err == nil {
+		glog.V(4).Info("instances.InstanceExistsByProviderID() EXISTS with ", uid)
+		return true, err
+	}
+
+	glog.V(4).Info("instances.InstanceExistsByProviderID() NOT FOUND with ", uid)
+	return false, nil
 }
 
 // InstanceShutdownByProviderID returns true if the instance is in safe state to detach volumes
 func (i *instances) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
+	glog.V(4).Info("instances.InstanceShutdownByProviderID() called")
 	return false, cloudprovider.NotImplemented
 }
 
-// PRIVATE
-
-func (i *instances) nodeDiscoveryByName(ctx context.Context, nodeName types.NodeName) error {
-	glog.V(4).Info("vsphere.instances.nodeDiscovery() called")
-
-	type VmSearch struct {
-		vc         string
-		datacenter *vclib.Datacenter
-	}
-
-	var mutex = &sync.Mutex{}
-	var globalErrMutex = &sync.Mutex{}
-	var queueChannel chan *VmSearch
-	var wg sync.WaitGroup
-	var globalErr *error
-
-	queueChannel = make(chan *VmSearch, QUEUE_SIZE)
-
-	glog.V(4).Infof("Discovering node %s with name %s", string(nodeName), string(nodeName))
-
-	vmFound := false
-	globalErr = nil
-
-	setGlobalErr := func(err error) {
-		globalErrMutex.Lock()
-		globalErr = &err
-		globalErrMutex.Unlock()
-	}
-
-	setVMFound := func(found bool) {
-		mutex.Lock()
-		vmFound = found
-		mutex.Unlock()
-	}
-
-	getVMFound := func() bool {
-		mutex.Lock()
-		found := vmFound
-		mutex.Unlock()
-		return found
-	}
-
-	go func() {
-		var datacenterObjs []*vclib.Datacenter
-		for vc, vsi := range i.nodeManager.vsphereInstanceMap {
-
-			found := getVMFound()
-			if found == true {
-				break
-			}
-
-			// Create context
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			err := i.vcConnect(ctx, vsi)
-			if err != nil {
-				glog.V(4).Info("Discovering node error vc:", err)
-				setGlobalErr(err)
-				continue
-			}
-
-			if vsi.cfg.Datacenters == "" {
-				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.conn)
-				if err != nil {
-					glog.V(4).Info("Discovering node error dc:", err)
-					setGlobalErr(err)
-					continue
-				}
-			} else {
-				datacenters := strings.Split(vsi.cfg.Datacenters, ",")
-				for _, dc := range datacenters {
-					dc = strings.TrimSpace(dc)
-					if dc == "" {
-						continue
-					}
-					datacenterObj, err := vclib.GetDatacenter(ctx, vsi.conn, dc)
-					if err != nil {
-						glog.V(4).Info("Discovering node error dc:", err)
-						setGlobalErr(err)
-						continue
-					}
-					datacenterObjs = append(datacenterObjs, datacenterObj)
-				}
-			}
-
-			for _, datacenterObj := range datacenterObjs {
-				found := getVMFound()
-				if found == true {
-					break
-				}
-
-				glog.V(4).Infof("Finding node %s in vc=%s and datacenter=%s", nodeName, vc, datacenterObj.Name())
-				queueChannel <- &VmSearch{
-					vc:         vc,
-					datacenter: datacenterObj,
-				}
-			}
-		}
-		close(queueChannel)
-	}()
-
-	for j := 0; j < POOL_SIZE; j++ {
-		go func() {
-			for res := range queueChannel {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				// vm, err := res.datacenter.GetVMByUUID(ctx, nodeUUID)
-				vm, err := res.datacenter.GetVMByDNSName(ctx, string(nodeName))
-				if err != nil {
-					glog.V(4).Infof("Error %q while looking for vm=%+v in vc=%s and datacenter=%s",
-						err, nodeName, vm, res.vc, res.datacenter.Name())
-					if err != vclib.ErrNoVMFound {
-						setGlobalErr(err)
-					} else {
-						glog.V(4).Infof("Did not find node %s in vc=%s and datacenter=%s",
-							nodeName, res.vc, res.datacenter.Name(), err)
-					}
-					continue
-				}
-				if vm != nil {
-					glog.V(4).Infof("Found node %s as vm=%+v in vc=%s and datacenter=%s",
-						nodeName, vm, res.vc, res.datacenter.Name())
-
-					nodeUUID, err := vm.GetVMUUID()
-					if err != nil {
-						glog.V(4).Infof("Did not find UUID node %s in vc=%s and datacenter=%s",
-							nodeName, res.vc, res.datacenter.Name(), err)
-					}
-
-					addrs := []v1.NodeAddress{}
-					vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*vclib.VirtualMachine{vm}, []string{"guest.net"})
-					if err != nil {
-						glog.Errorf("Failed to get VM Managed object with property guest.net for node: %q. err: +%v", string(nodeName), err)
-						// return nil, err
-					}
-					// retrieve VM's ip(s)
-					for _, v := range vmMoList[0].Guest.Net {
-						// if vsi.cfg.Network.PublicNetwork == v.Network {
-						for _, ip := range v.IpAddress {
-							if net.ParseIP(ip).To4() != nil {
-								v1helper.AddToNodeAddresses(&addrs,
-									v1.NodeAddress{
-										Type:    v1.NodeExternalIP,
-										Address: ip,
-									}, v1.NodeAddress{
-										Type:    v1.NodeInternalIP,
-										Address: ip,
-									},
-								)
-							}
-						}
-						// }
-					}
-
-					nodeInfo := &NodeInfo{
-						dataCenter:    res.datacenter,
-						vm:            vm,
-						vcServer:      res.vc,
-						UUID:          nodeUUID,
-						NodeName:      string(nodeName),
-						NodeAddresses: addrs,
-					}
-
-					i.nodeManager.nodeInfoLock.Lock()
-					i.nodeManager.nodeInfoMap[string(nodeName)] = nodeInfo
-					i.nodeManager.nodeInfoMap[ProviderPrefix+nodeUUID] = nodeInfo
-					i.nodeManager.nodeInfoLock.Unlock()
-
-					for range queueChannel {
-					}
-					setVMFound(true)
-					break
-				}
-			}
-			wg.Done()
-		}()
-		wg.Add(1)
-	}
-	wg.Wait()
-	if vmFound {
-		return nil
-	}
-	if globalErr != nil {
-		return *globalErr
-	}
-
-	glog.V(4).Infof("Discovery Node: %q vm not found", nodeName)
-	return vclib.ErrNoVMFound
-
-}
-
-// TODO(frapposelli): FIX THIS CODE DUPLICATION
-// TODO(frapposelli): THIS SHOULD BE DONE WITH PROPERTYCOLLECTOR
-func (i *instances) nodeDiscoveryByProviderID(ctx context.Context, providerID string) error {
-	glog.V(4).Info("vsphere.instances.nodeDiscovery() called")
-
-	type VmSearch struct {
-		vc         string
-		datacenter *vclib.Datacenter
-	}
-
-	var mutex = &sync.Mutex{}
-	var globalErrMutex = &sync.Mutex{}
-	var queueChannel chan *VmSearch
-	var wg sync.WaitGroup
-	var globalErr *error
-
-	queueChannel = make(chan *VmSearch, QUEUE_SIZE)
-
-	glog.V(4).Infof("Discovering node with providerID %s", providerID)
-
-	vmFound := false
-	globalErr = nil
-
-	setGlobalErr := func(err error) {
-		globalErrMutex.Lock()
-		globalErr = &err
-		globalErrMutex.Unlock()
-	}
-
-	setVMFound := func(found bool) {
-		mutex.Lock()
-		vmFound = found
-		mutex.Unlock()
-	}
-
-	getVMFound := func() bool {
-		mutex.Lock()
-		found := vmFound
-		mutex.Unlock()
-		return found
-	}
-
-	go func() {
-		var datacenterObjs []*vclib.Datacenter
-		for vc, vsi := range i.nodeManager.vsphereInstanceMap {
-
-			found := getVMFound()
-			if found == true {
-				break
-			}
-
-			// Create context
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			err := i.vcConnect(ctx, vsi)
-			if err != nil {
-				glog.V(4).Info("Discovering node error vc:", err)
-				setGlobalErr(err)
-				continue
-			}
-
-			if vsi.cfg.Datacenters == "" {
-				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.conn)
-				if err != nil {
-					glog.V(4).Info("Discovering node error dc:", err)
-					setGlobalErr(err)
-					continue
-				}
-			} else {
-				datacenters := strings.Split(vsi.cfg.Datacenters, ",")
-				for _, dc := range datacenters {
-					dc = strings.TrimSpace(dc)
-					if dc == "" {
-						continue
-					}
-					datacenterObj, err := vclib.GetDatacenter(ctx, vsi.conn, dc)
-					if err != nil {
-						glog.V(4).Info("Discovering node error dc:", err)
-						setGlobalErr(err)
-						continue
-					}
-					datacenterObjs = append(datacenterObjs, datacenterObj)
-				}
-			}
-
-			for _, datacenterObj := range datacenterObjs {
-				found := getVMFound()
-				if found == true {
-					break
-				}
-
-				glog.V(4).Infof("Finding providerID %s in vc=%s and datacenter=%s", providerID, vc, datacenterObj.Name())
-				queueChannel <- &VmSearch{
-					vc:         vc,
-					datacenter: datacenterObj,
-				}
-			}
-		}
-		close(queueChannel)
-	}()
-
-	for j := 0; j < POOL_SIZE; j++ {
-		go func() {
-			for res := range queueChannel {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				nodeUUID := i.GetUUIDFromProviderID(providerID)
-				vm, err := res.datacenter.GetVMByUUID(ctx, nodeUUID)
-				if err != nil {
-					glog.V(4).Infof("Error %q while looking for vm=%+v in vc=%s and datacenter=%s",
-						err, nodeUUID, vm, res.vc, res.datacenter.Name())
-					if err != vclib.ErrNoVMFound {
-						setGlobalErr(err)
-					} else {
-						glog.V(4).Infof("Did not find node %s in vc=%s and datacenter=%s",
-							nodeUUID, res.vc, res.datacenter.Name(), err)
-					}
-					continue
-				}
-				if vm != nil {
-					nodeName, err := vm.GetVMNodeName()
-					if err != nil {
-						glog.V(4).Infof("Did not find NodeName node %s in vc=%s and datacenter=%s",
-							nodeName, res.vc, res.datacenter.Name(), err)
-					}
-
-					glog.V(4).Infof("Found node %s as vm=%+v in vc=%s and datacenter=%s",
-						nodeName, vm, res.vc, res.datacenter.Name())
-
-					addrs := []v1.NodeAddress{}
-					vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*vclib.VirtualMachine{vm}, []string{"guest.net"})
-					if err != nil {
-						glog.Errorf("Failed to get VM Managed object with property guest.net for node: %q. err: +%v", string(nodeName), err)
-						// return nil, err
-					}
-					// retrieve VM's ip(s)
-					for _, v := range vmMoList[0].Guest.Net {
-						// if vsi.cfg.Network.PublicNetwork == v.Network {
-						for _, ip := range v.IpAddress {
-							if net.ParseIP(ip).To4() != nil {
-								v1helper.AddToNodeAddresses(&addrs,
-									v1.NodeAddress{
-										Type:    v1.NodeExternalIP,
-										Address: ip,
-									}, v1.NodeAddress{
-										Type:    v1.NodeInternalIP,
-										Address: ip,
-									},
-								)
-							}
-						}
-						// }
-					}
-
-					nodeInfo := &NodeInfo{
-						dataCenter:    res.datacenter,
-						vm:            vm,
-						vcServer:      res.vc,
-						UUID:          nodeUUID,
-						NodeName:      string(nodeName),
-						NodeAddresses: addrs,
-					}
-
-					i.nodeManager.nodeInfoLock.Lock()
-					i.nodeManager.nodeInfoMap[string(nodeName)] = nodeInfo
-					i.nodeManager.nodeInfoMap[ProviderPrefix+nodeUUID] = nodeInfo
-					i.nodeManager.nodeInfoLock.Unlock()
-
-					for range queueChannel {
-					}
-					setVMFound(true)
-					break
-				}
-			}
-			wg.Done()
-		}()
-		wg.Add(1)
-	}
-	wg.Wait()
-	if vmFound {
-		return nil
-	}
-	if globalErr != nil {
-		return *globalErr
-	}
-
-	glog.V(4).Infof("Discovery providerID: %q vm not found", providerID)
-	return vclib.ErrNoVMFound
-
-}
-
-func (i *instances) vcConnect(ctx context.Context, vsphereInstance *VSphereInstance) error {
-	credentialManager := i.CredentialManager()
-	if credentialManager == nil {
-		err := ErrCredentialManager
-		glog.Errorf("%v", err)
-		return err
-	}
-
-	// Get latest credentials from SecretCredentialManager
-	credentials, err := credentialManager.GetCredential(vsphereInstance.conn.Hostname)
-	if err == nil {
-		glog.V(4).Infof("Secret for server %q found. Attempting connection from secret.",
-			vsphereInstance.conn.Hostname)
-
-		//save username/password from config
-		tmpUsername := vsphereInstance.conn.Username
-		tmpPassword := vsphereInstance.conn.Password
-
-		vsphereInstance.conn.UpdateCredentials(credentials.User, credentials.Password)
-		err := vsphereInstance.conn.Connect(ctx)
-		if err == nil {
-			glog.V(4).Infof("Successfully connected to %q using credentials from secret.",
-				vsphereInstance.conn.Hostname)
-			return nil
-		} else {
-			glog.V(4).Infof("Failed to connected to %q using credentials from secret.",
-				vsphereInstance.conn.Hostname)
-		}
-
-		//revert username/password
-		vsphereInstance.conn.UpdateCredentials(tmpUsername, tmpPassword)
-
-		glog.V(4).Infof("Unable to connect to %q using credentials from secret.",
-			vsphereInstance.conn.Hostname)
-	} else {
-		glog.V(4).Infof("Unable to find secret for server %q. Using credentials from configuration.",
-			vsphereInstance.conn.Hostname)
-	}
-
-	glog.V(4).Infof("Attempting connection on %q using credentials from config.",
-		vsphereInstance.conn.Hostname)
-
-	err = vsphereInstance.conn.Connect(ctx)
-	if err == nil {
-		glog.V(4).Infof("Successfully connected to %q using credentials from config.",
-			vsphereInstance.conn.Hostname)
-	} else {
-		glog.V(4).Infof("Failed to connected to %q using credentials from secret.",
-			vsphereInstance.conn.Hostname)
-	}
-
-	return err
-}
-
-func (i *instances) CredentialManager() *SecretCredentialManager {
-	i.nodeManager.credentialManagerLock.Lock()
-	defer i.nodeManager.credentialManagerLock.Unlock()
-	return i.nodeManager.credentialManager
-}
-
-func (i *instances) UpdateCredentialManager(credentialManager *SecretCredentialManager) {
-	i.nodeManager.credentialManagerLock.Lock()
-	defer i.nodeManager.credentialManagerLock.Unlock()
-	i.nodeManager.credentialManager = credentialManager
-}
-
-func (i *instances) GetUUIDFromProviderID(providerID string) string {
+func (i *instances) getUUIDFromProviderID(providerID string) string {
 	return strings.TrimPrefix(providerID, ProviderPrefix)
 }

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cloud-provider-vsphere/pkg/vclib"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+
+	"github.com/vmware/govmomi/vim25/mo"
+)
+
+type FindVM int
+
+const (
+	FindVMByUUID FindVM = iota // 0
+	FindVMByName               // 1
+)
+
+// RegisterNode - Handler when node is removed from k8s cluster.
+func (nm *NodeManager) RegisterNode(node *v1.Node) {
+	glog.V(4).Info("RegisterNode ENTER: ", node.Name)
+	nm.addNode(node)
+	nm.DiscoverNode(nm.convertK8sUUIDtoNormal(node.Status.NodeInfo.SystemUUID), FindVMByUUID)
+	glog.V(4).Info("RegisterNode LEAVE: ", node.Name)
+}
+
+// UnregisterNode - Handler when node is removed from k8s cluster.
+func (nm *NodeManager) UnregisterNode(node *v1.Node) {
+	glog.V(4).Info("UnregisterNode ENTER: ", node.Name)
+	nm.removeNode(node)
+	glog.V(4).Info("UnregisterNode LEAVE: ", node.Name)
+}
+
+func (nm *NodeManager) addNodeInfo(node *NodeInfo) {
+	nm.nodeInfoLock.Lock()
+	glog.V(4).Info("addNodeInfo NodeName: ", node.NodeName, ", UUID: ", node.UUID)
+	nm.nodeNameMap[node.NodeName] = node
+	nm.nodeUUIDMap[node.UUID] = node
+	nm.nodeInfoLock.Unlock()
+}
+
+func (nm *NodeManager) addNode(node *v1.Node) {
+	nm.nodeRegInfoLock.Lock()
+	uuid := nm.convertK8sUUIDtoNormal(node.Status.NodeInfo.SystemUUID)
+	glog.V(4).Info("addNode NodeName: ", node.GetName(), ", UID: ", uuid)
+	nm.nodeRegUUIDMap[uuid] = node
+	nm.nodeRegInfoLock.Unlock()
+}
+
+func (nm *NodeManager) removeNode(node *v1.Node) {
+	nm.nodeRegInfoLock.Lock()
+	uuid := nm.convertK8sUUIDtoNormal(node.Status.NodeInfo.SystemUUID)
+	glog.V(4).Info("removeNode NodeName: ", node.GetName(), ", UID: ", uuid)
+	delete(nm.nodeRegUUIDMap, uuid)
+	nm.nodeRegInfoLock.Unlock()
+}
+
+func (nm *NodeManager) DiscoverNode(nodeID string, searchBy FindVM) error {
+	if nodeID == "" {
+		glog.V(4).Info("DiscoverNode called but nodeID is empty")
+		return vclib.ErrNoVMFound
+	}
+	type vmSearch struct {
+		vc         string
+		datacenter *vclib.Datacenter
+	}
+
+	var mutex = &sync.Mutex{}
+	var globalErrMutex = &sync.Mutex{}
+	var queueChannel chan *vmSearch
+	var wg sync.WaitGroup
+	var globalErr *error
+
+	queueChannel = make(chan *vmSearch, QUEUE_SIZE)
+
+	myNodeID := nodeID
+	if searchBy == FindVMByUUID {
+		glog.V(4).Info("DiscoverNode by UUID")
+		myNodeID = strings.ToLower(nodeID)
+	} else {
+		glog.V(4).Info("DiscoverNode by Name")
+	}
+	glog.V(4).Info("DiscoverNode nodeID: ", myNodeID)
+
+	vmFound := false
+	globalErr = nil
+
+	setGlobalErr := func(err error) {
+		globalErrMutex.Lock()
+		globalErr = &err
+		globalErrMutex.Unlock()
+	}
+
+	setVMFound := func(found bool) {
+		mutex.Lock()
+		vmFound = found
+		mutex.Unlock()
+	}
+
+	getVMFound := func() bool {
+		mutex.Lock()
+		found := vmFound
+		mutex.Unlock()
+		return found
+	}
+
+	go func() {
+		var datacenterObjs []*vclib.Datacenter
+		for vc, vsi := range nm.vsphereInstanceMap {
+
+			found := getVMFound()
+			if found == true {
+				break
+			}
+
+			// Create context
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := nm.vcConnect(ctx, vsi)
+			if err != nil {
+				glog.V(4).Info("Discovering node error vc:", err)
+				setGlobalErr(err)
+				continue
+			}
+
+			if vsi.cfg.Datacenters == "" {
+				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.conn)
+				if err != nil {
+					glog.V(4).Info("Discovering node error dc:", err)
+					setGlobalErr(err)
+					continue
+				}
+			} else {
+				datacenters := strings.Split(vsi.cfg.Datacenters, ",")
+				for _, dc := range datacenters {
+					dc = strings.TrimSpace(dc)
+					if dc == "" {
+						continue
+					}
+					datacenterObj, err := vclib.GetDatacenter(ctx, vsi.conn, dc)
+					if err != nil {
+						glog.V(4).Info("Discovering node error dc:", err)
+						setGlobalErr(err)
+						continue
+					}
+					datacenterObjs = append(datacenterObjs, datacenterObj)
+				}
+			}
+
+			for _, datacenterObj := range datacenterObjs {
+				found := getVMFound()
+				if found == true {
+					break
+				}
+
+				glog.V(4).Infof("Finding node %s in vc=%s and datacenter=%s", myNodeID, vc, datacenterObj.Name())
+				queueChannel <- &vmSearch{
+					vc:         vc,
+					datacenter: datacenterObj,
+				}
+			}
+		}
+		close(queueChannel)
+	}()
+
+	for i := 0; i < POOL_SIZE; i++ {
+		go func() {
+			for res := range queueChannel {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				var vm *vclib.VirtualMachine
+				var err error
+				if searchBy == FindVMByUUID {
+					vm, err = res.datacenter.GetVMByUUID(ctx, myNodeID)
+				} else {
+					vm, err = res.datacenter.GetVMByDNSName(ctx, myNodeID)
+				}
+
+				if err != nil {
+					glog.V(4).Infof("Error while looking for vm=%+v in vc=%s and datacenter=%s: %v",
+						vm, res.vc, res.datacenter.Name(), err)
+					if err != vclib.ErrNoVMFound {
+						setGlobalErr(err)
+					} else {
+						glog.V(4).Infof("Did not find node %s in vc=%s and datacenter=%s",
+							myNodeID, res.vc, res.datacenter.Name())
+					}
+					continue
+				}
+
+				var oVM mo.VirtualMachine
+				err = vm.Properties(ctx, vm.Reference(), []string{"config", "summary", "summary.config", "guest.net", "guest"}, &oVM)
+				if err != nil {
+					glog.V(4).Infof("Error collecting properties for vm=%+v in vc=%s and datacenter=%s: %v",
+						vm, res.vc, res.datacenter.Name(), err)
+					continue
+				}
+
+				addrs := []v1.NodeAddress{}
+				for _, v := range oVM.Guest.Net {
+					for _, ip := range v.IpAddress {
+						if net.ParseIP(ip).To4() != nil {
+							v1helper.AddToNodeAddresses(&addrs,
+								v1.NodeAddress{
+									Type:    v1.NodeExternalIP,
+									Address: ip,
+								}, v1.NodeAddress{
+									Type:    v1.NodeInternalIP,
+									Address: ip,
+								},
+							)
+						}
+					}
+				}
+
+				glog.V(4).Infof("Found node %s as vm=%+v in vc=%s and datacenter=%s",
+					nodeID, vm, res.vc, res.datacenter.Name())
+				glog.V(4).Info("Hostname: ", oVM.Guest.HostName, " UUID: ", oVM.Summary.Config.Uuid)
+
+				nodeInfo := &NodeInfo{dataCenter: res.datacenter, vm: vm, vcServer: res.vc,
+					UUID: oVM.Summary.Config.Uuid, NodeName: oVM.Guest.HostName, NodeAddresses: addrs}
+				nm.addNodeInfo(nodeInfo)
+				for range queueChannel {
+				}
+				setVMFound(true)
+				break
+			}
+			wg.Done()
+		}()
+		wg.Add(1)
+	}
+	wg.Wait()
+	if vmFound {
+		return nil
+	}
+	if globalErr != nil {
+		return *globalErr
+	}
+
+	glog.V(4).Infof("Discovery Node: %q vm not found", myNodeID)
+	return vclib.ErrNoVMFound
+}
+
+func (nm *NodeManager) uidToString(uid types.UID) string {
+	return strings.ToLower(string(uid))
+}
+
+func (nm *NodeManager) stringToUID(uid string) types.UID {
+	return types.UID(strings.ToLower(uid))
+}
+
+// vcConnect connects to vCenter with existing credentials
+// If credentials are invalid:
+// 		1. It will fetch credentials from credentialManager
+//      2. Update the credentials
+//		3. Connects again to vCenter with fetched credentials
+func (nm *NodeManager) vcConnect(ctx context.Context, vsphereInstance *VSphereInstance) error {
+	err := vsphereInstance.conn.Connect(ctx)
+	if err == nil {
+		return nil
+	}
+
+	if !vclib.IsInvalidCredentialsError(err) || nm.credentialManager == nil {
+		glog.Errorf("Cannot connect to vCenter with err: %v", err)
+		return err
+	}
+
+	glog.V(4).Infof("Invalid credentials. Cannot connect to server %q. "+
+		"Fetching credentials from secrets.", vsphereInstance.conn.Hostname)
+
+	// Get latest credentials from SecretCredentialManager
+	credentials, err := nm.credentialManager.GetCredential(vsphereInstance.conn.Hostname)
+	if err != nil {
+		glog.Errorf("Failed to get credentials from Secret Credential Manager with err: %v", err)
+		return err
+	}
+	vsphereInstance.conn.UpdateCredentials(credentials.User, credentials.Password)
+	return vsphereInstance.conn.Connect(ctx)
+}
+
+// Reformats UUID to match vSphere format
+// Endian Safe : https://www.dmtf.org/standards/smbios/
+//            8   -  4 -  4 - 4  -    12
+//K8s:    56492e42-22ad-3911-6d72-59cc8f26bc90
+//VMware: 422e4956-ad22-1139-6d72-59cc8f26bc90
+func (nm *NodeManager) convertK8sUUIDtoNormal(k8sUUID string) string {
+	uuid := fmt.Sprintf("%s%s%s%s-%s%s-%s%s-%s-%s",
+		k8sUUID[6:8], k8sUUID[4:6], k8sUUID[2:4], k8sUUID[0:2],
+		k8sUUID[11:13], k8sUUID[9:11],
+		k8sUUID[16:18], k8sUUID[14:16],
+		k8sUUID[19:23],
+		k8sUUID[24:36])
+	return strings.ToLower(uuid)
+}

--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -110,17 +110,22 @@ type NodeInfo struct {
 }
 
 type NodeManager struct {
-	// TODO: replace map with concurrent map when k8s supports go v1.9
-
 	// Maps the VC server to VSphereInstance
 	vsphereInstanceMap map[string]*VSphereInstance
-	// Maps node name to node info.
-	nodeInfoMap map[string]*NodeInfo
-	//CredentialsManager
+	// Maps node name to node info
+	nodeNameMap map[string]*NodeInfo
+	// Maps ProviderID (UUID) to node info.
+	nodeUUIDMap map[string]*NodeInfo
+	// Maps ProviderID (UUID) to node info.
+	nodeRegUUIDMap map[string]*v1.Node
+	// CredentialsManager
 	credentialManager *SecretCredentialManager
+	// NodeLister to track Node properties
+	nodeLister clientv1.NodeLister
 
 	// Mutexes
 	nodeInfoLock          sync.RWMutex
+	nodeRegInfoLock       sync.RWMutex
 	credentialManagerLock sync.Mutex
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This implements the NodeManager that handles management of existing nodes in a kubernetes cluster and also handles onboard new nodes. The reconciliation or the booking keeping on nodes has changed from using the DNS name to the SystemUUID (not to be confused with the VMware InstanceUUID).

**Which issue this PR fixes**: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/11 and https://github.com/kubernetes/cloud-provider-vsphere/issues/35

**Special notes for your reviewer**:
The in-tree provider used a single map to store looking up node information based DNS name and UUID. You could potentially craft ways of forcing a collision and possibly highjacking another nodes info. This implements two lookup maps one for DNS and one for UUID.

This also fixes an issue with gathering the creds from the kubernetes secret found in testing this feature.

Also adds a bunch more logging to understand what is going on in the provider both for verification and for future debugging/troubleshooting.

**Release note**:
Tested on kubernetes 1.11.2 with 3 worker nodes.
Tested adding a 4th worker node and made sure it was handled correctly.