### PR TITLE
Feature: Implement vcpctl create solution user for CCM

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -298,6 +298,19 @@
   version = "1.1.5"
 
 [[projects]]
+  branch = "govmomi"
+  name = "github.com/kr/pretty"
+  packages = ["."]
+  revision = "2ee9d7453c02ef7fa518a83ae23644eb8872186a"
+  source = "https://github.com/dougm/pretty"
+
+[[projects]]
+  name = "github.com/kr/text"
+  packages = ["."]
+  revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
+  version = "v0.1.0"
+
+[[projects]]
   branch = "master"
   digest = "1:84a5a2b67486d5d67060ac393aa255d05d24ed5ee41daecd5635ec22657b6492"
   name = "github.com/mailru/easyjson"
@@ -436,7 +449,78 @@
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
+    "event",
     "find",
+    "govc",
+    "govc/about",
+    "govc/cli",
+    "govc/cluster",
+    "govc/cluster/group",
+    "govc/cluster/override",
+    "govc/cluster/rule",
+    "govc/datacenter",
+    "govc/datastore",
+    "govc/datastore/disk",
+    "govc/datastore/vsan",
+    "govc/device",
+    "govc/device/cdrom",
+    "govc/device/floppy",
+    "govc/device/scsi",
+    "govc/device/serial",
+    "govc/device/usb",
+    "govc/dvs",
+    "govc/dvs/portgroup",
+    "govc/env",
+    "govc/events",
+    "govc/export",
+    "govc/extension",
+    "govc/fields",
+    "govc/flags",
+    "govc/folder",
+    "govc/host",
+    "govc/host/account",
+    "govc/host/autostart",
+    "govc/host/cert",
+    "govc/host/date",
+    "govc/host/esxcli",
+    "govc/host/firewall",
+    "govc/host/maintenance",
+    "govc/host/option",
+    "govc/host/portgroup",
+    "govc/host/service",
+    "govc/host/storage",
+    "govc/host/vnic",
+    "govc/host/vswitch",
+    "govc/importx",
+    "govc/license",
+    "govc/logs",
+    "govc/ls",
+    "govc/metric",
+    "govc/metric/interval",
+    "govc/object",
+    "govc/option",
+    "govc/permissions",
+    "govc/pool",
+    "govc/role",
+    "govc/session",
+    "govc/sso/service",
+    "govc/sso/user",
+    "govc/tags",
+    "govc/tags/association",
+    "govc/tags/category",
+    "govc/task",
+    "govc/vapp",
+    "govc/version",
+    "govc/vm",
+    "govc/vm/disk",
+    "govc/vm/guest",
+    "govc/vm/network",
+    "govc/vm/rdm",
+    "govc/vm/snapshot",
+    "guest",
+    "guest/toolbox",
+    "internal",
+    "license",
     "list",
     "lookup",
     "lookup/methods",
@@ -444,18 +528,26 @@
     "lookup/types",
     "nfc",
     "object",
+    "ovf",
     "pbm",
     "pbm/methods",
     "pbm/types",
+    "performance",
     "property",
     "session",
     "simulator",
     "simulator/esx",
     "simulator/vpx",
+    "ssoadmin",
+    "ssoadmin/methods",
+    "ssoadmin/types",
     "sts",
     "sts/internal",
     "sts/simulator",
     "task",
+    "units",
+    "vapi/tags",
+    "view",
     "vim25",
     "vim25/debug",
     "vim25/methods",
@@ -464,6 +556,7 @@
     "vim25/soap",
     "vim25/types",
     "vim25/xml",
+    "vmdk"
   ]
   pruneopts = "UT"
   revision = "22f74650cf39ba4649fba45e770df0f44df6f758"

--- a/cmd/vcpctl/provision/provision.go
+++ b/cmd/vcpctl/provision/provision.go
@@ -17,9 +17,12 @@ limitations under the License.
 package provision
 
 import (
+	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/cloud-provider-vsphere/pkg/cli"
 )
 
 var (
@@ -43,6 +46,10 @@ var (
 	vcUser string
 	// vCenter password in clear text.
 	vcPassword string
+	// vCenter certificate
+	vcCert string
+	// vcRole is role for solution user (Default is Administrator)
+	vcRole string
 )
 
 var provisionCmd = &cobra.Command{
@@ -60,16 +67,18 @@ var provisionCmd = &cobra.Command{
 }
 
 func AddProvision(cmd *cobra.Command) {
-	provisionCmd.Flags().StringVar(&configFile, "config", "", "vsphere cloud provider config file path")
-	provisionCmd.Flags().BoolVar(&oldInTreeConfig, "oldConfig", false, "old int-tree vsphere configuration file, true or false")
-	provisionCmd.Flags().BoolVar(&interactive, "interactive", true, "specify interactive mode (true) as default, set (false) for declarative mode for automation")
 
-	provisionCmd.Flags().StringVar(&vchost, "vchost", "", "specify vCenter IP ")
-	provisionCmd.Flags().StringVar(&vcport, "vcport", "", "specify vCenter Port ")
-	provisionCmd.Flags().StringVar(&vcUser, "vcuser", "", "specify vCenter user ")
-	provisionCmd.Flags().StringVar(&vcPassword, "vcpassword", "", "specify vCenter Password ")
+	provisionCmd.Flags().StringVar(&configFile, "config", "", "VSphere cloud provider config file path")
+	provisionCmd.Flags().BoolVar(&oldInTreeConfig, "oldConfig", false, "Old int-tree vsphere configuration file, true or false")
+	provisionCmd.Flags().BoolVar(&interactive, "interactive", true, "Specify interactive mode (true) as default, set (false) for declarative mode for automation")
+
+	provisionCmd.Flags().StringVar(&vchost, "host", "", "Specify vCenter IP")
+	provisionCmd.Flags().StringVar(&vcport, "port", "", "Specify vCenter Port")
+	provisionCmd.Flags().StringVar(&vcUser, "user", "", "Specify vCenter user")
+	provisionCmd.Flags().StringVar(&vcPassword, "password", "", "Specify vCenter Password")
 	provisionCmd.Flags().BoolVar(&insecure, "insecure", false, "Don't verify the server's certificate chain")
-	provisionCmd.Flags()
+	provisionCmd.Flags().StringVar(&vcCert, "cert", "", "Certificate for solution user")
+	provisionCmd.Flags().StringVar(&vcRole, "role", "Administrator", "Role for solution user (RegularUser|Administrator)")
 
 	cmd.AddCommand(provisionCmd)
 }
@@ -77,5 +86,14 @@ func AddProvision(cmd *cobra.Command) {
 func RunProvision(cmd *cobra.Command, args []string) {
 	// TODO (fanz): implement provision
 	fmt.Println("Perform cloud provider provisioning...")
-
+	o := cli.ClientOption{}
+	o.LoadCredential(vcUser, vcPassword, vcCert, vcRole)
+	ctx := context.Background()
+	client, err := o.NewClient(ctx, vchost)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	o.Client = client
+	cli.CreateSolutionUser(ctx, &o)
 }

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -18,20 +18,109 @@ package cli
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 )
 
 type ClientOption struct {
-	hostURL  string
-	insecure bool
+	insecure   bool
+	credential Credential
+	Client     *govmomi.Client
+	url        *url.URL
+	// config Config
+	Config Config
 }
 
-func (o *ClientOption) NewClient(ctx context.Context) (*govmomi.Client, error) {
-	u, err := soap.ParseURL(o.hostURL)
+func (o *ClientOption) NewClient(ctx context.Context, hostURL string) (*govmomi.Client, error) {
+	if o.Client != nil {
+		return o.Client, nil
+	}
+
+	u, err := soap.ParseURL(hostURL)
 	if err != nil {
 		return nil, err
 	}
-	return govmomi.NewClient(ctx, u, o.insecure)
+	o.processCredential(u)
+	o.url = u
+	client, err := govmomi.NewClient(ctx, o.url, o.insecure)
+	if err != nil {
+		return client, err
+	}
+	o.Client = client
+	return o.Client, nil
+}
+
+func (o *ClientOption) processCredential(u *url.URL) error {
+	// consider secret, and env for credentials
+
+	envUsername := o.getCredential().username
+	envPassword := o.getCredential().password
+	// Override username if provided
+	if envUsername != "" {
+		var password string
+		var ok bool
+
+		if u.User != nil {
+			password, ok = u.User.Password()
+		}
+
+		if ok {
+			u.User = url.UserPassword(envUsername, password)
+		} else {
+			u.User = url.User(envUsername)
+		}
+	}
+
+	// Override password if provided
+	if envPassword != "" {
+		var username string
+
+		if u.User != nil {
+			username = u.User.Username()
+		}
+
+		u.User = url.UserPassword(username, envPassword)
+	}
+	return nil
+}
+
+func (o *ClientOption) GetClient() (*vim25.Client, error) {
+	if o.Client.Client != nil {
+		return o.Client.Client, nil
+	}
+	return nil, nil
+}
+
+func (o *ClientOption) Userinfo() *url.Userinfo {
+	return o.url.User
+}
+
+func (o *ClientOption) getCredential() Credential {
+	return o.credential
+}
+
+type Credential struct {
+	username string
+	password string
+	cert     string
+	role     string
+	Secret   VCCMSecret
+}
+
+type VCCMSecret struct {
+	Name string
+	Data map[string]string
+}
+
+func (o *ClientOption) LoadCredential(username, password, cert, role string) {
+	c := Credential{}
+	c.username = username
+	c.password = password
+	c.cert = cert
+	c.role = role
+	// TODO: (fanz) Secret of Credential
+	o.credential = c
 }

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"os"
+
+	"github.com/vmware/govmomi/ssoadmin"
+	"github.com/vmware/govmomi/ssoadmin/types"
+	"github.com/vmware/govmomi/sts"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+type User struct {
+	id string
+	types.AdminPersonDetails
+	password string
+	solution types.AdminSolutionDetails
+	role     string
+	cert     string
+}
+
+// CreateUserFunc is function to create person user or solution user
+type CreateUserFunc func(c *ssoadmin.Client) error
+
+func (u *User) Run(ctx context.Context, c *ClientOption, fn CreateUserFunc) error {
+
+	vc, err := c.GetClient()
+	if err != nil {
+		return err
+	}
+
+	ssoClient, err := ssoadmin.NewClient(ctx, vc)
+	if err != nil {
+		return err
+	}
+
+	token := os.Getenv("SSO_LOGIN_TOKEN")
+	header := soap.Header{
+		Security: &sts.Signer{
+			Certificate: vc.Certificate(),
+			Token:       token,
+		},
+	}
+	if token == "" {
+		tokens, cerr := sts.NewClient(ctx, vc)
+		if cerr != nil {
+			return cerr
+		}
+		req := sts.TokenRequest{
+			Certificate: vc.Certificate(),
+			Userinfo:    c.Userinfo(),
+		}
+
+		header.Security, cerr = tokens.Issue(ctx, req)
+		if cerr != nil {
+			return cerr
+		}
+	}
+
+	if err = ssoClient.Login(ssoClient.WithHeader(ctx, header)); err != nil {
+		return err
+	}
+	defer ssoClient.Logout(ctx)
+
+	return fn(ssoClient)
+}

--- a/pkg/cli/util.go
+++ b/pkg/cli/util.go
@@ -17,16 +17,22 @@ limitations under the License.
 package cli
 
 import (
-	"io"
-
-	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere"
+	"fmt"
+	"io/ioutil"
+	"os"
 )
 
-// Config represents configuration of vcp
-type Config struct {
-}
-
-func readConfig(config io.Reader) (vsphere.Config, error) {
-	// TODO : implement
-	return vsphere.Config{}, nil
+func ReadContent(path string) (string, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("file [%s] does not exist", path)
+		}
+		return "", err
+	}
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
 }


### PR DESCRIPTION
- Add Client for delegating vim25 and ssoadmin
- Add Credential for client, session and sso
- Add CreateUserFunc for creating solution user and person user
- Implement creating default solution user and granting WSTrust
permission and Administrator role.



fixes #15 


**Special notes for your reviewer**:
Stage 2 for **vcpctl** implementation

**Release note**:
`NONE`
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write .
-->
```release-note
none
```
