### PR TITLE
remove --tty option when issue docker run

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -18,6 +18,6 @@
 # In other words you don't need a Go env on your system to run Make (build, test etc)
 # This script will just bind-mount the source directory into a container under the correct
 # GOPATH and handle all of the Go ENV stuff for you.  All you need is Docker
-docker run -it -v "$PWD":/go/src/k8s.io/cloud-provider-vsphere:z \
+docker run -i -v "$PWD":/go/src/k8s.io/cloud-provider-vsphere:z \
 	-w /go/src/k8s.io/cloud-provider-vsphere \
 	golang:1.10 make "$@"


### PR DESCRIPTION
the --tty option is incompatible with cron job setting.
will get en error saying: "the input device is not a TTY" if doing so.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
this is to unblock the CI job (as cron job now) to build CCM image and upload to registry

**Which issue this PR fixes**
no PR filed. but we got the issue to run 'hack/make.sh' at cron job.

**Special notes for your reviewer**:
None

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

/cc @dougm @frapposelli 
