### PR TITLE
Adds CCM user; fixes "watch secret" errors

### DIFF
--- a/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+++ b/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
@@ -36,5 +36,7 @@ items:
   - kind: ServiceAccount
     name: cloud-controller-manager
     namespace: kube-system
+  - kind: User
+    name: cloud-controller-manager
 kind: List
 metadata: {}

--- a/manifests/controller-manager/cloud-controller-manager-roles.yaml
+++ b/manifests/controller-manager/cloud-controller-manager-roles.yaml
@@ -70,6 +70,7 @@ items:
     verbs:
     - get
     - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch binds the user `cloud-controller-manager` to the role `system:cloud-controller-manager` in order to enable the use of a custom Kubernetes user and thus no longer needing to provide the CCM with the controller-manager's kubeconfig.

This patch also fixes the annoying "watch secret" failures that populate the logs. Adding the `watch` permission to the `secrets` resource for the `system:cloud-controller-manager` role and using the `cloud-controller-manager` user's `kubeconfig` will result in these errors being a thing of the past.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: NA

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```