### PR TITLE
Support for building and pushing the CCM via Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,64 @@
+# Use the newer Travis-CI build templates based on the
+# Debian Linux distribution "Trusty" release.
+os:             linux
+dist:           trusty
+
+# Set the version of Go.
+language:       go
+go:             1.11
+
+# Default to requiring Docker unless overriden by the job.
+sudo:           required
+services:       docker
+
+# Always set the project's Go import path to ensure that forked
+# builds get cloned to the correct location.
+go_import_path: k8s.io/cloud-provider-vsphere
+
+jobs:
+  include:
+
+    # The "build" stage builds the cloud provider for all pull requests.
+    - stage:          build
+      if: |
+        (
+          type = pull_request OR
+          (
+            commit_message =~ /\/ci-build/ AND
+            (fork = true OR sender =~ env(OWNERS))
+          )
+        ) AND NOT (
+          commit_message =~ /\/ci-nobuild/ AND
+          (fork = true OR sender =~ env(OWNERS))
+        )
+      sudo:           false
+      services:       false
+      install:
+        - make vendor
+      script:
+        - make build
+
+    # The "deploy" stage builds the cloud provider and then pushes the
+    # the cloud provider image to the GCR image registry. This stage is
+    # skipped when this configuration runs as a cron job.
+    - stage:          deploy
+      if: |
+        (
+          (branch = master AND type = push) OR
+          (
+            commit_message =~ /\/ci-deploy/ AND
+            (fork = true OR sender =~ env(OWNERS))
+          )
+        ) AND NOT (
+          commit_message =~ /\/ci-nodeploy/ AND
+          (fork = true OR sender =~ env(OWNERS))
+        )
+      install:
+        - make vendor
+      before_script:
+        - echo "${GCR_KEY_FILE}" | base64 -d | gzip -d >gcr-key-file.json
+      script:
+        - make build
+        - make images
+      after_success:
+        - GCR_KEY_FILE=gcr-key-file.json make upload-images


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR builds the CCM on Travis-CI and pushes the image to the GCR registry where the latest image may be pulled with `docker pull gcr.io/cloud-provider-vsphere/vsphere-cloud-controller-manager`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: NA @frapposelli?

**Special notes for your reviewer**:
Hi reviewers. This PR should be a single commit, but #57 and #58 are not yet merged. Also, I will be removing the `feature/travis-ci` branch under the Travis-CI config's `allowed_branches` list in a separate PR. Until this is merged, that lets my fork work off of my PR branch.

The following secure, environment variable must be added to the project's travisci.com settings: `GCR_KEY_FILE`. This is a gzip'd, base64 encoded version of the key file for service account `gcr-travis-ci-push`, which has permissions to upload images to the GCR registry.

The Travis-CI settings should also define and environment variable called `OWNERS` with a regex of the owners. For example, `'^(frapposelli|akutz)$'`. Please note the enclosing, single quotes are important or else Travis-CI fails exports the environment variable. Only GitHub users in this env var can use the `ci-` commands in a commit message to override the conditions on which the stages depend.

**Release note**:
```release-note
NONE
```