### PR TITLE
Disable k8s Secret Listener if Secret info is not provided.

### DIFF
--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -93,15 +93,19 @@ func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) 
 		stopCh := signals.SetupSignalHandler()
 
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-		secretInformer := informerFactory.Core().V1().Secrets()
-		vs.nodeManager.credentialManager = &SecretCredentialManager{
-			SecretName:      vs.cfg.Global.SecretName,
-			SecretNamespace: vs.cfg.Global.SecretNamespace,
-			SecretLister:    secretInformer.Lister(),
-			Cache: &SecretCache{
-				VirtualCenter: make(map[string]*Credential),
-			},
+
+		if vs.cfg.Global.SecretNamespace != "" && vs.cfg.Global.SecretName != "" {
+			secretInformer := informerFactory.Core().V1().Secrets()
+			vs.nodeManager.credentialManager = &SecretCredentialManager{
+				SecretName:      vs.cfg.Global.SecretName,
+				SecretNamespace: vs.cfg.Global.SecretNamespace,
+				SecretLister:    secretInformer.Lister(),
+				Cache: &SecretCache{
+					VirtualCenter: make(map[string]*Credential),
+				},
+			}
 		}
+
 		nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 		nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    vs.nodeAdded,


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the secret listener flooding the CCM logs if the secret listener is not configured correctly.

If not configured correctly, you will see the following message in the CCM log repeated over and over:
```
2018-09-20T12:09:16.424243246-05:00 stderr F E0920 17:09:16.424030       1 reflector.go:322] k8s.io/cloud-provider-vsphere/vendor/k8s.io/client-go/informers/factory.go:130: Failed to watch *v1.Secret: unknown (get secrets)
```

**Special notes for your reviewer**:
Tested on 1.11.2