### PR TITLE
Feature/k8s conformance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist:           trusty
 language:       go
 go:             1.11
 
-# Default to requiring Docker unless overriden by the job.
+# All jobs require Docker.
 sudo:           required
 services:       docker
 
@@ -62,3 +62,58 @@ jobs:
         - make images
       after_success:
         - GCR_KEY_FILE=gcr-key-file.json make upload-images
+
+    # The "conformance-test-stage" stage turns up K8s clusters, schedules
+    # the e2e conformance tests on the cluster, uploads the test results
+    # to a GCS bucket, and turns down the K8s clusters.
+    - &conformance-test-stage
+      stage: Kubernetes e2e conformance tests
+      env: CCM=true K8S_VERSION=ci/latest CLUSTER_NAME=ci-latest GCS_PATH=ci/latest EVENT_TYPE='^(push|cron)$' COMMIT_TRIGGER_YES='\/ci-ccm-conformance' COMMIT_TRIGGER_NO='\/ci-ccm-noconformance'
+      if: |
+        (
+          (env(CCM) = true AND branch = master AND type =~ env(EVENT_TYPE)) OR
+          (
+            commit_message =~ env(COMMIT_TRIGGER_YES) AND
+            (fork = true OR sender =~ env(OWNERS))
+          )
+        ) AND NOT (
+          commit_message =~ env(COMMIT_TRIGGER_NO) AND
+          (fork = true OR sender =~ env(OWNERS))
+        )
+
+      before_script:
+        - mkdir -p data/.terraform/plugins
+        - if [ -f e2e-job.yaml ]; then cp e2e-job.yaml data/; fi
+        - echo "${GCS_KEY_FILE}" | base64 -d | gzip -d >key-file.json
+        - echo "${VMC_INFO}" | base64 -d | gzip -d >vmc-info.env
+        - CLOUD_PROVIDER=vsphere; [ "${CCM}" = "true" ] && CLOUD_PROVIDER=external; export CLOUD_PROVIDER
+        - GCS_BUCKET=k8s-conformance-vsphere; [ "${CCM}" = "true" ] && GCS_BUCKET=k8s-conformance-cloud-provider-vsphere; export GCS_BUCKET
+        - export DOCKER_RUN="docker run -it --rm -v $(pwd)/data:/tf/data -v $(pwd)/key-file.json:/tf/data/key-file.json:ro -v $(pwd)/data/.terraform/plugins:/tf/.terraform/plugins --env-file vmc-info.env --env TF_VAR_wrk_count=3 --env TF_VAR_k8s_version="$K8S_VERSION" --env TF_VAR_cloud_provider="${CLOUD_PROVIDER}" "${E2E_IMAGE}" "${CLUSTER_NAME}-${TRAVIS_BUILD_NUMBER}""
+        - echo "DOCKER_RUN=${DOCKER_RUN}"
+      script:
+        - ${DOCKER_RUN} up
+        - ${DOCKER_RUN} version
+        - ${DOCKER_RUN} test
+        - ${DOCKER_RUN} tlog
+        - ${DOCKER_RUN} tget
+        - ${DOCKER_RUN} tput "gs://${GCS_BUCKET}/head/${GCS_PATH}" data/key-file.json
+      after_script:
+        - ${DOCKER_RUN} down
+
+    # Out-of-tree conformance tests (plus the initial definition above)
+    - <<: *conformance-test-stage
+      env: CCM=true K8S_VERSION=release/latest-1.12 CLUSTER_NAME=v1-12 GCS_PATH=release/v1.12 EVENT_TYPE='^(push|cron)$' COMMIT_TRIGGER_YES='\/ci-ccm-conformance' COMMIT_TRIGGER_NO='\/ci-ccm-noconformance'
+    - <<: *conformance-test-stage
+      env: CCM=true K8S_VERSION=release/latest-1.11 CLUSTER_NAME=v1-11 GCS_PATH=release/v1.11 EVENT_TYPE='^(push|cron)$' COMMIT_TRIGGER_YES='\/ci-ccm-conformance' COMMIT_TRIGGER_NO='\/ci-ccm-noconformance'
+    - <<: *conformance-test-stage
+      env: CCM=true K8S_VERSION=release/latest-1.10 CLUSTER_NAME=v1-10 GCS_PATH=release/v1.10 EVENT_TYPE='^(push|cron)$' COMMIT_TRIGGER_YES='\/ci-ccm-conformance' COMMIT_TRIGGER_NO='\/ci-ccm-noconformance'
+
+    # In-tree conformance tests
+    - <<: *conformance-test-stage
+      env: CCM=false K8S_VERSION=ci/latest CLUSTER_NAME=ci-latest GCS_PATH=ci/latest EVENT_TYPE='^cron$' COMMIT_TRIGGER_YES='\/ci-conformance' COMMIT_TRIGGER_NO='\/ci-noconformance'
+    - <<: *conformance-test-stage
+      env: CCM=false K8S_VERSION=release/latest-1.12 CLUSTER_NAME=v1-12 GCS_PATH=release/v1.12 EVENT_TYPE='^cron$' COMMIT_TRIGGER_YES='\/ci-conformance' COMMIT_TRIGGER_NO='\/ci-noconformance'
+    - <<: *conformance-test-stage
+      env: CCM=false K8S_VERSION=release/latest-1.11 CLUSTER_NAME=v1-11 GCS_PATH=release/v1.11 EVENT_TYPE='^cron$' COMMIT_TRIGGER_YES='\/ci-conformance' COMMIT_TRIGGER_NO='\/ci-noconformance'
+    - <<: *conformance-test-stage
+      env: CCM=false K8S_VERSION=release/latest-1.10 CLUSTER_NAME=v1-10 GCS_PATH=release/v1.10 EVENT_TYPE='^cron$' COMMIT_TRIGGER_YES='\/ci-conformance' COMMIT_TRIGGER_NO='\/ci-noconformance'

--- a/e2e-job.yaml
+++ b/e2e-job.yaml
@@ -1,0 +1,52 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: e2e
+  namespace: e2e
+  labels:
+    name: e2e
+spec:
+  template:
+    spec:
+      volumes:
+      - name: kubectl
+        hostPath:
+          path: /opt/bin/kubectl
+          type: File
+      - name: kubeconfig
+        secret:
+          secretName: kubeconfig
+      - name: e2e
+        hostPath:
+          path: /var/lib/kubernetes/e2e
+          type: Directory
+      - name: artifacts
+        emptyDir: {}
+      containers:
+      - name: run
+        image: gcr.io/kubernetes-conformance-testing/yake2e-job
+        args:
+        - run
+        volumeMounts:
+        - name: kubectl
+          mountPath: /usr/local/bin/kubectl
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubernetes
+          readOnly: true
+        - name: e2e
+          mountPath: /var/lib/kubernetes/e2e
+          readOnly: true
+        - name: artifacts
+          mountPath: /var/log/kubernetes/e2e
+          readOnly: false
+      - name: tgz
+        image: gcr.io/kubernetes-conformance-testing/yake2e-job
+        args:
+        - tgz
+        volumeMounts:
+        - name: artifacts
+          mountPath: /var/log/kubernetes/e2e
+          readOnly: false
+      restartPolicy: Never
+  backoffLimit: 4


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables Kubernetes e2e conformance tests for the CCM on all merges to master and provides the ability to enable e2e via a daily cron job (must be configured) in Travis-CI. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #38

**Special notes for your reviewer**:
The following environment variable must be added to the project's travisci.com settings: 

| Name | Secure | Description |
|-------|--------|-------------|
| `E2E_IMAGE` | | The image used to run the e2e workflow.Please set to `gcr.io/kubernetes-conformance-testing/yake2e` |
| `GCS_KEY_FILE` | ✓ | A Google Cloud JSON key file that has permissions to upload the test results to the GCS buckets `k8s-conformance-vsphere` and `k8s-conformance-cloud-provider-vsphere` |
| `GCS_EMAIL` | ✓ | The e-mail address associated with the user in the `GCS_KEY_FILE` |
| `OWNERS` | ✓ | A single-quoted regular expression that lists the GitHub user names of the people that may use commit message keywords to trigger manual e2e runs. For example, `'^(frapposelli|akutz)$'` |
| `VMC_INFO` | ✓ | A file that contains the credential information used to access VMC and AWS. Please see yake2e's [Quick Start](https://github.com/akutz/yake2e#quick-start) section for an example of the file. The file should be processed with `gzip -9c <FILE | base64` in order to set the environment variable with the file's contents. | 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```