### PR TITLE
General housekeeping/cleanup

### DIFF
--- a/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
@@ -39,7 +39,7 @@ spec:
           image: docker.io/vmware/vsphere-cloud-controller-manager:latest
           args:
             - /bin/vsphere-cloud-controller-manager
-            - --v=4
+            - --v=2
             - --cloud-provider=vsphere
             - --cloud-config=/etc/cloud/vsphere.conf
             - --kubeconfig=/etc/kubernetes/controller-manager.conf
@@ -94,8 +94,8 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - port: 50051
+    - port: 43001
       protocol: TCP
-      targetPort: 50051
+      targetPort: 43001
   selector:
     component: cloud-controller-manager

--- a/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
@@ -80,8 +80,8 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - port: 50051
+    - port: 43001
       protocol: TCP
-      targetPort: 50051
+      targetPort: 43001
   selector:
     component: cloud-controller-manager

--- a/pkg/cloudprovider/vsphere/credentialmanager.go
+++ b/pkg/cloudprovider/vsphere/credentialmanager.go
@@ -75,7 +75,7 @@ func (secretCredentialManager *SecretCredentialManager) updateCredentialsMap() e
 	cacheSecret := secretCredentialManager.Cache.GetSecret()
 	if cacheSecret != nil &&
 		cacheSecret.GetResourceVersion() == secret.GetResourceVersion() {
-		glog.V(4).Infof("VCP SecretCredentialManager: Secret %q will not be updated in cache. Since, secrets have same resource version %q", secretCredentialManager.SecretName, cacheSecret.GetResourceVersion())
+		glog.V(2).Infof("VCP SecretCredentialManager: Secret %q will not be updated in cache. Since, secrets have same resource version %q", secretCredentialManager.SecretName, cacheSecret.GetResourceVersion())
 		return nil
 	}
 	secretCredentialManager.Cache.UpdateSecret(secret)

--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -56,12 +56,12 @@ func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) 
 
 	// Check if node has been discovered already
 	if node, ok := i.nodeManager.nodeNameMap[string(nodeName)]; ok {
-		glog.V(4).Info("instances.NodeAddresses() CACHED with ", string(nodeName))
+		glog.V(2).Info("instances.NodeAddresses() CACHED with ", string(nodeName))
 		return node.NodeAddresses, nil
 	}
 
 	if err := i.nodeManager.DiscoverNode(string(nodeName), FindVMByName); err != nil {
-		glog.V(4).Info("instances.NodeAddresses() FOUND with ", string(nodeName))
+		glog.V(2).Info("instances.NodeAddresses() FOUND with ", string(nodeName))
 		return i.nodeManager.nodeNameMap[string(nodeName)].NodeAddresses, nil
 	}
 
@@ -78,12 +78,12 @@ func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 	// Check if node has been discovered already
 	uid := i.getUUIDFromProviderID(providerID)
 	if node, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
-		glog.V(4).Info("instances.NodeAddressesByProviderID() CACHED with ", uid)
+		glog.V(2).Info("instances.NodeAddressesByProviderID() CACHED with ", uid)
 		return node.NodeAddresses, nil
 	}
 
 	if err := i.nodeManager.DiscoverNode(uid, FindVMByUUID); err == nil {
-		glog.V(4).Info("instances.NodeAddressesByProviderID() FOUND with ", uid)
+		glog.V(2).Info("instances.NodeAddressesByProviderID() FOUND with ", uid)
 		return i.nodeManager.nodeUUIDMap[uid].NodeAddresses, nil
 	}
 
@@ -108,12 +108,12 @@ func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (st
 
 	// Check if node has been discovered already
 	if node, ok := i.nodeManager.nodeNameMap[string(nodeName)]; ok {
-		glog.V(4).Info("instances.InstanceID() CACHED with ", string(nodeName))
+		glog.V(2).Info("instances.InstanceID() CACHED with ", string(nodeName))
 		return node.UUID, nil
 	}
 
 	if err := i.nodeManager.DiscoverNode(string(nodeName), FindVMByName); err == nil {
-		glog.V(4).Info("instances.InstanceID() FOUND with ", string(nodeName))
+		glog.V(2).Info("instances.InstanceID() FOUND with ", string(nodeName))
 		return i.nodeManager.nodeNameMap[string(nodeName)].UUID, nil
 	}
 
@@ -153,12 +153,12 @@ func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID s
 	// Check if node has been discovered already
 	uid := i.getUUIDFromProviderID(providerID)
 	if _, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
-		glog.V(4).Info("instances.InstanceExistsByProviderID() CACHED with ", uid)
+		glog.V(2).Info("instances.InstanceExistsByProviderID() CACHED with ", uid)
 		return true, nil
 	}
 
 	if err := i.nodeManager.DiscoverNode(uid, FindVMByUUID); err == nil {
-		glog.V(4).Info("instances.InstanceExistsByProviderID() EXISTS with ", uid)
+		glog.V(2).Info("instances.InstanceExistsByProviderID() EXISTS with ", uid)
 		return true, err
 	}
 

--- a/pkg/cloudprovider/vsphere/server/server_test.go
+++ b/pkg/cloudprovider/vsphere/server/server_test.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	exampleUUIDForGoTest = "422e4956-ad22-1139-6d72-59cc8f26bc90"
+	DefaultAPIBinding    = ":43001"
 )
 
 type fakeNodeMgr struct{}
@@ -53,6 +54,7 @@ func TestGRPCServerClient(t *testing.T) {
 	//server
 	s := grpc.NewServer()
 	myServer := &server{
+		binding: DefaultAPIBinding,
 		s:       s,
 		nodeMgr: &fakeNodeMgr{},
 	}
@@ -62,7 +64,7 @@ func TestGRPCServerClient(t *testing.T) {
 	myServer.Start()
 
 	//client
-	conn, err := grpc.Dial(port, grpc.WithInsecure())
+	conn, err := grpc.Dial(DefaultAPIBinding, grpc.WithInsecure())
 	if err != nil {
 		t.Fatalf("did not connect: %v", err)
 	}

--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -71,7 +71,10 @@ type Config struct {
 		ServiceAccount string `gcfg:"service-account"`
 		// Disable the vSphere CCM API
 		// Default: true
-		DisableAPI bool `gcfg:"disable-api"`
+		APIDisable bool `gcfg:"api-disable"`
+		// Configurable vSphere CCM API port
+		// Default: 43001
+		APIBinding string `gcfg:"api-binding"`
 	}
 	VirtualCenter map[string]*VirtualCenterConfig
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains the following changes:
- Changed the default port number on the API server to 43001. This was done in order to avoid application protocol collision. Old port was used in the example.
- Provided a mechanism to change the default binding for the API server. This is required for Helm Chart development
- Changed ENV variables for API disabling and binding to standardize the names. Now they are VSPHERE_API_DISABLE and VSPHERE_API_BINDING respectively.
- Fixed logging to standardize on glog. There were some places where fmt.XXXX and log.XXXX were used
- Fixed the glog.V(X) logging level to appropriate levels
- Fixed various variable names to standardize on naming in the Config object.

**Special notes for your reviewer**:
Tested on 1.11.2