### PR TITLE
Fix for non-unique cluster names / disable PR builds in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,13 @@ go_import_path: k8s.io/cloud-provider-vsphere
 jobs:
   include:
 
-    # The "build" stage builds the cloud provider for all pull requests.
+    # The "build" stage builds the cloud provider when requested with a commit
+    # message trigger.
     - stage:          build
       if: |
         (
-          type = pull_request OR
-          (
-            commit_message =~ /\/ci-build/ AND
-            (fork = true OR sender =~ env(OWNERS))
-          )
+          commit_message =~ /\/ci-build/ AND
+          (fork = true OR sender =~ env(OWNERS))
         ) AND NOT (
           commit_message =~ /\/ci-nobuild/ AND
           (fork = true OR sender =~ env(OWNERS))

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ jobs:
         )
       sudo:           false
       services:       false
+      before_install:
+        - REPO_SLUG_SHA=$(echo $(TRAVIS_REPO_SLUG) | sha1sum | cut -c1-7); export REPO_SLUG_SHA; echo "REPO_SLUG_SHA=${REPO_SLUG_SHA}"
       install:
         - make vendor
       script:
@@ -86,9 +88,11 @@ jobs:
         - if [ -f e2e-job.yaml ]; then cp e2e-job.yaml data/; fi
         - echo "${GCS_KEY_FILE}" | base64 -d | gzip -d >key-file.json
         - echo "${VMC_INFO}" | base64 -d | gzip -d >vmc-info.env
-        - CLOUD_PROVIDER=vsphere; [ "${CCM}" = "true" ] && CLOUD_PROVIDER=external; export CLOUD_PROVIDER
-        - GCS_BUCKET=k8s-conformance-vsphere; [ "${CCM}" = "true" ] && GCS_BUCKET=k8s-conformance-cloud-provider-vsphere; export GCS_BUCKET
-        - export DOCKER_RUN="docker run -it --rm -v $(pwd)/data:/tf/data -v $(pwd)/key-file.json:/tf/data/key-file.json:ro -v $(pwd)/data/.terraform/plugins:/tf/.terraform/plugins --env-file vmc-info.env --env TF_VAR_wrk_count=3 --env TF_VAR_k8s_version="$K8S_VERSION" --env TF_VAR_cloud_provider="${CLOUD_PROVIDER}" "${E2E_IMAGE}" "${CLUSTER_NAME}-${TRAVIS_BUILD_NUMBER}""
+        - CLOUD_PROVIDER=vsphere; [ "${CCM}" = "true" ] && CLOUD_PROVIDER=external; export CLOUD_PROVIDER; echo "CLOUD_PROVIDER=${CLOUD_PROVIDER}"
+        - GCS_BUCKET=k8s-conformance-vsphere; [ "${CCM}" = "true" ] && GCS_BUCKET=k8s-conformance-cloud-provider-vsphere; export GCS_BUCKET; echo "GCS_BUCKET=${GCS_BUCKET}"
+        - REPO_SLUG_SHA=$(echo $(TRAVIS_REPO_SLUG) | sha1sum | cut -c1-7); export REPO_SLUG_SHA; echo "REPO_SLUG_SHA=${REPO_SLUG_SHA}"
+        - REAL_CLUSTER_NAME="${CLUSTER_NAME}-${REPO_SLUG_SHA}-${TRAVIS_BUILD_NUMBER}"; export REAL_CLUSTER_NAME; echo "REAL_CLUSTER_NAME=${REAL_CLUSTER_NAME}"
+        - export DOCKER_RUN="docker run -it --rm -v $(pwd)/data:/tf/data -v $(pwd)/key-file.json:/tf/data/key-file.json:ro -v $(pwd)/data/.terraform/plugins:/tf/.terraform/plugins --env-file vmc-info.env --env TF_VAR_wrk_count=3 --env TF_VAR_k8s_version="$K8S_VERSION" --env TF_VAR_cloud_provider="${CLOUD_PROVIDER}" "${E2E_IMAGE}" "${REAL_CLUSTER_NAME}""
         - echo "DOCKER_RUN=${DOCKER_RUN}"
       script:
         - ${DOCKER_RUN} up


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This patch adds a sha1sum'd repo slug to the end of the name of the cluster deployed by the CI process. This patch also disables PR builds in Travis-CI due to the limited jobs available and being used by the conformance tests. Otherwise PR builds will sit in the queue forever.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: NA

**Special notes for your reviewer**:

**Release note**:
```release-note
```
