### PR TITLE
Fix CCM container location in manifest

### DIFF
--- a/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: vsphere-cloud-controller-manager
-          image: docker.io/vmware/vsphere-cloud-controller-manager:latest
+          image: gcr.io/cloud-provider-vsphere/vsphere-cloud-controller-manager:latest
           args:
             - /bin/vsphere-cloud-controller-manager
             - --v=2

--- a/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   containers:
     - name: vsphere-cloud-controller-manager
-      image: docker.io/vmware/vsphere-cloud-controller-manager:latest
+      image: gcr.io/cloud-provider-vsphere/vsphere-cloud-controller-manager:latest
       args:
         - /bin/vsphere-cloud-controller-manager
         - --v=2


### PR DESCRIPTION
This PR fixes the location for the CCM location in the provider manifests, the new location is pushed automatically through CI.

/kind feature
/cc @akutz