### PR TITLE
format log explicitly with Errorf() and Infof()

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -216,7 +216,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy FindVM) error {
 				}
 
 				if err != nil {
-					glog.Error("Error while looking for vm=%+v in vc=%s and datacenter=%s: %v",
+					glog.Errorf("Error while looking for vm=%+v in vc=%s and datacenter=%s: %v",
 						vm, res.vc, res.datacenter.Name(), err)
 					if err != vclib.ErrNoVMFound {
 						setGlobalErr(err)
@@ -230,7 +230,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy FindVM) error {
 				var oVM mo.VirtualMachine
 				err = vm.Properties(ctx, vm.Reference(), []string{"config", "summary", "summary.config", "guest.net", "guest"}, &oVM)
 				if err != nil {
-					glog.Error("Error collecting properties for vm=%+v in vc=%s and datacenter=%s: %v",
+					glog.Errorf("Error collecting properties for vm=%+v in vc=%s and datacenter=%s: %v",
 						vm, res.vc, res.datacenter.Name(), err)
 					continue
 				}

--- a/pkg/vclib/diskmanagers/vmdm.go
+++ b/pkg/vclib/diskmanagers/vmdm.go
@@ -102,7 +102,7 @@ func (vmdisk vmDiskManager) Create(ctx context.Context, datastore *vclib.Datasto
 	dummyVM, err = datastore.Datacenter.GetVMByPath(ctx, vmdisk.vmOptions.VMFolder.InventoryPath+"/"+dummyVMFullName)
 	if err != nil {
 		// Create a dummy VM
-		glog.V(1).Info("Creating Dummy VM: %q", dummyVMFullName)
+		glog.V(1).Infof("Creating Dummy VM: %q", dummyVMFullName)
 		dummyVM, err = vmdisk.createDummyVM(ctx, datastore.Datacenter, dummyVMFullName)
 		if err != nil {
 			glog.Errorf("Failed to create Dummy VM. err: %v", err)
@@ -132,7 +132,7 @@ func (vmdisk vmDiskManager) Create(ctx context.Context, datastore *vclib.Datasto
 		fileAlreadyExist = isAlreadyExists(vmdisk.diskPath, err)
 		if fileAlreadyExist {
 			//Skip error and continue to detach the disk as the disk was already created on the datastore.
-			glog.V(vclib.LogLevel).Info("File: %v already exists", vmdisk.diskPath)
+			glog.V(vclib.LogLevel).Infof("File: %v already exists", vmdisk.diskPath)
 		} else {
 			glog.Errorf("Failed to attach the disk to VM: %q with err: %+v", dummyVMFullName, err)
 			return "", err
@@ -143,7 +143,7 @@ func (vmdisk vmDiskManager) Create(ctx context.Context, datastore *vclib.Datasto
 	if err != nil {
 		if vclib.DiskNotFoundErrMsg == err.Error() && fileAlreadyExist {
 			// Skip error if disk was already detached from the dummy VM but still present on the datastore.
-			glog.V(vclib.LogLevel).Info("File: %v is already detached", vmdisk.diskPath)
+			glog.V(vclib.LogLevel).Infof("File: %v is already detached", vmdisk.diskPath)
 		} else {
 			glog.Errorf("Failed to detach the disk: %q from VM: %q with err: %+v", vmdisk.diskPath, dummyVMFullName, err)
 			return "", err


### PR DESCRIPTION
when run `make test` with go1.11.1, will get error like:
`pkg/vclib/diskmanagers/vmdm.go:105: Verbose.Info call has possible
formatting directive %q`, those issues been ignored if using
go version 1.10.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:


**Which issue this PR fixes** 
this will unlock the consistently failing CI test for all pull request
like #70 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

/cc @frapposelli  @dougm @fanzhangio 