### PR TITLE
Add empty CSI plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,5 @@ zz_generated.openapi.go
 *.pyc
 
 # binaries
-vsphere-cloud-controller-manager
+/vsphere-cloud-controller-manager
+/vsphere-csi

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,14 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  digest = "1:5090455975191d02ed0875979b7dc14a76f73005f71404cca242eeb5b83361e9"
+  name = "github.com/akutz/gosync"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "94b0033d0b5fc254594c3174329c19356c2c4f63"
+  version = "v0.1.0"
+
+[[projects]]
   branch = "master"
   digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
   name = "github.com/beorn7/perks"
@@ -42,12 +50,21 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
-  digest = "1:ed319ae4ca2e3d1884e22d307b4d02f4020316ebf95e565eaa4ead5983f48fda"
+  digest = "1:a54dc69ec3668e0e57ad159a0a8c0ce1ec571174bb4eb6b3915833a8c21d40f3"
+  name = "github.com/container-storage-interface/spec"
+  packages = ["lib/go/csi/v0"]
+  pruneopts = "UT"
+  revision = "2178fdeea87f1150a17a63252eee28d4d8141f72"
+  version = "v0.3.0"
+
+[[projects]]
+  digest = "1:219324e0a689fe0a31bd25c295b643b6f3a0867313002f7c3b33305739c4cb5a"
   name = "github.com/coreos/etcd"
   packages = [
     "auth/authpb",
     "client",
     "clientv3",
+    "clientv3/concurrency",
     "etcdserver/api/v3rpc/rpctypes",
     "etcdserver/etcdserverpb",
     "mvcc/mvccpb",
@@ -202,7 +219,7 @@
   revision = "24b0969c4cb722950103eed87108c8d291a8df00"
 
 [[projects]]
-  digest = "1:5d1b5a25486fc7d4e133646d834f6fca7ba1cef9903d40e7aa786c41b89e9e91"
+  digest = "1:588beb9f80d2b0afddf05663b32d01c867da419458b560471d81cca0286e76b8"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -211,6 +228,7 @@
     "ptypes/any",
     "ptypes/duration",
     "ptypes/timestamp",
+    "ptypes/wrappers",
   ]
   pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
@@ -297,6 +315,14 @@
   pruneopts = "UT"
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "1.1.5"
+
+[[projects]]
+  digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
+  version = "v1.0.1"
 
 [[projects]]
   branch = "master"
@@ -406,6 +432,32 @@
   ]
   pruneopts = "UT"
   revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
+
+[[projects]]
+  branch = "master"
+  digest = "1:bfacccb149d451c243e47c66b1ee1cb56ff724bfce5b4eb196b5c07f69e660f4"
+  name = "github.com/rexray/gocsi"
+  packages = [
+    ".",
+    "context",
+    "middleware/logging",
+    "middleware/requestid",
+    "middleware/serialvolume",
+    "middleware/serialvolume/etcd",
+    "middleware/serialvolume/types",
+    "middleware/specvalidator",
+    "utils",
+  ]
+  pruneopts = "UT"
+  revision = "47f4bd656ddea05ff2d9c85cc55c6b9eafcf960e"
+
+[[projects]]
+  digest = "1:3f53e9e4dfbb664cd62940c9c4b65a2171c66acd0b7621a1a6b8e78513525a52"
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ad15b42461921f1fb3529b058c6786c6a45d5162"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
@@ -1112,9 +1164,12 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/container-storage-interface/spec/lib/go/csi/v0",
     "github.com/golang/glog",
     "github.com/golang/protobuf/proto",
     "github.com/prometheus/client_golang/prometheus",
+    "github.com/rexray/gocsi",
+    "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
     "github.com/vmware/govmomi",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,17 +5,13 @@
 
 ignored = ["k8s.io/cloud-provider-vsphere"]
 
-[[override]]
-  name = "github.com/container-storage-interface/spec"
-  version = "0.2.0"
+[[constraint]]
+  name = "github.com/rexray/gocsi"
+  branch = "master"
 
 [[override]]
   branch = "master"
   name = "github.com/golang/glog"
-
-[[override]]
-  branch = "master"
-  name = "github.com/kubernetes-csi/drivers"
 
 [[override]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
                  git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 GOFLAGS   :=
 TAGS      :=
-LDFLAGS   := "-w -s -X 'main.version=${VERSION}'"
+LDFLAGSCCM := "-w -s -X 'main.version=${VERSION}'"
+LDFLAGSCSI := "-w -s -X 'k8s.io/cloud-provider-vsphere/pkg/csi/service.version=${VERSION}'"
 REGISTRY ?= gcr.io/cloud-provider-vsphere
 PUSH_LATEST ?= TRUE
 
@@ -65,13 +66,19 @@ ifndef HAS_DEP
 endif
 	dep ensure -v$(DEP_FLAGS) && touch vendor
 
-build: vsphere-cloud-controller-manager
+build: vsphere-cloud-controller-manager vsphere-csi
 
 vsphere-cloud-controller-manager: vendor $(SOURCES)
 	CGO_ENABLED=0 GOOS=$(GOOS) go build \
-		-ldflags $(LDFLAGS) \
+		-ldflags $(LDFLAGSCCM) \
 		-o vsphere-cloud-controller-manager \
 		cmd/vsphere-cloud-controller-manager/main.go
+
+vsphere-csi: vendor $(SOURCES)
+	CGO_ENABLED=0 GOOS=$(GOOS) go build \
+		-ldflags $(LDFLAGSCSI) \
+		-o vsphere-csi \
+		cmd/vsphere-csi/main.go
 
 test: unit
 
@@ -136,7 +143,7 @@ install-distro-packages:
 	tools/install-distro-packages.sh
 
 clean:
-	rm -rf _dist .bindep vsphere-cloud-controller-manager
+	rm -rf _dist .bindep vsphere-cloud-controller-manager vsphere-csi
 
 realclean: clean
 	rm -rf vendor

--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+
+	"github.com/rexray/gocsi"
+
+	"k8s.io/cloud-provider-vsphere/pkg/csi/provider"
+	"k8s.io/cloud-provider-vsphere/pkg/csi/service"
+)
+
+// main is ignored when this package is built as a go plug-in.
+func main() {
+	gocsi.Run(
+		context.Background(),
+		service.Name,
+		"A description of the SP",
+		"",
+		provider.New())
+}

--- a/pkg/csi/provider/provider.go
+++ b/pkg/csi/provider/provider.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"net"
+
+	"github.com/rexray/gocsi"
+	log "github.com/sirupsen/logrus"
+
+	"k8s.io/cloud-provider-vsphere/pkg/csi/service"
+)
+
+// New returns a new CSI Storage Plug-in Provider.
+func New() gocsi.StoragePluginProvider {
+	svc := service.New()
+	return &gocsi.StoragePlugin{
+		Controller: svc,
+		Identity:   svc,
+		Node:       svc,
+
+		// BeforeServe allows the SP to participate in the startup
+		// sequence. This function is invoked directly before the
+		// gRPC server is created, giving the callback the ability to
+		// modify the SP's interceptors, server options, or prevent the
+		// server from starting by returning a non-nil error.
+		BeforeServe: func(
+			ctx context.Context,
+			sp *gocsi.StoragePlugin,
+			lis net.Listener) error {
+
+			log.WithField("service", service.Name).Debug("BeforeServe")
+			return nil
+		},
+
+		EnvVars: []string{
+			// Enable request validation.
+			gocsi.EnvVarSpecReqValidation + "=true",
+
+			// Enable serial volume access.
+			gocsi.EnvVarSerialVolAccess + "=true",
+		},
+	}
+}

--- a/pkg/csi/service/controller.go
+++ b/pkg/csi/service/controller.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"golang.org/x/net/context"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+)
+
+func (s *service) CreateVolume(
+	ctx context.Context,
+	req *csi.CreateVolumeRequest) (
+	*csi.CreateVolumeResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) DeleteVolume(
+	ctx context.Context,
+	req *csi.DeleteVolumeRequest) (
+	*csi.DeleteVolumeResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) ControllerPublishVolume(
+	ctx context.Context,
+	req *csi.ControllerPublishVolumeRequest) (
+	*csi.ControllerPublishVolumeResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) ControllerUnpublishVolume(
+	ctx context.Context,
+	req *csi.ControllerUnpublishVolumeRequest) (
+	*csi.ControllerUnpublishVolumeResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) ValidateVolumeCapabilities(
+	ctx context.Context,
+	req *csi.ValidateVolumeCapabilitiesRequest) (
+	*csi.ValidateVolumeCapabilitiesResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) ListVolumes(
+	ctx context.Context,
+	req *csi.ListVolumesRequest) (
+	*csi.ListVolumesResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) GetCapacity(
+	ctx context.Context,
+	req *csi.GetCapacityRequest) (
+	*csi.GetCapacityResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) ControllerGetCapabilities(
+	ctx context.Context,
+	req *csi.ControllerGetCapabilitiesRequest) (
+	*csi.ControllerGetCapabilitiesResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) CreateSnapshot(
+	ctx context.Context,
+	req *csi.CreateSnapshotRequest) (
+	*csi.CreateSnapshotResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) DeleteSnapshot(
+	ctx context.Context,
+	req *csi.DeleteSnapshotRequest) (
+	*csi.DeleteSnapshotResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) ListSnapshots(
+	ctx context.Context,
+	req *csi.ListSnapshotsRequest) (
+	*csi.ListSnapshotsResponse, error) {
+
+	return nil, nil
+}

--- a/pkg/csi/service/identity.go
+++ b/pkg/csi/service/identity.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"golang.org/x/net/context"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+)
+
+// set via ldflags
+var version string
+
+func (s *service) Probe(
+	ctx context.Context,
+	req *csi.ProbeRequest) (
+	*csi.ProbeResponse, error) {
+
+	return &csi.ProbeResponse{}, nil
+}
+
+func (s *service) GetPluginInfo(
+	ctx context.Context,
+	req *csi.GetPluginInfoRequest) (
+	*csi.GetPluginInfoResponse, error) {
+
+	return &csi.GetPluginInfoResponse{
+		Name:          Name,
+		VendorVersion: version,
+	}, nil
+}
+
+func (s *service) GetPluginCapabilities(
+	ctx context.Context,
+	req *csi.GetPluginCapabilitiesRequest) (
+	*csi.GetPluginCapabilitiesResponse, error) {
+
+	rep := &csi.GetPluginCapabilitiesResponse{
+		Capabilities: []*csi.PluginCapability{
+			&csi.PluginCapability{
+				Type: &csi.PluginCapability_Service_{
+					Service: &csi.PluginCapability_Service{
+						Type: csi.PluginCapability_Service_CONTROLLER_SERVICE,
+					},
+				},
+			},
+		},
+	}
+	return rep, nil
+}

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"golang.org/x/net/context"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+)
+
+func (s *service) NodeStageVolume(
+	ctx context.Context,
+	req *csi.NodeStageVolumeRequest) (
+	*csi.NodeStageVolumeResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) NodeUnstageVolume(
+	ctx context.Context,
+	req *csi.NodeUnstageVolumeRequest) (
+	*csi.NodeUnstageVolumeResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) NodePublishVolume(
+	ctx context.Context,
+	req *csi.NodePublishVolumeRequest) (
+	*csi.NodePublishVolumeResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) NodeUnpublishVolume(
+	ctx context.Context,
+	req *csi.NodeUnpublishVolumeRequest) (
+	*csi.NodeUnpublishVolumeResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) NodeGetId(
+	ctx context.Context,
+	req *csi.NodeGetIdRequest) (
+	*csi.NodeGetIdResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) NodeGetInfo(
+	ctx context.Context,
+	req *csi.NodeGetInfoRequest) (
+	*csi.NodeGetInfoResponse, error) {
+
+	return nil, nil
+}
+
+func (s *service) NodeGetCapabilities(
+	ctx context.Context,
+	req *csi.NodeGetCapabilitiesRequest) (
+	*csi.NodeGetCapabilitiesResponse, error) {
+
+	return nil, nil
+}

--- a/pkg/csi/service/service.go
+++ b/pkg/csi/service/service.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
+)
+
+const (
+	// Name is the name of this CSI SP.
+	Name = "io.k8s.cloud-provider-vsphere.vsphere"
+)
+
+// Service is a CSI SP and idempotency.Provider.
+type Service interface {
+	csi.ControllerServer
+	csi.IdentityServer
+	csi.NodeServer
+}
+
+type service struct{}
+
+// New returns a new Service.
+func New() Service {
+	return &service{}
+}


### PR DESCRIPTION
This commit adds the structure for implementing the CSI plugin using
the structure promoted by GoCSI. A 'make vsphere-csi' now produces a
vsphere-csi binary at the top level, just like the CCM.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Starts the CSI implementation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #73 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
