### PR TITLE
csi: add ability to support multiple backend APIs

### DIFF
--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -30,7 +30,13 @@ func main() {
 	gocsi.Run(
 		context.Background(),
 		service.Name,
-		"A description of the SP",
-		"",
+		"A CSI plugin for VMware vSphere storage",
+		usage,
 		provider.New())
 }
+
+const usage = `    X_CSI_VSPHERE_APINAME
+        Specifies the name of the API to use when talking to vCenter
+
+				The default value is "FCD" (First Class Disk)
+`

--- a/pkg/csi/service/envvars.go
+++ b/pkg/csi/service/envvars.go
@@ -14,31 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provider
+package service
 
-import (
-	"github.com/rexray/gocsi"
-
-	"k8s.io/cloud-provider-vsphere/pkg/csi/service"
+const (
+	// EnvAPI is the name of the API to use with vSphere
+	EnvAPI = "X_CSI_VSPHERE_APINAME"
 )
-
-// New returns a new CSI Storage Plug-in Provider.
-func New() gocsi.StoragePluginProvider {
-	svc := service.New()
-	ctrl := svc.GetController()
-
-	return &gocsi.StoragePlugin{
-		Controller:  ctrl,
-		Identity:    svc,
-		Node:        svc,
-		BeforeServe: svc.BeforeServe,
-
-		EnvVars: []string{
-			// Enable request validation.
-			gocsi.EnvVarSpecReqValidation + "=true",
-
-			// Enable serial volume access.
-			gocsi.EnvVarSerialVolAccess + "=true",
-		},
-	}
-}

--- a/pkg/csi/service/fcd/controller.go
+++ b/pkg/csi/service/fcd/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package service
+package fcd
 
 import (
 	"golang.org/x/net/context"
@@ -22,7 +22,17 @@ import (
 	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
 )
 
-func (s *service) CreateVolume(
+type Controller interface {
+	csi.ControllerServer
+}
+
+type controller struct{}
+
+func New() Controller {
+	return &controller{}
+}
+
+func (c *controller) CreateVolume(
 	ctx context.Context,
 	req *csi.CreateVolumeRequest) (
 	*csi.CreateVolumeResponse, error) {
@@ -30,7 +40,7 @@ func (s *service) CreateVolume(
 	return nil, nil
 }
 
-func (s *service) DeleteVolume(
+func (c *controller) DeleteVolume(
 	ctx context.Context,
 	req *csi.DeleteVolumeRequest) (
 	*csi.DeleteVolumeResponse, error) {
@@ -38,7 +48,7 @@ func (s *service) DeleteVolume(
 	return nil, nil
 }
 
-func (s *service) ControllerPublishVolume(
+func (c *controller) ControllerPublishVolume(
 	ctx context.Context,
 	req *csi.ControllerPublishVolumeRequest) (
 	*csi.ControllerPublishVolumeResponse, error) {
@@ -46,7 +56,7 @@ func (s *service) ControllerPublishVolume(
 	return nil, nil
 }
 
-func (s *service) ControllerUnpublishVolume(
+func (c *controller) ControllerUnpublishVolume(
 	ctx context.Context,
 	req *csi.ControllerUnpublishVolumeRequest) (
 	*csi.ControllerUnpublishVolumeResponse, error) {
@@ -54,7 +64,7 @@ func (s *service) ControllerUnpublishVolume(
 	return nil, nil
 }
 
-func (s *service) ValidateVolumeCapabilities(
+func (c *controller) ValidateVolumeCapabilities(
 	ctx context.Context,
 	req *csi.ValidateVolumeCapabilitiesRequest) (
 	*csi.ValidateVolumeCapabilitiesResponse, error) {
@@ -62,7 +72,7 @@ func (s *service) ValidateVolumeCapabilities(
 	return nil, nil
 }
 
-func (s *service) ListVolumes(
+func (c *controller) ListVolumes(
 	ctx context.Context,
 	req *csi.ListVolumesRequest) (
 	*csi.ListVolumesResponse, error) {
@@ -70,7 +80,7 @@ func (s *service) ListVolumes(
 	return nil, nil
 }
 
-func (s *service) GetCapacity(
+func (c *controller) GetCapacity(
 	ctx context.Context,
 	req *csi.GetCapacityRequest) (
 	*csi.GetCapacityResponse, error) {
@@ -78,7 +88,7 @@ func (s *service) GetCapacity(
 	return nil, nil
 }
 
-func (s *service) ControllerGetCapabilities(
+func (c *controller) ControllerGetCapabilities(
 	ctx context.Context,
 	req *csi.ControllerGetCapabilitiesRequest) (
 	*csi.ControllerGetCapabilitiesResponse, error) {
@@ -86,7 +96,7 @@ func (s *service) ControllerGetCapabilities(
 	return nil, nil
 }
 
-func (s *service) CreateSnapshot(
+func (c *controller) CreateSnapshot(
 	ctx context.Context,
 	req *csi.CreateSnapshotRequest) (
 	*csi.CreateSnapshotResponse, error) {
@@ -94,7 +104,7 @@ func (s *service) CreateSnapshot(
 	return nil, nil
 }
 
-func (s *service) DeleteSnapshot(
+func (c *controller) DeleteSnapshot(
 	ctx context.Context,
 	req *csi.DeleteSnapshotRequest) (
 	*csi.DeleteSnapshotResponse, error) {
@@ -102,7 +112,7 @@ func (s *service) DeleteSnapshot(
 	return nil, nil
 }
 
-func (s *service) ListSnapshots(
+func (c *controller) ListSnapshots(
 	ctx context.Context,
 	req *csi.ListSnapshotsRequest) (
 	*csi.ListSnapshotsResponse, error) {


### PR DESCRIPTION
This commit introduces the X_CSI_VSPHERE_APINAME env var, which can be
used to specify the name of the API to use when talking to vCenter.
Currently the only supported API name is "FCD", and is the default. FCD
will be used if no API is specified. If one is specified, anything that
doesn't evaluate to FCD will produce an error.

Right now it is envisioned that alternate APIs will only require changes
to the Controller portion of the code. Identity and Node are likely to
remain the same, but this can be re-evaluated in the future.

fixes #86 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
