### PR TITLE
Restore Network configuration section and add deprecation notice

### DIFF
--- a/pkg/cloudprovider/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/vsphere/vsphere_test.go
@@ -92,6 +92,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (vcfg.Con
 	cfg.Global.User = s.URL.User.Username()
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = vclib.TestDefaultDatacenter
+	cfg.Network.PublicNetwork = vclib.TestDefaultNetwork
 	cfg.VirtualCenter = make(map[string]*vcfg.VirtualCenterConfig)
 	cfg.VirtualCenter[s.URL.Hostname()] = &vcfg.VirtualCenterConfig{
 		User:         cfg.Global.User,

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -246,6 +246,10 @@ func fixUpConfigFromFile(cfg *Config) error {
 		cfg.Global.VCenterPort = DefaultVCenterPort
 	}
 
+	if len(cfg.Network.PublicNetwork) > 0 {
+		glog.Warningf("Network section is deprecated, please remove it from your configuration.")
+	}
+
 	isSecretInfoProvided := true
 	if cfg.Global.SecretName == "" || cfg.Global.SecretNamespace == "" {
 		isSecretInfoProvided = false

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -56,6 +56,11 @@ type Config struct {
 		APIBinding string `gcfg:"api-binding"`
 	}
 	VirtualCenter map[string]*VirtualCenterConfig
+
+	Network struct {
+		// PublicNetwork is name of the network the VMs are joined to.
+		PublicNetwork string `gcfg:"public-network"`
+	}
 }
 
 // Structure that represents Virtual Center configuration


### PR DESCRIPTION
This was causing issues with existing configmaps, this fix should restore continuity and adds a warning that the section has been deprecated

/cc @akutz