### PR TITLE
Move CredMgr to pkg/common, add DCOS/generic-CO support

### DIFF
--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -32,6 +32,7 @@ import (
 
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/server"
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
+	cm "k8s.io/cloud-provider-vsphere/pkg/common/credentialmanager"
 )
 
 const (
@@ -69,12 +70,22 @@ func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) 
 
 		if vs.cfg.Global.SecretNamespace != "" && vs.cfg.Global.SecretName != "" {
 			secretInformer := informerFactory.Core().V1().Secrets()
-			vs.nodeManager.credentialManager = &SecretCredentialManager{
-				SecretName:      vs.cfg.Global.SecretName,
-				SecretNamespace: vs.cfg.Global.SecretNamespace,
-				SecretLister:    secretInformer.Lister(),
-				Cache: &SecretCache{
-					VirtualCenter: make(map[string]*Credential),
+			vs.nodeManager.credentialManager = &cm.SecretCredentialManager{
+				SecretName:            vs.cfg.Global.SecretName,
+				SecretNamespace:       vs.cfg.Global.SecretNamespace,
+				SecretLister:          secretInformer.Lister(),
+				SecretsDirectory:      vs.cfg.Global.SecretsDirectory,
+				SecretsDirectoryParse: false,
+				Cache: &cm.SecretCache{
+					VirtualCenter: make(map[string]*cm.Credential),
+				},
+			}
+		} else if vs.cfg.Global.SecretsDirectory != "" {
+			vs.nodeManager.credentialManager = &cm.SecretCredentialManager{
+				SecretsDirectory:      vs.cfg.Global.SecretsDirectory,
+				SecretsDirectoryParse: false,
+				Cache: &cm.SecretCache{
+					VirtualCenter: make(map[string]*cm.Credential),
 				},
 			}
 		}

--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -21,10 +21,11 @@ import (
 
 	"k8s.io/api/core/v1"
 	clientv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
+	cm "k8s.io/cloud-provider-vsphere/pkg/common/credentialmanager"
+	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
 )
 
 // GRPCServer interface
@@ -73,7 +74,7 @@ type NodeManager struct {
 	// Maps UUID to node info.
 	nodeRegUUIDMap map[string]*v1.Node
 	// CredentialsManager
-	credentialManager *SecretCredentialManager
+	credentialManager *cm.SecretCredentialManager
 	// NodeLister to track Node properties
 	nodeLister clientv1.NodeLister
 
@@ -81,24 +82,6 @@ type NodeManager struct {
 	nodeInfoLock          sync.RWMutex
 	nodeRegInfoLock       sync.RWMutex
 	credentialManagerLock sync.Mutex
-}
-
-type SecretCache struct {
-	cacheLock     sync.Mutex
-	VirtualCenter map[string]*Credential
-	Secret        *v1.Secret
-}
-
-type Credential struct {
-	User     string `gcfg:"user"`
-	Password string `gcfg:"password"`
-}
-
-type SecretCredentialManager struct {
-	SecretName      string
-	SecretNamespace string
-	SecretLister    clientv1.SecretLister
-	Cache           *SecretCache
 }
 
 type instances struct {

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -48,6 +48,11 @@ type Config struct {
 		// The kubernetes service account used to launch the cloud controller manager.
 		// Default: cloud-controller-manager
 		ServiceAccount string `gcfg:"service-account"`
+		// Secret directory in the event that:
+		// 1) we don't want to use the k8s API to listen for changes to secrets
+		// 2) we are not in a k8s env, namely DC/OS, since CSI is CO agnostic
+		// Default: /etc/cloud/credentials
+		SecretsDirectory string `gcfg:"secrets-directory"`
 		// Disable the vSphere CCM API
 		// Default: true
 		APIDisable bool `gcfg:"api-disable"`

--- a/pkg/common/credentialmanager/credentialmanager_test.go
+++ b/pkg/common/credentialmanager/credentialmanager_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package vsphere
+package credentialmanager
 
 import (
 	"reflect"
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 )
 
-func TestSecretCredentialManager_GetCredential(t *testing.T) {
+func TestSecretCredentialManagerK8s_GetCredential(t *testing.T) {
 	var (
 		userKey             = "username"
 		passwordKey         = "password"
@@ -190,7 +190,6 @@ func TestSecretCredentialManager_GetCredential(t *testing.T) {
 		SecretName:      secretName,
 		SecretNamespace: secretNamespace,
 		SecretLister:    secretInformer.Lister(),
-		//Client: client,
 		Cache: &SecretCache{
 			VirtualCenter: make(map[string]*Credential),
 		},

--- a/pkg/common/credentialmanager/types.go
+++ b/pkg/common/credentialmanager/types.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentialmanager
+
+import (
+	"sync"
+
+	"k8s.io/api/core/v1"
+	clientv1 "k8s.io/client-go/listers/core/v1"
+)
+
+type SecretCache struct {
+	cacheLock     sync.Mutex
+	VirtualCenter map[string]*Credential
+	Secret        *v1.Secret
+	SecretFile    map[string][]byte
+}
+
+type Credential struct {
+	User     string `gcfg:"user"`
+	Password string `gcfg:"password"`
+}
+
+type SecretCredentialManager struct {
+	SecretName            string
+	SecretNamespace       string
+	SecretLister          clientv1.SecretLister
+	SecretsDirectory      string
+	SecretsDirectoryParse bool
+	Cache                 *SecretCache
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Moved credential manager into pkg/common for CSI to reuse. Also, adds support for other container orchestrators like DCOS.

**Which issue this PR fixes**: NA

**Special notes for your reviewer**:
Since this is a refactor plus additional implementation to support DCOS and other generic COs, the k8s workflow, docs, and user experience is unchanged.

Tested using k8s on 1.11.3 using k8s secret listener
Tested by mounting the k8s secret to the filesystem which simulates a DCOS deploy of CSI
`make test` functions correctly