### PR TITLE
Remove dead/stale code

### DIFF
--- a/pkg/cloudprovider/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/vsphere/vsphere_test.go
@@ -93,7 +93,6 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (vcfg.Con
 	cfg.Global.User = s.URL.User.Username()
 	cfg.Global.Password, _ = s.URL.User.Password()
 	cfg.Global.Datacenters = vclib.TestDefaultDatacenter
-	cfg.Network.PublicNetwork = vclib.TestDefaultNetwork
 	cfg.VirtualCenter = make(map[string]*vcfg.VirtualCenterConfig)
 	cfg.VirtualCenter[s.URL.Hostname()] = &vcfg.VirtualCenterConfig{
 		User:         cfg.Global.User,

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -257,10 +257,6 @@ func fixUpConfigFromFile(cfg *Config) error {
 		cfg.Global.VCenterPort = DefaultVCenterPort
 	}
 
-	if len(cfg.Network.PublicNetwork) > 0 {
-		glog.Warningf("Network section is deprecated, please remove it from your configuration.")
-	}
-
 	isSecretInfoProvided := true
 	if (cfg.Global.SecretName == "" || cfg.Global.SecretNamespace == "") && cfg.Global.SecretsDirectory == "" {
 		isSecretInfoProvided = false

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -340,7 +340,7 @@ func ReadConfig(config io.Reader) (Config, error) {
 
 	cfg, _ := ConfigFromEnv()
 
-	err := gcfg.ReadInto(&cfg, config)
+	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
 	if err != nil {
 		return cfg, err
 	}

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -59,11 +59,6 @@ type Config struct {
 		APIBinding string `gcfg:"api-binding"`
 	}
 	VirtualCenter map[string]*VirtualCenterConfig
-
-	Network struct {
-		// PublicNetwork is name of the network the VMs are joined to.
-		PublicNetwork string `gcfg:"public-network"`
-	}
 }
 
 // Structure that represents Virtual Center configuration


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes dead/stale code that was carried/copied over from the in-tree provider which is no longer needed. This removes the networking section from the configuration file because it isn't needed by the out-of-tree provider. 

There was an original attempt to remove this dead/stale code but it broke a couple of projects that were using/deploying the CCM as apart of these other projects. Sorry about that! This is a second attempt to remove code that is no longer needed before we cut a first version/tag of the CCM.

The behavior of `gcfg` was changed such that if extra or missing sections/keyvalues are parsed, they will not produce a fatal error. Only invalid config file syntax are errors. This was tested with the legacy `network` section in the config file, did not produce a fatal error and the CCM was able to run successfully.

**Special notes for your reviewer**:
When these lines of code were reverted/added back into the CCM, the updates to the documentation, example YAML, the outstanding Helm chart, etc were not reverted along with it. It would be very nice to remove this code/property from the config so we don't create technical debt or legacy issues before we cut the first version.

If we decided not to merge this PR, we can close this PR but we would need to create a new PR to "revert" the documentation, example YAML, Helm chart, etc to match the existence of this property in the config file.

CC: @frapposelli @dougm @codenrhoden @akutz 