### PR TITLE
Initial implementation for CSI create/delete

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1088,7 +1088,7 @@
   revision = "e3762e86a74c878ffed47484592986685639c2cd"
 
 [[projects]]
-  digest = "1:f7f7777d09307c2c606e4779fd7810e53bb18d07ea2f8860a60abe67c4973b6b"
+  digest = "1:cba624958aaf538386f59ff24426f41d2521ea215c55274dba0a6271d4556876"
   name = "k8s.io/kubernetes"
   packages = [
     "cmd/cloud-controller-manager/app",
@@ -1140,15 +1140,24 @@
     "pkg/util/file",
     "pkg/util/flag",
     "pkg/util/hash",
+    "pkg/util/io",
     "pkg/util/metrics",
+    "pkg/util/mount",
     "pkg/util/net/sets",
     "pkg/util/node",
+    "pkg/util/nsenter",
     "pkg/util/parsers",
     "pkg/util/pointer",
     "pkg/util/taints",
     "pkg/version",
     "pkg/version/prometheus",
     "pkg/version/verflag",
+    "pkg/volume",
+    "pkg/volume/util",
+    "pkg/volume/util/fs",
+    "pkg/volume/util/recyclerclient",
+    "pkg/volume/util/types",
+    "pkg/volume/util/volumepathhandler",
   ]
   pruneopts = "UT"
   revision = "bb9ffb1654d4a729bb4cec18ff088eacc153c239"
@@ -1161,6 +1170,14 @@
   packages = ["pkg/signals"]
   pruneopts = "UT"
   revision = "be98dc6210ab86895825bb9ed212f9f60557c33e"
+
+[[projects]]
+  branch = "master"
+  digest = "1:381323c2fe2e890a3dd3b5d6dc6f2199068408cca89b24f6b7ca1c60f32644a5"
+  name = "k8s.io/utils"
+  packages = ["exec"]
+  pruneopts = "UT"
+  revision = "0d26856f57b32ec3398579285e5c8a2bfe8c5243"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -1198,7 +1215,9 @@
     "github.com/vmware/govmomi/vslm",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
+    "google.golang.org/grpc/codes",
     "google.golang.org/grpc/reflection",
+    "google.golang.org/grpc/status",
     "gopkg.in/gcfg.v1",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
@@ -1225,6 +1244,7 @@
     "k8s.io/kubernetes/pkg/util/flag",
     "k8s.io/kubernetes/pkg/version/prometheus",
     "k8s.io/kubernetes/pkg/version/verflag",
+    "k8s.io/kubernetes/pkg/volume/util",
     "k8s.io/sample-controller/pkg/signals",
   ]
   solver-name = "gps-cdcl"

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -115,6 +115,7 @@ func TestDiscoverNodeByName(t *testing.T) {
 		t.Errorf("Failed to construct/authenticate vSphere: %s", err)
 	}
 	vsphere.connectionManager = cm.NewConnectionManager(&cfg, nil)
+	defer vsphere.connectionManager.Logout()
 
 	nm := NodeManager{
 		nodeNameMap:       make(map[string]*NodeInfo),
@@ -126,7 +127,6 @@ func TestDiscoverNodeByName(t *testing.T) {
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Config.GuestFullName
-
 	err = nm.connectionManager.VsphereInstanceMap[cfg.Global.VCenterIP].Conn.Connect(context.Background())
 	if err != nil {
 		t.Errorf("Failed to Connect to vSphere: %s", err)
@@ -182,6 +182,7 @@ func TestExport(t *testing.T) {
 		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
 	}
 	vsphere.connectionManager = cm.NewConnectionManager(&cfg, nil)
+	defer vsphere.connectionManager.Logout()
 
 	nm := NodeManager{
 		nodeNameMap:       make(map[string]*NodeInfo),

--- a/pkg/cloudprovider/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/vsphere/vsphere_test.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"strings"
 	"testing"
-	"time"
 
 	lookup "github.com/vmware/govmomi/lookup/simulator"
 	"github.com/vmware/govmomi/simulator"
@@ -134,14 +133,13 @@ func TestVSphereLogin(t *testing.T) {
 	cfg, cleanup := configFromEnvOrSim()
 	defer cleanup()
 
-	time.Sleep(5 * time.Second)
-
 	// Create vSphere configuration object
 	vs, err := newVSphere(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
 	}
 	vs.connectionManager = cm.NewConnectionManager(&cfg, nil)
+	defer vs.connectionManager.Logout()
 
 	// Create context
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/common/connectionmanager/connectionmanager.go
+++ b/pkg/common/connectionmanager/connectionmanager.go
@@ -32,7 +32,6 @@ import (
 	vclib "k8s.io/cloud-provider-vsphere/pkg/common/vclib"
 )
 
-// Error Messages
 type FindVM int
 
 const (
@@ -43,14 +42,12 @@ const (
 	QUEUE_SIZE int = POOL_SIZE * 10
 
 	// Error Messages
-	VMNotFoundErrMsg               = "VM not found"
 	ConnectionNotFoundErrMsg       = "vCenter not found"
 	UnsupportedConfigurationErrMsg = "Unsupported configuration: Supports only a single VC/DC"
 )
 
 // Error constants
 var (
-	ErrVMNotFound               = errors.New(VMNotFoundErrMsg)
 	ErrConnectionNotFound       = errors.New(ConnectionNotFoundErrMsg)
 	ErrUnsupportedConfiguration = errors.New(UnsupportedConfigurationErrMsg)
 )
@@ -93,6 +90,32 @@ func NewConnectionManager(config *vcfg.Config, secretLister v1.SecretLister) *Co
 			},
 		},
 	}
+}
+
+//GenerateInstanceMap creates a map of vCenter connection objects that can be
+//use to create a connection to a vCenter using vclib package
+func generateInstanceMap(cfg *vcfg.Config) map[string]*VSphereInstance {
+	vsphereInstanceMap := make(map[string]*VSphereInstance)
+
+	for vcServer, vcConfig := range cfg.VirtualCenter {
+		vSphereConn := vclib.VSphereConnection{
+			Username:          vcConfig.User,
+			Password:          vcConfig.Password,
+			Hostname:          vcServer,
+			Insecure:          vcConfig.InsecureFlag,
+			RoundTripperCount: vcConfig.RoundTripperCount,
+			Port:              vcConfig.VCenterPort,
+			CACert:            vcConfig.CAFile,
+			Thumbprint:        vcConfig.Thumbprint,
+		}
+		vsphereIns := VSphereInstance{
+			Conn: &vSphereConn,
+			Cfg:  vcConfig,
+		}
+		vsphereInstanceMap[vcServer] = &vsphereIns
+	}
+
+	return vsphereInstanceMap
 }
 
 func (cm *ConnectionManager) Connect(ctx context.Context, vcenter string) error {
@@ -168,9 +191,15 @@ func (cm *ConnectionManager) VerifyWithContext(ctx context.Context) error {
 }
 
 // WhichVCandDCByZone gets the corresponding VC+DC combo that supports the availability zone
-//TODO: we currently only support a single VC/DC combinations until we support availability zones
-func (cm *ConnectionManager) WhichVCandDCByZone(zone string) (*DiscoveryInfo, error) {
-	//TODO: we currently only support a single VC/DC combinations until we support availability zones
+// TODO: we currently only support a single VC/DC combinations until we support availability zones
+// *** Working Idea ***
+// The current thinking is that Datacenters will be tagged with a "zone" value. This function
+// will be passed the zone from the k8s cluster then "look up" the tag on datacenter using
+// a method similar to what is done in the function WhichVCandDCByNodeId (aka in parallel)
+// then return the DiscoveryInfo for that zone. This should handle non-unique
+// DatastoreCluster and Datastore names between Datacenters.
+// *** Working Idea ***
+func (cm *ConnectionManager) WhichVCandDCByZone(ctx context.Context, zone string) (*DiscoveryInfo, error) {
 	if len(cm.VsphereInstanceMap) != 1 {
 		glog.Error("Only a single vServer is currently supported")
 		return nil, ErrUnsupportedConfiguration
@@ -187,9 +216,6 @@ func (cm *ConnectionManager) WhichVCandDCByZone(zone string) (*DiscoveryInfo, er
 		glog.Error("Only a single Datacenter is currently supported")
 		return nil, ErrUnsupportedConfiguration
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	var err error
 	for i := 0; i < 3; i++ {
@@ -219,10 +245,10 @@ func (cm *ConnectionManager) WhichVCandDCByZone(zone string) (*DiscoveryInfo, er
 	return discoveryInfo, nil
 }
 
-func (cm *ConnectionManager) WhichVCandDCByNodeId(nodeID string, searchBy FindVM) (*VmDiscoveryInfo, error) {
+func (cm *ConnectionManager) WhichVCandDCByNodeId(ctx context.Context, nodeID string, searchBy FindVM) (*VmDiscoveryInfo, error) {
 	if nodeID == "" {
-		glog.V(3).Info("DiscoverNode called but nodeID is empty")
-		return nil, ErrVMNotFound
+		glog.V(3).Info("WhichVCandDCByNodeId called but nodeID is empty")
+		return nil, vclib.ErrNoVMFound
 	}
 	type vmSearch struct {
 		vc         string
@@ -239,12 +265,12 @@ func (cm *ConnectionManager) WhichVCandDCByNodeId(nodeID string, searchBy FindVM
 
 	myNodeID := nodeID
 	if searchBy == FindVMByUUID {
-		glog.V(3).Info("DiscoverNode by UUID")
+		glog.V(3).Info("WhichVCandDCByNodeId by UUID")
 		myNodeID = strings.ToLower(nodeID)
 	} else {
-		glog.V(3).Info("DiscoverNode by Name")
+		glog.V(3).Info("WhichVCandDCByNodeId by Name")
 	}
-	glog.V(2).Info("DiscoverNode nodeID: ", myNodeID)
+	glog.V(2).Info("WhichVCandDCByNodeId nodeID: ", myNodeID)
 
 	vmFound := false
 	globalErr = nil
@@ -277,13 +303,13 @@ func (cm *ConnectionManager) WhichVCandDCByNodeId(nodeID string, searchBy FindVM
 				break
 			}
 
-			// Create context
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			var err error
 			for i := 0; i < 3; i++ {
 				err = cm.Connect(ctx, vc)
+				if err == nil {
+					break
+				}
+				err = cm.ConnectByInstance(ctx, vsi)
 				if err == nil {
 					break
 				}
@@ -291,7 +317,7 @@ func (cm *ConnectionManager) WhichVCandDCByNodeId(nodeID string, searchBy FindVM
 			}
 
 			if err != nil {
-				glog.Error("Discovering node error vc:", err)
+				glog.Error("WhichVCandDCByNodeId error vc:", err)
 				setGlobalErr(err)
 				continue
 			}
@@ -299,7 +325,7 @@ func (cm *ConnectionManager) WhichVCandDCByNodeId(nodeID string, searchBy FindVM
 			if vsi.Cfg.Datacenters == "" {
 				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.Conn)
 				if err != nil {
-					glog.Error("Discovering node error dc:", err)
+					glog.Error("WhichVCandDCByNodeId error dc:", err)
 					setGlobalErr(err)
 					continue
 				}
@@ -312,7 +338,7 @@ func (cm *ConnectionManager) WhichVCandDCByNodeId(nodeID string, searchBy FindVM
 					}
 					datacenterObj, err := vclib.GetDatacenter(ctx, vsi.Conn, dc)
 					if err != nil {
-						glog.Error("Discovering node error dc:", err)
+						glog.Error("WhichVCandDCByNodeId error dc:", err)
 						setGlobalErr(err)
 						continue
 					}
@@ -340,9 +366,6 @@ func (cm *ConnectionManager) WhichVCandDCByNodeId(nodeID string, searchBy FindVM
 	for i := 0; i < POOL_SIZE; i++ {
 		go func() {
 			for res := range queueChannel {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
 				var vm *vclib.VirtualMachine
 				var err error
 				if searchBy == FindVMByUUID {
@@ -377,8 +400,6 @@ func (cm *ConnectionManager) WhichVCandDCByNodeId(nodeID string, searchBy FindVM
 
 				vmInfo = &VmDiscoveryInfo{DataCenter: res.datacenter, VM: vm, VcServer: res.vc,
 					UUID: oVM.Summary.Config.Uuid, NodeName: oVM.Guest.HostName}
-				for range queueChannel {
-				}
 				setVMFound(true)
 				break
 			}
@@ -394,32 +415,157 @@ func (cm *ConnectionManager) WhichVCandDCByNodeId(nodeID string, searchBy FindVM
 		return nil, *globalErr
 	}
 
-	glog.V(4).Infof("Discovery Node: %q vm not found", myNodeID)
+	glog.V(4).Infof("WhichVCandDCByNodeId: %q vm not found", myNodeID)
 	return nil, vclib.ErrNoVMFound
 }
 
-//GenerateInstanceMap creates a map of vCenter connection objects that can be
-//use to create a connection to a vCenter using vclib package
-func generateInstanceMap(cfg *vcfg.Config) map[string]*VSphereInstance {
-	vsphereInstanceMap := make(map[string]*VSphereInstance)
+func (cm *ConnectionManager) WhichVCandDCByFCDId(ctx context.Context, fcdID string) (*FcdDiscoveryInfo, error) {
+	if fcdID == "" {
+		glog.V(3).Info("WhichVCandDCByFCDId called but fcdID is empty")
+		return nil, vclib.ErrNoDiskIDFound
+	}
+	glog.V(2).Info("WhichVCandDCByFCDId fcdID: ", fcdID)
 
-	for vcServer, vcConfig := range cfg.VirtualCenter {
-		vSphereConn := vclib.VSphereConnection{
-			Username:          vcConfig.User,
-			Password:          vcConfig.Password,
-			Hostname:          vcServer,
-			Insecure:          vcConfig.InsecureFlag,
-			RoundTripperCount: vcConfig.RoundTripperCount,
-			Port:              vcConfig.VCenterPort,
-			CACert:            vcConfig.CAFile,
-			Thumbprint:        vcConfig.Thumbprint,
-		}
-		vsphereIns := VSphereInstance{
-			Conn: &vSphereConn,
-			Cfg:  vcConfig,
-		}
-		vsphereInstanceMap[vcServer] = &vsphereIns
+	type fcdSearch struct {
+		vc         string
+		datacenter *vclib.Datacenter
 	}
 
-	return vsphereInstanceMap
+	var mutex = &sync.Mutex{}
+	var globalErrMutex = &sync.Mutex{}
+	var queueChannel chan *fcdSearch
+	var wg sync.WaitGroup
+	var globalErr *error
+
+	queueChannel = make(chan *fcdSearch, QUEUE_SIZE)
+
+	fcdFound := false
+	globalErr = nil
+
+	setGlobalErr := func(err error) {
+		globalErrMutex.Lock()
+		globalErr = &err
+		globalErrMutex.Unlock()
+	}
+
+	setFCDFound := func(found bool) {
+		mutex.Lock()
+		fcdFound = found
+		mutex.Unlock()
+	}
+
+	getFCDFound := func() bool {
+		mutex.Lock()
+		found := fcdFound
+		mutex.Unlock()
+		return found
+	}
+
+	go func() {
+		var datacenterObjs []*vclib.Datacenter
+		for vc, vsi := range cm.VsphereInstanceMap {
+
+			found := getFCDFound()
+			if found == true {
+				break
+			}
+
+			var err error
+			for i := 0; i < 3; i++ {
+				err = cm.Connect(ctx, vc)
+				if err == nil {
+					break
+				}
+				err = cm.ConnectByInstance(ctx, vsi)
+				if err == nil {
+					break
+				}
+				time.Sleep(1 * time.Second)
+			}
+
+			if err != nil {
+				glog.Error("WhichVCandDCByFCDId error vc:", err)
+				setGlobalErr(err)
+				continue
+			}
+
+			if vsi.Cfg.Datacenters == "" {
+				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.Conn)
+				if err != nil {
+					glog.Error("WhichVCandDCByFCDId error dc:", err)
+					setGlobalErr(err)
+					continue
+				}
+			} else {
+				datacenters := strings.Split(vsi.Cfg.Datacenters, ",")
+				for _, dc := range datacenters {
+					dc = strings.TrimSpace(dc)
+					if dc == "" {
+						continue
+					}
+					datacenterObj, err := vclib.GetDatacenter(ctx, vsi.Conn, dc)
+					if err != nil {
+						glog.Error("WhichVCandDCByFCDId error dc:", err)
+						setGlobalErr(err)
+						continue
+					}
+					datacenterObjs = append(datacenterObjs, datacenterObj)
+				}
+			}
+
+			for _, datacenterObj := range datacenterObjs {
+				found := getFCDFound()
+				if found == true {
+					break
+				}
+
+				glog.V(4).Infof("Finding FCD %s in vc=%s and datacenter=%s", fcdID, vc, datacenterObj.Name())
+				queueChannel <- &fcdSearch{
+					vc:         vc,
+					datacenter: datacenterObj,
+				}
+			}
+		}
+		close(queueChannel)
+	}()
+
+	var fcdInfo *FcdDiscoveryInfo
+	for i := 0; i < POOL_SIZE; i++ {
+		go func() {
+			for res := range queueChannel {
+
+				fcd, err := res.datacenter.DoesFirstClassDiskExist(ctx, fcdID)
+				if err != nil {
+					glog.Errorf("Error while looking for FCD=%+v in vc=%s and datacenter=%s: %v",
+						fcd, res.vc, res.datacenter.Name(), err)
+					if err != vclib.ErrNoDiskIDFound {
+						setGlobalErr(err)
+					} else {
+						glog.V(2).Infof("Did not find FCD %s in vc=%s and datacenter=%s",
+							fcdID, res.vc, res.datacenter.Name())
+					}
+					continue
+				}
+
+				glog.V(2).Infof("Found FCD %s as vm=%+v in vc=%s and datacenter=%s",
+					fcdID, fcd, res.vc, res.datacenter.Name())
+
+				fcdInfo = &FcdDiscoveryInfo{DataCenter: res.datacenter, FCDInfo: fcd, VcServer: res.vc}
+				setFCDFound(true)
+				break
+			}
+			wg.Done()
+		}()
+		wg.Add(1)
+	}
+	wg.Wait()
+	if fcdFound {
+		return fcdInfo, nil
+	}
+	if globalErr != nil {
+		return nil, *globalErr
+	}
+
+	glog.V(4).Infof("WhichVCandDCByFCDId: %q FCD not found", fcdID)
+	return nil, vclib.ErrNoDiskIDFound
 }

--- a/pkg/common/connectionmanager/types.go
+++ b/pkg/common/connectionmanager/types.go
@@ -45,6 +45,13 @@ type VmDiscoveryInfo struct {
 	NodeName   string
 }
 
+// FcdDiscoveryInfo contains FCD info about a discovered FCD
+type FcdDiscoveryInfo struct {
+	DataCenter *vclib.Datacenter
+	FCDInfo    *vclib.FirstClassDiskInfo
+	VcServer   string
+}
+
 // DiscoveryInfo contains VC+DC info based on a given zone
 type DiscoveryInfo struct {
 	DataCenter *vclib.Datacenter

--- a/pkg/common/vclib/constants.go
+++ b/pkg/common/vclib/constants.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package vclib
 
+type FindFCD int
+
+const (
+	FindFCDByID   FindFCD = iota // 0
+	FindFCDByName                // 1
+)
+
 // Volume Constnts
 const (
 	ThinDiskType             = "thin"

--- a/pkg/common/vclib/custom_errors.go
+++ b/pkg/common/vclib/custom_errors.go
@@ -21,19 +21,19 @@ import "errors"
 // Error Messages
 const (
 	FileAlreadyExistErrMsg     = "File requested already exist"
-	NoDiskUUIDFoundErrMsg      = "No disk UUID found"
 	NoDevicesFoundErrMsg       = "No devices found"
-	DiskNotFoundErrMsg         = "No vSphere disk ID found"
+	DiskNotFoundErrMsg         = "No vSphere disk ID/Name found"
 	InvalidVolumeOptionsErrMsg = "VolumeOptions verification failed"
 	NoVMFoundErrMsg            = "No VM found"
+	NoDatastoreFoundErrMsg     = "Datastore not found"
 )
 
 // Error constants
 var (
 	ErrFileAlreadyExist     = errors.New(FileAlreadyExistErrMsg)
-	ErrNoDiskUUIDFound      = errors.New(NoDiskUUIDFoundErrMsg)
 	ErrNoDevicesFound       = errors.New(NoDevicesFoundErrMsg)
 	ErrNoDiskIDFound        = errors.New(DiskNotFoundErrMsg)
 	ErrInvalidVolumeOptions = errors.New(InvalidVolumeOptionsErrMsg)
 	ErrNoVMFound            = errors.New(NoVMFoundErrMsg)
+	ErrNoDatastoreFound     = errors.New(NoDatastoreFoundErrMsg)
 )

--- a/pkg/common/vclib/datacenter_test.go
+++ b/pkg/common/vclib/datacenter_test.go
@@ -133,7 +133,7 @@ func TestDatacenter(t *testing.T) {
 		t.Error(err)
 	}
 
-	diskPath := ds.Path(avm.Name + "/disk1.vmdk")
+	diskPath := ds.Datastore.Path(avm.Name + "/disk1.vmdk")
 
 	_, err = dc.GetVirtualDiskPage83Data(ctx, diskPath+testNameNotFound)
 	if err == nil {
@@ -142,7 +142,7 @@ func TestDatacenter(t *testing.T) {
 
 	_, err = dc.GetVirtualDiskPage83Data(ctx, diskPath)
 	if err != nil {
-		t.Error(err)
+		t.Errorf("GetVirtualDiskPage83Data: %v", err)
 	}
 
 	_, err = dc.GetDatastoreMoList(ctx, nil, nil)
@@ -150,12 +150,12 @@ func TestDatacenter(t *testing.T) {
 		t.Error("expected error")
 	}
 
-	_, err = dc.GetDatastoreMoList(ctx, []*Datastore{ds}, []string{testNameNotFound}) // invalid property
+	_, err = dc.GetDatastoreMoList(ctx, []*Datastore{ds.Datastore}, []string{testNameNotFound}) // invalid property
 	if err == nil {
 		t.Error("expected error")
 	}
 
-	_, err = dc.GetDatastoreMoList(ctx, []*Datastore{ds}, []string{DatastoreInfoProperty})
+	_, err = dc.GetDatastoreMoList(ctx, []*Datastore{ds.Datastore}, []string{DatastoreInfoProperty})
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/common/vclib/virtualmachine.go
+++ b/pkg/common/vclib/virtualmachine.go
@@ -98,7 +98,7 @@ func (vm *VirtualMachine) AttachDisk(ctx context.Context, vmDiskPath string, vol
 		return "", err
 	}
 	// If disk is not attached, create a disk spec for disk to be attached to the VM.
-	disk, newSCSIController, err := vm.CreateDiskSpec(ctx, vmDiskPath, dsObj, volumeOptions)
+	disk, newSCSIController, err := vm.CreateDiskSpec(ctx, vmDiskPath, dsObj.Datastore, volumeOptions)
 	if err != nil {
 		glog.Errorf("Error occurred while creating disk spec. err: %+v", err)
 		return "", err

--- a/pkg/csi/service/fcd/constants.go
+++ b/pkg/csi/service/fcd/constants.go
@@ -20,6 +20,12 @@ const (
 	// MbInBytes... just like it sounds but as int64
 	MbInBytes = int64(1024 * 1024)
 
+	// GbInBytes... just like it sounds but as int64
+	GbInBytes = int64(1024 * 1024 * 1024)
+
+	// DefaultGbDiskSize... just like it sounds but as int64
+	DefaultGbDiskSize = int64(10)
+
 	// FirstClassDiskTypeString in string form
 	FirstClassDiskTypeString = "First Class Disk"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Initial implementation for Create/Delete for vSphere CSI.
- Handles DatastoreClusters, VSAN datastores, and "traditional" Datastores
- added a comment/doc idea for how to implement zones

Other:
- connectiomanager implements WhichVCandDCByFCDId to retrieve which VC/DC owns a given FCD
- reverted recent changes to nodemanager.DiscoverNode() which was causing the go tests to fail
- refactored some ctx stuff on nodemanager and connectionmanager to handle some intermittent go test failures
- changed a few functions on Datacenter to return DatastoreInfo instead of Datastore
- updated go tests to reflect the above
- removed some unnecessary loops carried over from the in-tree version

**Which issue this PR fixes**: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/78 and https://github.com/kubernetes/cloud-provider-vsphere/issues/104

**Special notes for your reviewer**:
- tested CSI Create/Delete FCD on DatastoreClusters, VSAN datastores, and "traditional" Datastores
- `make test` functions normally
- tested on k8s 1.11.3
- tested on vSphere 6.7U1

**Release note**:
Changes to CCM and CSI functionality does not impact the end user, documentation, or etc.