### PR TITLE
Implement CSI Node Stage/Unstage

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,6 +34,14 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
+  digest = "1:ba7ea5f59171f2da1bfa7a00711b850cc109e5e6b9ea67be324210c66f96cac2"
+  name = "github.com/akutz/gofsutil"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "56ae374ef75adf5ca8ea6b4b79d97175cb86deb2"
+  version = "v0.1.2"
+
+[[projects]]
   digest = "1:5090455975191d02ed0875979b7dc14a76f73005f71404cca242eeb5b83361e9"
   name = "github.com/akutz/gosync"
   packages = ["."]
@@ -452,12 +460,12 @@
   revision = "207653674028b68706993f72ac0d4846a2d228d2"
 
 [[projects]]
-  digest = "1:3f53e9e4dfbb664cd62940c9c4b65a2171c66acd0b7621a1a6b8e78513525a52"
+  branch = "master"
+  digest = "1:1d11307230f6c30c988350d470540c477f7567dd15c9f32a51eb941f749b0b33"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ad15b42461921f1fb3529b058c6786c6a45d5162"
-  version = "v1.1.1"
+  revision = "29d7eb25e8ffa54207ff5a9a5c3d63e95be2cc39"
 
 [[projects]]
   digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
@@ -1183,11 +1191,13 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/akutz/gofsutil",
     "github.com/container-storage-interface/spec/lib/go/csi",
     "github.com/golang/glog",
     "github.com/golang/protobuf/proto",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/rexray/gocsi",
+    "github.com/rexray/gocsi/context",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,6 +13,10 @@ ignored = ["k8s.io/cloud-provider-vsphere"]
   name = "github.com/container-storage-interface/spec"
   version = "1.0.0"
 
+[[constraint]]
+  name = "github.com/akutz/gofsutil"
+  version = "0.1.2"
+
 [[override]]
   branch = "master"
   name = "github.com/golang/glog"

--- a/Makefile
+++ b/Makefile
@@ -48,13 +48,8 @@ $(GOBIN):
 	mkdir -p $(GOBIN)
 
 vendor: | $(GOBIN)
-ifeq (0,$(shell { test ! -d vendor || test vendor -ot Gopkg.lock; } && echo 0))
-vendor:
 	@$(MAKE) --always-make Gopkg.lock
 .PHONY: vendor
-else
-vendor: Gopkg.lock
-endif
 vendor-update: | $(GOBIN)
 	@DEP_FLAGS=" -update" $(MAKE) --always-make Gopkg.lock
 Gopkg.lock: Gopkg.toml $(SOURCES)

--- a/pkg/csi/service/node.go
+++ b/pkg/csi/service/node.go
@@ -17,15 +17,151 @@ limitations under the License.
 package service
 
 import (
-	"golang.org/x/net/context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 
+	"github.com/akutz/gofsutil"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	devDiskID   = "/dev/disk/by-id"
+	blockPrefix = "wwn-0x"
 )
 
 func (s *service) NodeStageVolume(
 	ctx context.Context,
 	req *csi.NodeStageVolumeRequest) (
 	*csi.NodeStageVolumeResponse, error) {
+
+	volID := req.GetVolumeId()
+	if volID == "" {
+		return nil, status.Error(codes.InvalidArgument,
+			"Volume ID required")
+	}
+
+	// Check that volume exists and is accessible
+	volPath, err := getDiskPath(volID, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"Error trying to read attached disks: %v", err)
+	}
+	if volPath == "" {
+		return nil, status.Errorf(codes.NotFound,
+			"Volume ID: %s not attached to node", volID)
+	}
+
+	// Check that block device looks good
+	dev, err := getDevice(volPath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"error getting block device for volume: %s, err: %s",
+			volID, err.Error())
+	}
+
+	// Check that target_path is created by CO and is a directory
+	target := req.GetStagingTargetPath()
+	if target == "" {
+		return nil, status.Error(codes.InvalidArgument,
+			"target path required")
+	}
+
+	tgtStat, err := os.Stat(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"stage volume, target: %s not pre-created", target)
+		}
+		return nil, status.Errorf(codes.Internal,
+			"failed to stat target, err: %s", err.Error())
+	}
+
+	// This check is mandated by the spec, but this would/should faile if the
+	// volume has a block accessType. Mayvbe staging isn't intended to be used
+	// with block? That would make sense you can share the volume for block.
+	if !tgtStat.IsDir() {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"existing path: %s is not a directory", target)
+	}
+
+	//Mount if the device if needed, and if already mounted, verify compatibility
+	volCap := req.GetVolumeCapability()
+	mountVol := volCap.GetMount()
+	if mountVol == nil {
+		return nil, status.Error(codes.InvalidArgument,
+			"Only Mount access type supported")
+	}
+	fs := mountVol.GetFsType()
+	mntFlags := mountVol.GetMountFlags()
+
+	accMode := volCap.GetAccessMode().GetMode()
+	ro := false
+	if accMode == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY ||
+		accMode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
+		ro = true
+	}
+
+	// Get mounts to check if already staged
+	mnts, err := gofsutil.GetDevMounts(context.Background(), dev.RealDev)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"could not reliably determine existing mount status: %s",
+			err.Error())
+	}
+
+	if len(mnts) == 0 {
+		// Device isn't mounted anywhere, stage the volume
+		if fs == "" {
+			fs = "ext4"
+		}
+
+		// If read-only access mode, we don't allow formatting
+		if ro {
+			mntFlags = append(mntFlags, "ro")
+			if err := gofsutil.Mount(ctx, dev.FullPath, target, fs, mntFlags...); err != nil {
+				return nil, status.Errorf(codes.Internal,
+					"error with mount during staging: %s",
+					err.Error())
+			}
+			return &csi.NodeStageVolumeResponse{}, nil
+		}
+		if err := gofsutil.FormatAndMount(ctx, dev.FullPath, target, fs, mntFlags...); err != nil {
+			return nil, status.Errorf(codes.Internal,
+				"error with format and mount during staging: %s",
+				err.Error())
+		}
+		return &csi.NodeStageVolumeResponse{}, nil
+
+	}
+	// Device is already mounted. Need to ensure that it is already
+	// mounted to the expected staging target, with correct rw/ro perms
+	mounted := false
+	for _, m := range mnts {
+		if m.Path == target {
+			mounted = true
+			rwo := "rw"
+			if ro {
+				rwo = "ro"
+			}
+			if contains(m.Opts, rwo) {
+				//TODO make sure that mount options match
+				//log.WithFields(f).Debug(
+				//	"private mount already in place")
+				return &csi.NodeStageVolumeResponse{}, nil
+			}
+			return nil, status.Error(codes.AlreadyExists,
+				"access mode conflicts with existing mount")
+		}
+	}
+	if !mounted {
+		return nil, status.Error(codes.Internal,
+			"device already in use and mounted elsewhere")
+	}
 
 	return nil, nil
 }
@@ -35,7 +171,69 @@ func (s *service) NodeUnstageVolume(
 	req *csi.NodeUnstageVolumeRequest) (
 	*csi.NodeUnstageVolumeResponse, error) {
 
-	return nil, nil
+	volID := req.GetVolumeId()
+	if volID == "" {
+		return nil, status.Error(codes.InvalidArgument,
+			"Volume ID required")
+	}
+
+	// Check that volume is attached
+	volPath, err := getDiskPath(volID, nil)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"Error trying to read attached disks: %v", err)
+	}
+	if volPath == "" {
+		return nil, status.Errorf(codes.NotFound,
+			"Volume ID: %s not attached to node", volID)
+	}
+
+	target := req.GetStagingTargetPath()
+	if target == "" {
+		return nil, status.Error(codes.InvalidArgument,
+			"target path required")
+	}
+
+	// Check that block device looks good
+	dev, err := getDevice(volPath)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"error getting block device for volume: %s, err: %s",
+			volID, err.Error())
+	}
+
+	// Get mounts for device
+	mnts, err := gofsutil.GetDevMounts(context.Background(), dev.RealDev)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal,
+			"could not reliably determine existing mount status: %s",
+			err.Error())
+	}
+
+	if len(mnts) == 0 {
+		// device isn't mounted, so this has been unstaged already
+		return &csi.NodeUnstageVolumeResponse{}, nil
+	}
+
+	// device is mounted. Should only be mounted to target
+	if len(mnts) > 1 {
+		return nil, status.Errorf(codes.Internal,
+			"volume: %s appears mounted in multiple places", volID)
+	}
+
+	if mnts[0].Source == dev.RealDev && mnts[0].Path == target {
+		// perfect, unstage this
+		if err := gofsutil.Unmount(context.Background(), target); err != nil {
+			return nil, status.Errorf(codes.Internal,
+				"Error unmounting target: %s", err.Error())
+		}
+	} else {
+		return nil, status.Errorf(codes.Internal,
+			"volume %s is mounted someplace other than target: %s, mounted to: %s",
+			volID, target, mnts[0].Path)
+	}
+
+	return &csi.NodeUnstageVolumeResponse{}, nil
 }
 
 func (s *service) NodePublishVolume(
@@ -67,7 +265,17 @@ func (s *service) NodeGetCapabilities(
 	req *csi.NodeGetCapabilitiesRequest) (
 	*csi.NodeGetCapabilitiesResponse, error) {
 
-	return nil, nil
+	return &csi.NodeGetCapabilitiesResponse{
+		Capabilities: []*csi.NodeServiceCapability{
+			&csi.NodeServiceCapability{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+					},
+				},
+			},
+		},
+	}, nil
 }
 
 func (s *service) NodeGetInfo(
@@ -76,4 +284,79 @@ func (s *service) NodeGetInfo(
 	*csi.NodeGetInfoResponse, error) {
 
 	return nil, nil
+}
+
+// Device is a struct for holding details about a block device
+type Device struct {
+	FullPath string
+	Name     string
+	RealDev  string
+}
+
+// getDevice returns a Device struct with info about the given device, or
+// an error if it doesn't exist or is not a block device
+func getDevice(path string) (*Device, error) {
+
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// eval any symlinks and make sure it points to a device
+	d, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil, err
+	}
+
+	ds, err := os.Stat(d)
+	if err != nil {
+		return nil, err
+	}
+	dm := ds.Mode()
+	if dm&os.ModeDevice == 0 {
+		return nil, fmt.Errorf(
+			"%s is not a block device", path)
+	}
+
+	return &Device{
+		Name:     fi.Name(),
+		FullPath: path,
+		RealDev:  d,
+	}, nil
+}
+
+// The files parameter is optional for testing purposes
+func getDiskPath(id string, files []os.FileInfo) (string, error) {
+	var (
+		devs []os.FileInfo
+		err  error
+	)
+
+	if files == nil {
+		devs, err = ioutil.ReadDir(devDiskID)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		devs = files
+	}
+
+	targetDisk := blockPrefix + id
+
+	for _, f := range devs {
+		if f.Name() == targetDisk {
+			return filepath.Join(devDiskID, f.Name()), nil
+		}
+	}
+
+	return "", nil
+}
+
+func contains(list []string, item string) bool {
+	for _, x := range list {
+		if x == item {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/csi/service/node_test.go
+++ b/pkg/csi/service/node_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGetDisk(t *testing.T) {
+	tests := []struct {
+		devs  []os.FileInfo
+		volID string
+		match bool
+	}{
+		{
+			devs: []os.FileInfo{
+				&FakeFileInfo{name: "wwn-0x702438570234875"},
+				&FakeFileInfo{name: "wwn-0x702345804753484"},
+			},
+			volID: "702438570234875",
+			match: true,
+		},
+		{
+			devs: []os.FileInfo{
+				&FakeFileInfo{name: "wwn-0x702438570234435"},
+				&FakeFileInfo{name: "wwn-0x702345804753484"},
+			},
+			volID: "702438570234875",
+			match: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(st *testing.T) {
+			st.Parallel()
+			d, e := getDiskPath(tt.volID, tt.devs)
+			if e != nil {
+				t.Errorf("%v", e)
+			}
+
+			disk := filepath.Join(devDiskID, blockPrefix+tt.volID)
+			if tt.match {
+				if d != disk {
+					t.Errorf("Expected disk: %s got: %s", disk, d)
+				}
+			} else {
+				if d != "" {
+					t.Errorf("Expected disk: got: %s", d)
+				}
+			}
+		})
+	}
+}
+
+type FakeFileInfo struct {
+	name string
+}
+
+func (fi *FakeFileInfo) Name() string {
+	return fi.name
+}
+
+func (fi *FakeFileInfo) Size() int64 {
+	return 0
+}
+
+func (fi *FakeFileInfo) Mode() os.FileMode {
+	return 0
+}
+
+func (fi *FakeFileInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (fi *FakeFileInfo) IsDir() bool {
+	return false
+}
+
+func (fi *FakeFileInfo) Sys() interface{} {
+	return nil
+}


### PR DESCRIPTION
This patch adds logic for CSI Node staging and unstaging. This takes a
pre-attached block volume, and mounts it to the given path in the
staging request. `gofsutil` is used to take care of the formatting,
mounting, and parsing of the mount tables.

<!-- Thanks for sending a pull request! -->

**Which issue this PR fixes**: fixes #106

**Special notes for your reviewer**: Tested this with node-only funcitonally. An FCD was previously attached to a node, and tested that I could idempotently stage and unstage that volume to a pre-created staging directory.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
