### PR TITLE
Initial implementation for CSI Publish/Unpublish

### DIFF
--- a/pkg/common/vclib/virtualmachine.go
+++ b/pkg/common/vclib/virtualmachine.go
@@ -163,8 +163,8 @@ func (vm *VirtualMachine) DetachDisk(ctx context.Context, vmDiskPath string) err
 		return err
 	}
 	if device == nil {
-		glog.Errorf("No virtual device found with diskPath: %q on VM: %q", vmDiskPath, vm.InventoryPath)
-		return fmt.Errorf("No virtual device found with diskPath: %q on VM: %q", vmDiskPath, vm.InventoryPath)
+		glog.Warningf("No virtual device found with diskPath: %q on VM: %q", vmDiskPath, vm.InventoryPath)
+		return nil
 	}
 	// Detach disk from VM
 	requestTime := time.Now()

--- a/pkg/csi/service/fcd/constants.go
+++ b/pkg/csi/service/fcd/constants.go
@@ -35,4 +35,6 @@ const (
 	AttributeFirstClassDiskParentType      = "parent_type"
 	AttributeFirstClassDiskParentName      = "parent_name"
 	AttributeFirstClassDiskOwningDatastore = "owning_datastore"
+	AttributeFirstClassDiskVcenter         = "vcenter"
+	AttributeFirstClassDiskDatacenter      = "datacenter"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Initial implementation for Publish/Unpublish for vSphere CSI.
- Handles DatastoreClusters, VSAN datastores, and "traditional" Datastores

Other:
- changed existing DetachDisk to be idempotent

**Which issue this PR fixes**: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/105

**Special notes for your reviewer**:
- tested CSI Publish/Unpublish FCD on DatastoreClusters, VSAN datastores, and "traditional" Datastores
- `make test` functions normally
- tested on k8s 1.11.3
- tested on vSphere 6.7U1

**Release note**:
Changes to CCM and CSI functionality does not impact the end user, documentation, or etc.