### PR TITLE
Implement NodeGetInfo

### DIFF
--- a/pkg/csi/service/node_test.go
+++ b/pkg/csi/service/node_test.go
@@ -97,3 +97,26 @@ func (fi *FakeFileInfo) IsDir() bool {
 func (fi *FakeFileInfo) Sys() interface{} {
 	return nil
 }
+
+func TestConvertUUID(t *testing.T) {
+	tests := []struct {
+		pre  string
+		post string
+	}{
+		{
+			pre:  "242A3042-6F0D-9058-1606-52FDB7E5E0AC",
+			post: "42302a24-0d6f-5890-1606-52fdb7e5e0ac",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(st *testing.T) {
+			st.Parallel()
+			result := convertUUID(tt.pre)
+			if result != tt.post {
+				t.Errorf("Expected: %s, got %s", tt.post, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This patch implements the CSI NodeGetInfo endpoint. For our purposes
right now, this just needs to return the Node ID, which is actually the
VM UUID as read from /sysfs with a conversion applied.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This PR builds off of two prior PRs, #107, and #106. Those will need to be merged first so this can be rebased on top of them.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Node
```
