### PR TITLE
Fix cloudprovider test races

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -215,6 +215,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy FindVM) error {
 	}()
 
 	for i := 0; i < cm.POOL_SIZE; i++ {
+		wg.Add(1)
 		go func() {
 			for res := range queueChannel {
 				var vm *vclib.VirtualMachine
@@ -277,7 +278,6 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy FindVM) error {
 			}
 			wg.Done()
 		}()
-		wg.Add(1)
 	}
 	wg.Wait()
 	if vmFound {

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -53,7 +53,7 @@ func TestRegUnregNode(t *testing.T) {
 	}
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
-	name := vm.Config.GuestFullName
+	name := vm.Name
 	UUID := vm.Config.Uuid
 	k8sUUID := nm.convertK8sUUIDtoNormal(UUID)
 
@@ -100,7 +100,7 @@ type SearchIndex struct {
 
 func (s *SearchIndex) FindByDnsName(req *types.FindByDnsName) soap.HasFault {
 	res := &methods.FindByDnsNameBody{Res: new(types.FindByDnsNameResponse)}
-	if req.VmSearch && strings.ToLower(req.DnsName) == strings.ToLower(s.vm.Config.GuestFullName) {
+	if req.VmSearch && strings.EqualFold(req.DnsName, s.vm.Name) {
 		res.Res.Returnval = &s.vm.Self
 	}
 	return res
@@ -126,7 +126,8 @@ func TestDiscoverNodeByName(t *testing.T) {
 	}
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
-	name := vm.Config.GuestFullName
+	name := vm.Name
+
 	err = nm.connectionManager.VsphereInstanceMap[cfg.Global.VCenterIP].Conn.Connect(context.Background())
 	if err != nil {
 		t.Errorf("Failed to Connect to vSphere: %s", err)
@@ -193,7 +194,7 @@ func TestExport(t *testing.T) {
 	}
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
-	name := vm.Config.GuestFullName
+	name := vm.Name
 	UUID := vm.Config.Uuid
 	k8sUUID := nm.convertK8sUUIDtoNormal(UUID)
 


### PR DESCRIPTION
GuestFullName is the OS type, which is the same for all VMs. This means the FindByDnsName impl could randomly return the wrong VM.
Change to using the vm.Name which is unique in these test cases.

DiscoverNode had a race where wg.Done() could be called before wg.Add(), causing wg.Wait() to return earlier than expected.
