### PR TITLE
More fixes for cloudprovider test races

### DIFF
--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -42,17 +42,20 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return newVSphere(cfg)
+		return newVSphere(cfg, true)
 	})
 }
 
 // Creates new Controller node interface and returns
-func newVSphere(cfg vcfg.Config) (*VSphere, error) {
+func newVSphere(cfg vcfg.Config, finalize ...bool) (*VSphere, error) {
 	vs, err := buildVSphereFromConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
-	runtime.SetFinalizer(vs, logout)
+	if len(finalize) == 1 && finalize[0] {
+		// optional for use in tests
+		runtime.SetFinalizer(vs, logout)
+	}
 	return vs, nil
 }
 

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -55,6 +55,17 @@ var (
 	ErrVMNotFound         = errors.New(VMNotFoundErrMsg)
 )
 
+func (f FindVM) String() string {
+	switch f {
+	case FindVMByUUID:
+		return "byUUID"
+	case FindVMByName:
+		return "byName"
+	default:
+		return "byUnknown"
+	}
+}
+
 // RegisterNode - Handler when node is removed from k8s cluster.
 func (nm *NodeManager) RegisterNode(node *v1.Node) {
 	glog.V(4).Info("RegisterNode ENTER: ", node.Name)
@@ -227,8 +238,8 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy FindVM) error {
 				}
 
 				if err != nil {
-					glog.Errorf("Error while looking for vm=%+v in vc=%s and datacenter=%s: %v",
-						vm, res.vc, res.datacenter.Name(), err)
+					glog.Errorf("Error while looking for vm=%s(%s) in vc=%s and datacenter=%s: %v",
+						myNodeID, searchBy, res.vc, res.datacenter.Name(), err)
 					if err != vclib.ErrNoVMFound {
 						setGlobalErr(err)
 					} else {

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -128,12 +128,13 @@ func TestDiscoverNodeByName(t *testing.T) {
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name
 
-	err = nm.connectionManager.VsphereInstanceMap[cfg.Global.VCenterIP].Conn.Connect(context.Background())
+	vsi := nm.connectionManager.VsphereInstanceMap[cfg.Global.VCenterIP]
+	err = nm.connectionManager.Connect(context.Background(), cfg.Global.VCenterIP)
 	if err != nil {
 		t.Errorf("Failed to Connect to vSphere: %s", err)
 	}
 
-	search := object.NewSearchIndex(nm.connectionManager.VsphereInstanceMap[cfg.Global.VCenterIP].Conn.Client)
+	search := object.NewSearchIndex(vsi.Conn.Client)
 	si := simulator.Map.Get(search.Reference()).(*simulator.SearchIndex)
 	simulator.Map.Put(&SearchIndex{si, vm})
 


### PR DESCRIPTION
- Protect read/write access to VSphereInstance.Conn field (in-tree does the same)

- Avoid use of runtime.SetFinalizer in tests as it randomly kicks in, logging out client sessions

- Fixup error message when vm search fails
