### PR TITLE
Add empty response for ValidateVolumeCapabilities

### DIFF
--- a/pkg/csi/service/fcd/controller.go
+++ b/pkg/csi/service/fcd/controller.go
@@ -331,7 +331,7 @@ func (c *controller) ValidateVolumeCapabilities(
 	req *csi.ValidateVolumeCapabilitiesRequest) (
 	*csi.ValidateVolumeCapabilitiesResponse, error) {
 
-	return nil, nil
+	return &csi.ValidateVolumeCapabilitiesResponse{}, nil
 }
 
 func (c *controller) ListVolumes(


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: The ValidateVolumeCapabilities is required to be implemented for the
Controller service. This is the last missing required API. Right now it
just returns an empty response, which is allowed. Since the "confirmed"
value is empty, this tells the CO that it has *not* confirmed that any
of the requested capabilties for the given volume have been confirmed.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: This probably isn't strictly necessary for the Alpha version, but it at least brings us in line with all the **required** APIs for CSI. Returning nil here could have caused problems if a CO were to actually call this method.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
