### PR TITLE
Always create a Controller Service early

### DIFF
--- a/pkg/csi/types/types.go
+++ b/pkg/csi/types/types.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
+)
+
+// Controller is the interface for the CSI Controller Server plus extra methods
+// required to support multiple API backends
+type Controller interface {
+	csi.ControllerServer
+	Init(config *vcfg.Config) error
+}


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: 
The previous code would skip creating a Controller Service if one was
not needed, and if it was needed, the service would would be created at
the end of BeforeServe. With GoCSI, this was too late because a check
was done to see that the ControllerService was not nil, and the previous
code told GoCSI that it was nil.

This patch changes GetController() to instantiate a ControllerService
struct early and return it, even though it is not initialize. To
facilitate this, New() not returns a nil struct, and Init() has been
added to actually configure the controller with the vSphere config file.

This patch also removes the calls for `log.Fatal*` - we need to avoid
the use of Fatal as it prevents GoCSI from performing automatic sock
file cleanup.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
