### PR TITLE
Update CSI container image with FS utilities

### DIFF
--- a/cluster/images/csi/Dockerfile
+++ b/cluster/images/csi/Dockerfile
@@ -12,6 +12,16 @@
 
 FROM photon:2.0
 
+RUN tdnf -y remove toybox
+
+RUN tdnf -y install \
+  util-linux \
+  e2fsprogs \
+  xfsprogs \
+  btrfs-progs
+
+RUN tdnf clean all
+
 ADD vsphere-csi /bin/
 
 CMD ["/bin/vsphere-csi"]

--- a/manifests/csi/vsphere-csi-controller-ss.yaml
+++ b/manifests/csi/vsphere-csi-controller-ss.yaml
@@ -49,6 +49,8 @@ spec:
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
             - name: X_CSI_MODE
               value: "controller"
+            - name: X_CSI_SPEC_REQ_VALIDATION
+              value: "false"
           imagePullPolicy: "Always"
           volumeMounts:
             - mountPath: /etc/kubernetes/pki

--- a/manifests/csi/vsphere-csi-node-ds.yaml
+++ b/manifests/csi/vsphere-csi-node-ds.yaml
@@ -43,6 +43,8 @@ spec:
             value: unix:///csi/csi.sock
           - name: X_CSI_MODE
             value: "node"
+          - name: X_CSI_SPEC_REQ_VALIDATION
+            value: "false"
           imagePullPolicy: "Always"
           securityContext:
             privileged: true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Install utilities for ext2/3/4, XFS, and BtrFS, along with lsblk.

`toybox` has to be uninstalled from Photon 2.0, otherwise it conflicts with `e2fsprogs` and others.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I considered also installing `ca-certificates`, but chose not to since our YAML examples mount `/etc/ssl/certificates` from the host.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```