### PR TITLE
Refactor Config package to allow for specialization

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -34,7 +34,8 @@ import (
 )
 
 func ParseConfig(configFile string) (config.Config, error) {
-	var cfg config.Config
+	cfg := config.Config{}
+
 	if len(configFile) == 0 {
 		return cfg, fmt.Errorf("Please specify vsphere cloud config file, e.g. --config vsphere.conf")
 	}
@@ -45,10 +46,7 @@ func ParseConfig(configFile string) (config.Config, error) {
 	if err != nil {
 		return cfg, fmt.Errorf("Can not open config file %s, %v", configFile, err)
 	}
-	cfg, err = config.ReadConfig(f)
-	if err != nil {
-		return cfg, err
-	}
+	err = config.ReadConfig(&cfg, f)
 	return cfg, err
 }
 

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -38,7 +38,8 @@ const (
 
 func init() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
-		cfg, err := vcfg.ReadConfig(config)
+		cfg := vcfg.Config{}
+		err := vcfg.ReadConfig(&cfg, config)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloudprovider/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/vsphere/vsphere_test.go
@@ -110,7 +110,8 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (vcfg.Con
 
 // configFromEnvOrSim returns config from configFromEnv if set, otherwise returns configFromSim.
 func configFromEnvOrSim() (vcfg.Config, func()) {
-	cfg, ok := vcfg.ConfigFromEnv()
+	cfg := vcfg.Config{}
+	ok := vcfg.ConfigFromEnv(&cfg)
 	if ok {
 		return cfg, func() {}
 	}
@@ -118,7 +119,9 @@ func configFromEnvOrSim() (vcfg.Config, func()) {
 }
 
 func TestNewVSphere(t *testing.T) {
-	cfg, ok := vcfg.ConfigFromEnv()
+	cfg := vcfg.Config{}
+
+	ok := vcfg.ConfigFromEnv(&cfg)
 	if !ok {
 		t.Skipf("No config found in environment")
 	}
@@ -455,7 +458,8 @@ func TestSecretVSphereConfig(t *testing.T) {
 
 	for _, testcase := range testcases {
 		t.Logf("Executing Testcase: %s", testcase.testName)
-		cfg, err := vcfg.ReadConfig(strings.NewReader(testcase.conf))
+		cfg := vcfg.Config{}
+		err := vcfg.ReadConfig(&cfg, strings.NewReader(testcase.conf))
 		if err != nil {
 			t.Fatalf("readConfig: Should succeed when a valid config is provided: %v", err)
 		}

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/golang/glog"
 
-	"gopkg.in/gcfg.v1"
+	gcfg "gopkg.in/gcfg.v1"
 )
 
 const (
@@ -79,7 +79,12 @@ func getEnvKeyValue(match string, partial bool) (string, string, error) {
 }
 
 //ConfigFromEnv allows setting configuration via environment variables.
-func ConfigFromEnv() (cfg Config, ok bool) {
+func ConfigFromEnv(cfg *Config) (ok bool) {
+	if cfg == nil {
+		ok = false
+		return
+	}
+
 	var err error
 
 	//Init
@@ -336,19 +341,22 @@ func fixUpConfigFromFile(cfg *Config) error {
 }
 
 //ReadConfig parses vSphere cloud config file and stores it into VSphereConfig.
-func ReadConfig(config io.Reader) (Config, error) {
-	if config == nil {
-		return Config{}, fmt.Errorf("no vSphere cloud provider config file given")
+func ReadConfig(cfg *Config, reader io.Reader) error {
+	if reader == nil {
+		return fmt.Errorf("no vSphere cloud provider config file given")
+	}
+	if cfg == nil {
+		return fmt.Errorf("no vSphere cloud provider config given")
 	}
 
-	cfg, _ := ConfigFromEnv()
+	_ = ConfigFromEnv(cfg)
 
-	err := gcfg.FatalOnly(gcfg.ReadInto(&cfg, config))
+	err := gcfg.FatalOnly(gcfg.ReadInto(cfg, reader))
 	if err != nil {
-		return cfg, err
+		return err
 	}
 
-	err = fixUpConfigFromFile(&cfg)
+	err = fixUpConfigFromFile(cfg)
 
-	return cfg, err
+	return err
 }

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -22,12 +22,18 @@ import (
 )
 
 func TestReadConfigGlobal(t *testing.T) {
-	_, err := ReadConfig(nil)
+	cfg := Config{}
+
+	err := ReadConfig(&cfg, nil)
+	if err == nil {
+		t.Errorf("Should fail when no config file is provided: %s", err)
+	}
+	err = ReadConfig(nil, strings.NewReader(""))
 	if err == nil {
 		t.Errorf("Should fail when no config is provided: %s", err)
 	}
 
-	cfg, err := ReadConfig(strings.NewReader(`
+	err = ReadConfig(&cfg, strings.NewReader(`
 [Global]
 server = 0.0.0.0
 port = 443

--- a/pkg/csi/service/service.go
+++ b/pkg/csi/service/service.go
@@ -113,7 +113,8 @@ func (s *service) BeforeServe(
 			log.Errorf("Failed to open %s. Err: %v", cfgPath, err)
 			return err
 		}
-		cfg, err := vcfg.ReadConfig(config)
+		cfg := vcfg.Config{}
+		err = vcfg.ReadConfig(&cfg, config)
 		if err != nil {
 			log.Errorf("Failed to parse config. Err: %v", err)
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor pkg/common/config to allow for specialization or customization of a config file based on the components need. This allows a component to have a configuration that only pertains to it without requiring other components config to be aware of it.

An example of how this could be done is by creating a Config object that wraps the common one:
```
import (
 vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config
)

struct MyComponent {
  vcfg.Config
  OtherField string
}
```

**Which issue this PR fixes**: NA

**Special notes for your reviewer**:
Was tested on:
k8s 1.13.1 cluster with 10 worker nodes
vSphere 6.7u1
Used a multiple vCenters (2 to be exact) with multiple Datacenters (3 to be exact)

**Release note**:
This is only a refactor of existing code and the changes to CCM and CSI functionality does not impact the end user, documentation, or etc.