### PR TITLE
Implement Zone Support on CCM

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -493,7 +493,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b7bca6301bab2a5f5da81f3b39756b98f6de92989585c9b13b6ad5c172d3166a"
+  digest = "1:324f1888e6b2dcfa1efa164ae9a874e77b40ac5f785e2eb548d3ae86f502731f"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
@@ -521,6 +521,10 @@
     "sts/simulator",
     "task",
     "units",
+    "vapi/internal",
+    "vapi/rest",
+    "vapi/simulator",
+    "vapi/tags",
     "view",
     "vim25",
     "vim25/debug",
@@ -1216,6 +1220,9 @@
     "github.com/vmware/govmomi/sts",
     "github.com/vmware/govmomi/sts/simulator",
     "github.com/vmware/govmomi/units",
+    "github.com/vmware/govmomi/vapi/rest",
+    "github.com/vmware/govmomi/vapi/simulator",
+    "github.com/vmware/govmomi/vapi/tags",
     "github.com/vmware/govmomi/view",
     "github.com/vmware/govmomi/vim25",
     "github.com/vmware/govmomi/vim25/methods",

--- a/docs/deploying_cloud_provider_vsphere_with_rbac.md
+++ b/docs/deploying_cloud_provider_vsphere_with_rbac.md
@@ -19,6 +19,18 @@ Steps that will be covered in deploying `cloud-provider-vsphere`:
 
 This is already covered in the Kubernetes documentation. Please take a look at configuration guidelines located [here](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager).
 
+> **NOTE**: According to the above documentation, enabling the external provider should automatically add a taint `node.cloudprovider.kubernetes.io/uninitialized` with an effect `NoSchedule` during initialization. This may not occur leading to partially initialized nodes. If this occurs, the taint can manually be applied *BEFORE* launching the cloud controller manager by running the following command:
+
+```bash
+[k8suser@k8master ~]$ kubectl taint nodes YOUR_NODE_NAME node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
+```
+
+> **NOTE**: To remove the taint above, the following command can be executed:
+
+```bash
+[k8suser@k8master ~]$ kubectl taint nodes YOUR_NODE_NAME node.cloudprovider.kubernetes.io/uninitialized:NoSchedule-
+```
+
 #### 2. Creating a `configmap` of your vSphere configuration
 
 There are 2 methods for configuring the `cloud-provider-vsphere`:

--- a/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
@@ -42,44 +42,15 @@ spec:
             - --v=2
             - --cloud-provider=vsphere
             - --cloud-config=/etc/cloud/vsphere.conf
-            - --kubeconfig=/etc/kubernetes/controller-manager.conf
-            - --address=127.0.0.1
           volumeMounts:
-            - mountPath: /etc/kubernetes/pki
-              name: k8s-certs
-              readOnly: true
-            - mountPath: /etc/ssl/certs
-              name: ca-certs
-              readOnly: true
-            - mountPath: /etc/kubernetes/controller-manager.conf
-              name: kubeconfig
-              readOnly: true
             - mountPath: /etc/cloud
               name: vsphere-config-volume
               readOnly: true
-            - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-              name: flexvolume-dir
           resources:
             requests:
               cpu: 200m
       hostNetwork: true
       volumes:
-      - hostPath:
-          path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-          type: DirectoryOrCreate
-        name: flexvolume-dir
-      - hostPath:
-          path: /etc/kubernetes/pki
-          type: DirectoryOrCreate
-        name: k8s-certs
-      - hostPath:
-          path: /etc/ssl/certs
-          type: DirectoryOrCreate
-        name: ca-certs
-      - hostPath:
-          path: /etc/kubernetes/controller-manager.conf
-          type: FileOrCreate
-        name: kubeconfig
       - name: vsphere-config-volume
         configMap:
           name: cloud-config

--- a/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
@@ -24,21 +24,7 @@ spec:
         - --v=2
         - --cloud-config=/etc/cloud/vsphere.conf
         - --cloud-provider=vsphere
-        - --use-service-account-credentials=true
-        - --address=127.0.0.1
-        - --kubeconfig=/etc/kubernetes/controller-manager.conf
       volumeMounts:
-        - mountPath: /etc/kubernetes/pki
-          name: k8s-certs
-          readOnly: true
-        - mountPath: /etc/ssl/certs
-          name: ca-certs
-          readOnly: true
-        - mountPath: /etc/kubernetes/controller-manager.conf
-          name: kubeconfig
-          readOnly: true
-        - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-          name: flexvolume-dir
         - mountPath: /etc/cloud
           name: cloud-config-volume
           readOnly: true
@@ -50,22 +36,6 @@ spec:
     runAsUser: 1001
   serviceAccountName: cloud-controller-manager
   volumes:
-  - hostPath:
-      path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
-      type: DirectoryOrCreate
-    name: flexvolume-dir
-  - hostPath:
-      path: /etc/kubernetes/pki
-      type: DirectoryOrCreate
-    name: k8s-certs
-  - hostPath:
-      path: /etc/ssl/certs
-      type: DirectoryOrCreate
-    name: ca-certs
-  - hostPath:
-      path: /etc/kubernetes/controller-manager.conf
-      type: FileOrCreate
-    name: kubeconfig
   - name: cloud-config-volume
     configMap:
       name: cloud-config

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -91,16 +91,18 @@ func (vs *VSphere) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 }
 
 func (vs *VSphere) Instances() (cloudprovider.Instances, bool) {
+	glog.V(1).Info("Enabling Instances interface on vSphere cloud provider")
 	return vs.instances, true
 }
 
 func (vs *VSphere) Zones() (cloudprovider.Zones, bool) {
-	glog.V(1).Info("The vSphere cloud provider does not support zones")
-	return nil, false
+	glog.V(1).Info("Enabling Zones interface on vSphere cloud provider")
+	return vs.zones, true
 }
 
 func (vs *VSphere) Clusters() (cloudprovider.Clusters, bool) {
-	return nil, true
+	glog.V(1).Info("The vSphere cloud provider does not support clusters")
+	return nil, false
 }
 
 func (vs *VSphere) Routes() (cloudprovider.Routes, bool) {
@@ -135,6 +137,7 @@ func buildVSphereFromConfig(cfg vcfg.Config) (*VSphere, error) {
 		cfg:         &cfg,
 		nodeManager: &nm,
 		instances:   newInstances(&nm),
+		zones:       newZones(&nm, cfg.Labels.Zone, cfg.Labels.Region),
 		server:      server.NewServer(cfg.Global.APIBinding, nodeMgr),
 	}
 	return &vs, nil

--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -19,7 +19,6 @@ package vsphere
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
@@ -28,8 +27,6 @@ import (
 )
 
 const (
-	ProviderPrefix string = "vsphere://"
-
 	//CredentialManagerErrMsg = "The Credential Manager is not initialized"
 	NodeNotFoundErrMsg = "Node not found"
 )
@@ -74,7 +71,7 @@ func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 	glog.V(4).Info("instances.NodeAddressesByProviderID() called with ", providerID)
 
 	// Check if node has been discovered already
-	uid := i.getUUIDFromProviderID(providerID)
+	uid := GetUUIDFromProviderID(providerID)
 	if node, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
 		glog.V(2).Info("instances.NodeAddressesByProviderID() CACHED with ", uid)
 		return node.NodeAddresses, nil
@@ -149,7 +146,7 @@ func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID s
 	glog.V(4).Info("instances.InstanceExistsByProviderID() called with ", providerID)
 
 	// Check if node has been discovered already
-	uid := i.getUUIDFromProviderID(providerID)
+	uid := GetUUIDFromProviderID(providerID)
 	if _, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
 		glog.V(2).Info("instances.InstanceExistsByProviderID() CACHED with ", uid)
 		return true, nil
@@ -168,8 +165,4 @@ func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID s
 func (i *instances) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
 	glog.V(4).Info("instances.InstanceShutdownByProviderID() called")
 	return false, cloudprovider.NotImplemented
-}
-
-func (i *instances) getUUIDFromProviderID(providerID string) string {
-	return strings.TrimPrefix(providerID, ProviderPrefix)
 }

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -55,7 +55,7 @@ func TestRegUnregNode(t *testing.T) {
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name
 	UUID := vm.Config.Uuid
-	k8sUUID := nm.convertK8sUUIDtoNormal(UUID)
+	k8sUUID := ConvertK8sUUIDtoNormal(UUID)
 
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -151,30 +151,6 @@ func TestDiscoverNodeByName(t *testing.T) {
 	}
 }
 
-func TestUUIDConvert1(t *testing.T) {
-	k8sUUID := "56492e42-22ad-3911-6d72-59cc8f26bc90"
-
-	nm := NodeManager{}
-
-	biosUUID := nm.convertK8sUUIDtoNormal(k8sUUID)
-
-	if biosUUID != "422e4956-ad22-1139-6d72-59cc8f26bc90" {
-		t.Errorf("Failed to translate UUID")
-	}
-}
-
-func TestUUIDConvert2(t *testing.T) {
-	k8sUUID := "422e4956-ad22-1139-6d72-59cc8f26bc90"
-
-	nm := NodeManager{}
-
-	biosUUID := nm.convertK8sUUIDtoNormal(k8sUUID)
-
-	if biosUUID != "56492e42-22ad-3911-6d72-59cc8f26bc90" {
-		t.Errorf("Failed to translate UUID")
-	}
-}
-
 func TestExport(t *testing.T) {
 	cfg, ok := configFromEnvOrSim()
 	defer ok()
@@ -197,7 +173,7 @@ func TestExport(t *testing.T) {
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name
 	UUID := vm.Config.Uuid
-	k8sUUID := nm.convertK8sUUIDtoNormal(UUID)
+	k8sUUID := ConvertK8sUUIDtoNormal(UUID)
 
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cloudprovider/vsphere/server/server.go
+++ b/pkg/cloudprovider/vsphere/server/server.go
@@ -47,7 +47,6 @@ type server struct {
 // ListNodes implements CloudProviderVsphere interface
 func (s *server) ListNodes(ctx context.Context, request *pb.ListNodesRequest) (*pb.ListNodesReply, error) {
 	reply := &pb.ListNodesReply{
-
 		Nodes: make([]*pb.Node, 0),
 	}
 	//Do not allow specifying the Datacenter without specifying the vCenter

--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -41,6 +41,7 @@ type VSphere struct {
 	nodeManager       *NodeManager
 	informMgr         *k8s.InformerManager
 	instances         cloudprovider.Instances
+	zones             cloudprovider.Zones
 	server            GRPCServer
 }
 
@@ -85,4 +86,10 @@ type NodeManager struct {
 
 type instances struct {
 	nodeManager *NodeManager
+}
+
+type zones struct {
+	nodeManager *NodeManager
+	zone        string
+	region      string
 }

--- a/pkg/cloudprovider/vsphere/util.go
+++ b/pkg/cloudprovider/vsphere/util.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	ProviderPrefix = "vsphere://"
+)
+
+func GetUUIDFromProviderID(providerID string) string {
+	return strings.TrimPrefix(providerID, ProviderPrefix)
+}
+
+// Reformats UUID to match vSphere format
+// Endian Safe : https://www.dmtf.org/standards/smbios/
+//            8   -  4 -  4 - 4  -    12
+//K8s:    56492e42-22ad-3911-6d72-59cc8f26bc90
+//VMware: 422e4956-ad22-1139-6d72-59cc8f26bc90
+func ConvertK8sUUIDtoNormal(k8sUUID string) string {
+	uuid := fmt.Sprintf("%s%s%s%s-%s%s-%s%s-%s-%s",
+		k8sUUID[6:8], k8sUUID[4:6], k8sUUID[2:4], k8sUUID[0:2],
+		k8sUUID[11:13], k8sUUID[9:11],
+		k8sUUID[16:18], k8sUUID[14:16],
+		k8sUUID[19:23],
+		k8sUUID[24:36])
+	return strings.ToLower(uuid)
+}

--- a/pkg/cloudprovider/vsphere/util_test.go
+++ b/pkg/cloudprovider/vsphere/util_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"testing"
+)
+
+func TestUUIDConvert1(t *testing.T) {
+	k8sUUID := "56492e42-22ad-3911-6d72-59cc8f26bc90"
+
+	biosUUID := ConvertK8sUUIDtoNormal(k8sUUID)
+
+	if biosUUID != "422e4956-ad22-1139-6d72-59cc8f26bc90" {
+		t.Errorf("Failed to translate UUID")
+	}
+}
+
+func TestUUIDConvert2(t *testing.T) {
+	k8sUUID := "422e4956-ad22-1139-6d72-59cc8f26bc90"
+
+	biosUUID := ConvertK8sUUIDtoNormal(k8sUUID)
+
+	if biosUUID != "56492e42-22ad-3911-6d72-59cc8f26bc90" {
+		t.Errorf("Failed to translate UUID")
+	}
+}

--- a/pkg/cloudprovider/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/vsphere/vsphere_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/simulator/vpx"
 	sts "github.com/vmware/govmomi/sts/simulator"
+	vapi "github.com/vmware/govmomi/vapi/simulator"
 
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
 	cm "k8s.io/cloud-provider-vsphere/pkg/common/connectionmanager"
@@ -81,6 +82,10 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool) (vcfg.Con
 
 	// STS simulator
 	path, handler := sts.New(s.URL, vpx.Setting)
+	model.Service.ServeMux.Handle(path, handler)
+
+	// vAPI simulator
+	path, handler = vapi.New(s.URL, nil)
 	model.Service.ServeMux.Handle(path, handler)
 
 	// Lookup Service simulator

--- a/pkg/cloudprovider/vsphere/zones.go
+++ b/pkg/cloudprovider/vsphere/zones.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25/mo"
+
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+func newZones(nodeManager *NodeManager, zone string, region string) cloudprovider.Zones {
+	return &zones{
+		nodeManager: nodeManager,
+		zone:        zone,
+		region:      region,
+	}
+}
+
+// GetZone implements Zones.GetZone for In-Tree providers
+func (z *zones) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
+	glog.V(4).Info("zones.GetZone() called")
+
+	nodeName, err := os.Hostname()
+	if err != nil {
+		glog.V(2).Info("Failed to get hostname. Err: ", err)
+		return cloudprovider.Zone{}, err
+	}
+
+	node, ok := z.nodeManager.nodeNameMap[nodeName]
+	if !ok {
+		glog.V(2).Info("zones.GetZone() NOT FOUND with ", nodeName)
+		return cloudprovider.Zone{}, ErrVMNotFound
+	}
+
+	return z.getZoneByVM(ctx, node)
+}
+
+// GetZone implements Zones.GetZone for In-Tree providers
+
+// GetZoneByNodeName implements Zones.GetZone for Out-Tree providers
+func (z *zones) GetZoneByNodeName(ctx context.Context, nodeName k8stypes.NodeName) (cloudprovider.Zone, error) {
+	glog.V(4).Info("zones.GetZoneByNodeName() called with ", string(nodeName))
+
+	node, ok := z.nodeManager.nodeNameMap[string(nodeName)]
+	if !ok {
+		glog.V(2).Info("zones.GetZoneByNodeName() NOT FOUND with ", string(nodeName))
+		return cloudprovider.Zone{}, ErrVMNotFound
+	}
+
+	return z.getZoneByVM(ctx, node)
+}
+
+// GetZoneByProviderID implements Zones.GetZone for Out-Tree providers
+func (z *zones) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
+	glog.V(4).Info("zones.GetZoneByProviderID() called with ", providerID)
+
+	uid := GetUUIDFromProviderID(providerID)
+
+	node, ok := z.nodeManager.nodeUUIDMap[uid]
+	if !ok {
+		glog.V(2).Info("zones.GetZoneByProviderID() NOT FOUND with ", uid)
+		return cloudprovider.Zone{}, ErrVMNotFound
+	}
+
+	return z.getZoneByVM(ctx, node)
+}
+
+func withTagsClient(ctx context.Context, connection *vclib.VSphereConnection, f func(c *rest.Client) error) error {
+	c := rest.NewClient(connection.Client)
+	user := url.UserPassword(connection.Username, connection.Password)
+	if err := c.Login(ctx, user); err != nil {
+		return err
+	}
+	defer c.Logout(ctx)
+	return f(c)
+}
+
+func (z *zones) getZoneByVM(ctx context.Context, node *NodeInfo) (cloudprovider.Zone, error) {
+	glog.V(4).Infof("getZoneByVM for %s on VC: %s in DC: %s", node.NodeName, node.vcServer, node.dataCenter.Name())
+
+	zone := cloudprovider.Zone{}
+
+	vmHost, err := node.vm.HostSystem(ctx)
+	if err != nil {
+		glog.Errorf("Failed to get host system for VM: %q. err: %+v", node.vm.InventoryPath, err)
+		return zone, err
+	}
+
+	var oHost mo.HostSystem
+	err = vmHost.Properties(ctx, vmHost.Reference(), []string{"summary"}, &oHost)
+	if err != nil {
+		glog.Errorf("Failed to get host system properties. err: %+v", err)
+		return zone, err
+	}
+	glog.V(4).Infof("Host owning VM is %s", oHost.Summary.Config.Name)
+
+	pc := node.vm.Client().ServiceContent.PropertyCollector
+	err = withTagsClient(ctx, z.nodeManager.connectionManager.VsphereInstanceMap[node.vcServer].Conn, func(c *rest.Client) error {
+		client := tags.NewManager(c)
+		// example result: ["Folder", "Datacenter", "Cluster", "Host"]
+		objects, err := mo.Ancestors(ctx, node.vm.Client(), pc, vmHost.Reference())
+		if err != nil {
+			return err
+		}
+
+		// search the hierarchy, example order: ["Host", "Cluster", "Datacenter", "Folder"]
+		for i := range objects {
+			obj := objects[len(objects)-1-i]
+			tags, err := client.ListAttachedTags(ctx, obj)
+			if err != nil {
+				glog.Errorf("Cannot list attached tags. Get zone for node %s: %s", node.NodeName, err)
+				return err
+			}
+			for _, value := range tags {
+				tag, err := client.GetTag(ctx, value)
+				if err != nil {
+					glog.Errorf("Zones Get tag %s: %s", value, err)
+					return err
+				}
+				category, err := client.GetCategory(ctx, tag.CategoryID)
+				if err != nil {
+					glog.Errorf("Zones Get category %s error", value)
+					return err
+				}
+
+				found := func() {
+					glog.Infof("Found %q tag (%s) for %s attached to %s", category.Name, tag.Name, node.UUID, obj.Reference())
+				}
+				switch {
+				case category.Name == z.zone:
+					zone.FailureDomain = tag.Name
+					found()
+				case category.Name == z.region:
+					zone.Region = tag.Name
+					found()
+				}
+
+				if zone.FailureDomain != "" && zone.Region != "" {
+					return nil
+				}
+			}
+		}
+
+		if zone.Region == "" {
+			if z.region != "" {
+				return fmt.Errorf("vSphere region category %q does not match any tags for node %s [%s]", z.region, node.NodeName, node.UUID)
+			}
+		}
+		if zone.FailureDomain == "" {
+			if z.zone != "" {
+				return fmt.Errorf("vSphere zone category %q does not match any tags for node %s [%s]", z.region, node.NodeName, node.UUID)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		glog.Errorf("Get zone for node %s: %s", node.NodeName, err)
+		return cloudprovider.Zone{}, err
+	}
+	return zone, nil
+}

--- a/pkg/cloudprovider/vsphere/zones_test.go
+++ b/pkg/cloudprovider/vsphere/zones_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25/mo"
+
+	cm "k8s.io/cloud-provider-vsphere/pkg/common/connectionmanager"
+	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
+)
+
+func TestZones(t *testing.T) {
+	// Any context will do
+	ctx := context.Background()
+
+	// Create a vcsim instance
+	cfg, close := configFromEnvOrSim()
+	defer close()
+
+	// Configure region and zone categories
+	cfg.Labels.Region = "k8s-region"
+	cfg.Labels.Zone = "k8s-zone"
+
+	// Create vSphere configuration object
+	vs, err := newVSphere(cfg)
+	if err != nil {
+		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
+	}
+	vs.connectionManager = cm.NewConnectionManager(&cfg, nil)
+	vs.nodeManager = newNodeManager(vs.connectionManager, nil)
+	vs.zones = newZones(vs.nodeManager, cfg.Labels.Zone, cfg.Labels.Region)
+
+	// Create vSphere client
+	err = vs.connectionManager.Connect(ctx, cfg.Global.VCenterIP)
+	if err != nil {
+		t.Errorf("Failed to connect to vSphere: %s", err)
+	}
+	vsi := vs.connectionManager.VsphereInstanceMap[cfg.Global.VCenterIP]
+
+	// Get a simulator VM
+	myvm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	name := myvm.Name
+	UUID := myvm.Config.Uuid
+	k8sUUID := ConvertK8sUUIDtoNormal(UUID)
+
+	// Get a simulator DC
+	mydc := simulator.Map.Any("Datacenter").(*simulator.Datacenter)
+
+	// Add the node to the NodeManager
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{
+				SystemUUID: k8sUUID,
+			},
+		},
+	}
+
+	vs.nodeManager.RegisterNode(node)
+
+	if len(vs.nodeManager.nodeNameMap) != 1 {
+		t.Fatalf("Failed: nodeNameMap should be a length of 1")
+	}
+	if len(vs.nodeManager.nodeUUIDMap) != 1 {
+		t.Fatalf("Failed: nodeUUIDMap should be a length of  1")
+	}
+	if len(vs.nodeManager.nodeRegUUIDMap) != 1 {
+		t.Fatalf("Failed: nodeRegUUIDMap should be a length of  1")
+	}
+
+	// Get vclib DC
+	dc, err := vclib.GetDatacenter(ctx, vsi.Conn, mydc.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Lookup vclib VM
+	vm, err := dc.GetVMByUUID(ctx, UUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Lookup vclib Host
+	host, err := vm.HostSystem(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Property Collector instance
+	pc := property.DefaultCollector(vsi.Conn.Client)
+
+	// Tag manager instance
+	m := tags.NewManager(rest.NewClient(vsi.Conn.Client))
+
+	// Create a region category
+	regionID, err := m.CreateCategory(ctx, &tags.Category{Name: vs.cfg.Labels.Region})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a region tag
+	regionID, err = m.CreateTag(ctx, &tags.Tag{CategoryID: regionID, Name: "k8s-region-US"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a zone category
+	zoneID, err := m.CreateCategory(ctx, &tags.Category{Name: vs.cfg.Labels.Zone})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a zone tag
+	zoneID, err = m.CreateTag(ctx, &tags.Tag{CategoryID: zoneID, Name: "k8s-zone-US-CA1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a random category
+	randomID, err := m.CreateCategory(ctx, &tags.Category{Name: "random-cat"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a random tag
+	randomID, err = m.CreateTag(ctx, &tags.Tag{CategoryID: randomID, Name: "random-tag"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach a random tag to VM's host
+	if err = m.AttachTag(ctx, randomID, host); err != nil {
+		t.Fatal(err)
+	}
+
+	// Expecting Zones() to return true, indicating VCP supports the Zones interface
+	zones, ok := vs.Zones()
+	if !ok {
+		t.Fatalf("zones=%t", ok)
+	}
+
+	// GetZone() tests, covering error and success paths
+	tests := []struct {
+		name string // name of the test for logging
+		fail bool   // expect GetZone() to return error if true
+		prep func() // prepare vCenter state for the test
+	}{
+		{"no tags", true, func() {
+			// no prep
+		}},
+		{"no zone tag", true, func() {
+			if err = m.AttachTag(ctx, regionID, host); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"host tags set", false, func() {
+			if err = m.AttachTag(ctx, zoneID, host); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"host tags removed", true, func() {
+			if err = m.DetachTag(ctx, zoneID, host); err != nil {
+				t.Fatal(err)
+			}
+			if err = m.DetachTag(ctx, regionID, host); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"dc region, cluster zone", false, func() {
+			var h mo.HostSystem
+			if err = pc.RetrieveOne(ctx, host.Reference(), []string{"parent"}, &h); err != nil {
+				t.Fatal(err)
+			}
+			// Attach region tag to Datacenter
+			if err = m.AttachTag(ctx, regionID, dc); err != nil {
+				t.Fatal(err)
+			}
+			// Attach zone tag to Cluster
+			if err = m.AttachTag(ctx, zoneID, h.Parent); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	}
+
+	for _, test := range tests {
+		test.prep()
+
+		zone, err := zones.GetZoneByProviderID(ctx, UUID)
+		if test.fail {
+			if err == nil {
+				t.Errorf("%s: expected error", test.name)
+			} else {
+				t.Logf("%s: expected error=%s", test.name, err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%s: %s", test.name, err)
+			}
+			t.Logf("zone=%#v", zone)
+		}
+	}
+}

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -154,6 +154,9 @@ func ConfigFromEnv() (cfg Config, ok bool) {
 	cfg.Global.CAFile = os.Getenv("VSPHERE_CAFILE")
 	cfg.Global.Thumbprint = os.Getenv("VSPHERE_THUMBPRINT")
 
+	cfg.Labels.Region = os.Getenv("VSPHERE_LABEL_REGION")
+	cfg.Labels.Zone = os.Getenv("VSPHERE_LABEL_ZONE")
+
 	//Build VirtualCenter from ENVs
 	for _, e := range os.Environ() {
 		pair := strings.Split(e, "=")

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -58,7 +58,15 @@ type Config struct {
 		// Default: 43001
 		APIBinding string `gcfg:"api-binding"`
 	}
+
+	// Virtual Center configurations
 	VirtualCenter map[string]*VirtualCenterConfig
+
+	// Tag categories and tags which correspond to "built-in node labels: zones and region"
+	Labels struct {
+		Zone   string `gcfg:"zone"`
+		Region string `gcfg:"region"`
+	}
 }
 
 // Structure that represents Virtual Center configuration

--- a/pkg/common/vclib/custom_errors.go
+++ b/pkg/common/vclib/custom_errors.go
@@ -26,6 +26,7 @@ const (
 	InvalidVolumeOptionsErrMsg = "VolumeOptions verification failed"
 	NoVMFoundErrMsg            = "No VM found"
 	NoDatastoreFoundErrMsg     = "Datastore not found"
+	NoDatacenterFoundErrMsg    = "Datacenter not found"
 )
 
 // Error constants
@@ -36,4 +37,5 @@ var (
 	ErrInvalidVolumeOptions = errors.New(InvalidVolumeOptionsErrMsg)
 	ErrNoVMFound            = errors.New(NoVMFoundErrMsg)
 	ErrNoDatastoreFound     = errors.New(NoDatastoreFoundErrMsg)
+	ErrNoDatacenterFound    = errors.New(NoDatacenterFoundErrMsg)
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This implements the zone support that currently exists within the in-tree provider.

Additional notes:
- Updates to the documentation to note atypical behaviors.
- Removed sections of YAML that were overriding permissions of the service account used for CCM that was causing the zones functionality to not work. It turns out these sections aren't required anyways.
- Moved GetUUIDFromProviderID and ConvertK8sUUIDtoNormal out of NodeManager to a common util file so that other code can use without requiring an instance of NodeManager.
- Fixed bug in NodeManager which was causing intermittent failure of zones discovery in a multi-vCenter configuration. Side effect was that the wrong VC address would be assigned/associated to a given node. Fix is moving the declaration of `var datacenterObjs []*vclib.Datacenter` to adjust its scope. Turns out this issue also exists in the in-tree provider. Will file a separate PR for k/k.

**Which issue this PR fixes**:
https://github.com/kubernetes/cloud-provider-vsphere/issues/36

**Special notes for your reviewer**:
Tested CCM on:
k8s 1.13.2 cluster with 10 worker nodes in 3 zones
vSphere 6.7u1
Deployed a test pod which targeted a particular zone
Used a multiple vCenters (2 to be exact) with multiple Datacenters (3 to be exact)
`make test` passes

**Release note**:
For any tests (like e2e or etc), the removal of sections of YAML is important for the zones functionality. Please take note of these changes.