### PR TITLE
Remove K8s 1.10 / add 1.13 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,8 @@ jobs:
 
     # Out-of-tree conformance tests (plus the initial definition above)
     - <<: *conformance-test-stage
+      env: CCM=true K8S_VERSION=release/latest-1.13 CLUSTER_NAME=v1-13 GCS_PATH=release/v1.13 EVENT_TYPE='^(push|cron)$' COMMIT_TRIGGER_YES='\/ci-ccm-conformance' COMMIT_TRIGGER_NO='\/ci-ccm-noconformance'
+    - <<: *conformance-test-stage
       env: CCM=true K8S_VERSION=release/latest-1.12 CLUSTER_NAME=v1-12 GCS_PATH=release/v1.12 EVENT_TYPE='^(push|cron)$' COMMIT_TRIGGER_YES='\/ci-ccm-conformance' COMMIT_TRIGGER_NO='\/ci-ccm-noconformance'
     - <<: *conformance-test-stage
       env: CCM=true K8S_VERSION=release/latest-1.11 CLUSTER_NAME=v1-11 GCS_PATH=release/v1.11 EVENT_TYPE='^(push|cron)$' COMMIT_TRIGGER_YES='\/ci-ccm-conformance' COMMIT_TRIGGER_NO='\/ci-ccm-noconformance'
@@ -111,6 +113,8 @@ jobs:
     # In-tree conformance tests
     - <<: *conformance-test-stage
       env: CCM=false K8S_VERSION=ci/latest CLUSTER_NAME=ci-latest GCS_PATH=ci/latest EVENT_TYPE='^cron$' COMMIT_TRIGGER_YES='\/ci-conformance' COMMIT_TRIGGER_NO='\/ci-noconformance'
+    - <<: *conformance-test-stage
+      env: CCM=false K8S_VERSION=release/latest-1.13 CLUSTER_NAME=v1-13 GCS_PATH=release/v1.13 EVENT_TYPE='^cron$' COMMIT_TRIGGER_YES='\/ci-conformance' COMMIT_TRIGGER_NO='\/ci-noconformance'
     - <<: *conformance-test-stage
       env: CCM=false K8S_VERSION=release/latest-1.12 CLUSTER_NAME=v1-12 GCS_PATH=release/v1.12 EVENT_TYPE='^cron$' COMMIT_TRIGGER_YES='\/ci-conformance' COMMIT_TRIGGER_NO='\/ci-noconformance'
     - <<: *conformance-test-stage

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,8 +107,6 @@ jobs:
       env: CCM=true K8S_VERSION=release/latest-1.12 CLUSTER_NAME=v1-12 GCS_PATH=release/v1.12 EVENT_TYPE='^(push|cron)$' COMMIT_TRIGGER_YES='\/ci-ccm-conformance' COMMIT_TRIGGER_NO='\/ci-ccm-noconformance'
     - <<: *conformance-test-stage
       env: CCM=true K8S_VERSION=release/latest-1.11 CLUSTER_NAME=v1-11 GCS_PATH=release/v1.11 EVENT_TYPE='^(push|cron)$' COMMIT_TRIGGER_YES='\/ci-ccm-conformance' COMMIT_TRIGGER_NO='\/ci-ccm-noconformance'
-    - <<: *conformance-test-stage
-      env: CCM=true K8S_VERSION=release/latest-1.10 CLUSTER_NAME=v1-10 GCS_PATH=release/v1.10 EVENT_TYPE='^(push|cron)$' COMMIT_TRIGGER_YES='\/ci-ccm-conformance' COMMIT_TRIGGER_NO='\/ci-ccm-noconformance'
 
     # In-tree conformance tests
     - <<: *conformance-test-stage
@@ -117,5 +115,3 @@ jobs:
       env: CCM=false K8S_VERSION=release/latest-1.12 CLUSTER_NAME=v1-12 GCS_PATH=release/v1.12 EVENT_TYPE='^cron$' COMMIT_TRIGGER_YES='\/ci-conformance' COMMIT_TRIGGER_NO='\/ci-noconformance'
     - <<: *conformance-test-stage
       env: CCM=false K8S_VERSION=release/latest-1.11 CLUSTER_NAME=v1-11 GCS_PATH=release/v1.11 EVENT_TYPE='^cron$' COMMIT_TRIGGER_YES='\/ci-conformance' COMMIT_TRIGGER_NO='\/ci-noconformance'
-    - <<: *conformance-test-stage
-      env: CCM=false K8S_VERSION=release/latest-1.10 CLUSTER_NAME=v1-10 GCS_PATH=release/v1.10 EVENT_TYPE='^cron$' COMMIT_TRIGGER_YES='\/ci-conformance' COMMIT_TRIGGER_NO='\/ci-noconformance'


### PR DESCRIPTION
This PR removes Kubernetes 1.10 from the list of GA releases tested against `master` and with the nightly cron job. In its place K8s 1.13 has been added. The prevailing CI strategy is to test `ci/latest` and the three, previous GA release trains, which are currently `1.13`, `1.12`, and `1.11`.

cc @figo