### PR TITLE
Switch from using glog to klog

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1086,6 +1086,14 @@
   version = "kubernetes-1.11.0"
 
 [[projects]]
+  digest = "1:72fd56341405f53c745377e0ebc4abeff87f1a048e0eea6568a20212650f5a82"
+  name = "k8s.io/klog"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "71442cd4037d612096940ceb0f3fec3f7fff66e0"
+  version = "v0.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:a8a0fdd623b2a37c433d137bddfab6b155e988efbc7cd68c18f9923dce6c8742"
   name = "k8s.io/kube-openapi"
@@ -1197,7 +1205,6 @@
   input-imports = [
     "github.com/akutz/gofsutil",
     "github.com/container-storage-interface/spec/lib/go/csi",
-    "github.com/golang/glog",
     "github.com/golang/protobuf/proto",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/rexray/gocsi",
@@ -1252,6 +1259,7 @@
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/klog",
     "k8s.io/kubernetes/cmd/cloud-controller-manager/app",
     "k8s.io/kubernetes/cmd/cloud-controller-manager/app/options",
     "k8s.io/kubernetes/pkg/apis/core/v1/helper",

--- a/cmd/vsphere-cloud-controller-manager/main.go
+++ b/cmd/vsphere-cloud-controller-manager/main.go
@@ -38,7 +38,7 @@ import (
 
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -90,7 +90,7 @@ the cloud specific control loops shipped with Kubernetes.`,
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	glog.V(1).Infof("vsphere-cloud-controller-manager version: %s", version)
+	klog.V(1).Infof("vsphere-cloud-controller-manager version: %s", version)
 
 	s.CloudProvider.Name = vsphere.ProviderName
 	if err := command.Execute(); err != nil {

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -20,7 +20,7 @@ import (
 	"io"
 	"runtime"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/cloudprovider"
@@ -62,7 +62,7 @@ func newVSphere(cfg vcfg.Config, finalize ...bool) (*VSphere, error) {
 func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) {
 	client, err := clientBuilder.Client(vs.cfg.Global.ServiceAccount)
 	if err == nil {
-		glog.V(1).Info("Kubernetes Client Init Succeeded")
+		klog.V(1).Info("Kubernetes Client Init Succeeded")
 
 		vs.informMgr = k8s.NewInformer(&client)
 
@@ -75,38 +75,38 @@ func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) 
 		vs.informMgr.Listen()
 
 		if !vs.cfg.Global.APIDisable {
-			glog.V(1).Info("Starting the API Server")
+			klog.V(1).Info("Starting the API Server")
 			vs.server.Start()
 		} else {
-			glog.V(1).Info("API Server is disabled")
+			klog.V(1).Info("API Server is disabled")
 		}
 	} else {
-		glog.Errorf("Kubernetes Client Init Failed: %v", err)
+		klog.Errorf("Kubernetes Client Init Failed: %v", err)
 	}
 }
 
 func (vs *VSphere) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
-	glog.V(1).Info("The vSphere cloud provider does not support load balancers")
+	klog.V(1).Info("The vSphere cloud provider does not support load balancers")
 	return nil, false
 }
 
 func (vs *VSphere) Instances() (cloudprovider.Instances, bool) {
-	glog.V(1).Info("Enabling Instances interface on vSphere cloud provider")
+	klog.V(1).Info("Enabling Instances interface on vSphere cloud provider")
 	return vs.instances, true
 }
 
 func (vs *VSphere) Zones() (cloudprovider.Zones, bool) {
-	glog.V(1).Info("Enabling Zones interface on vSphere cloud provider")
+	klog.V(1).Info("Enabling Zones interface on vSphere cloud provider")
 	return vs.zones, true
 }
 
 func (vs *VSphere) Clusters() (cloudprovider.Clusters, bool) {
-	glog.V(1).Info("The vSphere cloud provider does not support clusters")
+	klog.V(1).Info("The vSphere cloud provider does not support clusters")
 	return nil, false
 }
 
 func (vs *VSphere) Routes() (cloudprovider.Routes, bool) {
-	glog.V(1).Info("The vSphere cloud provider does not support routes")
+	klog.V(1).Info("The vSphere cloud provider does not support routes")
 	return nil, false
 }
 
@@ -151,7 +151,7 @@ func logout(vs *VSphere) {
 func (vs *VSphere) nodeAdded(obj interface{}) {
 	node, ok := obj.(*v1.Node)
 	if node == nil || !ok {
-		glog.Warningf("nodeAdded: unrecognized object %+v", obj)
+		klog.Warningf("nodeAdded: unrecognized object %+v", obj)
 		return
 	}
 
@@ -162,7 +162,7 @@ func (vs *VSphere) nodeAdded(obj interface{}) {
 func (vs *VSphere) nodeDeleted(obj interface{}) {
 	node, ok := obj.(*v1.Node)
 	if node == nil || !ok {
-		glog.Warningf("nodeDeleted: unrecognized object %+v", obj)
+		klog.Warningf("nodeDeleted: unrecognized object %+v", obj)
 		return
 	}
 

--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider"
@@ -47,24 +47,24 @@ func newInstances(nodeManager *NodeManager) cloudprovider.Instances {
 // When nodeName identifies more than one instance, only the first will be
 // considered.
 func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v1.NodeAddress, error) {
-	glog.V(4).Info("instances.NodeAddresses() called with ", string(nodeName))
+	klog.V(4).Info("instances.NodeAddresses() called with ", string(nodeName))
 
 	// Check if node has been discovered already
 	if node, ok := i.nodeManager.nodeNameMap[string(nodeName)]; ok {
-		glog.V(2).Info("instances.NodeAddresses() CACHED with ", string(nodeName))
+		klog.V(2).Info("instances.NodeAddresses() CACHED with ", string(nodeName))
 		return node.NodeAddresses, nil
 	}
 
 	if err := i.nodeManager.DiscoverNode(string(nodeName), FindVMByName); err == nil {
 		if i.nodeManager.nodeNameMap[string(nodeName)] == nil {
-			glog.Errorf("DiscoverNode succeeded, but CACHE missed for node=%s. If this is a Linux VM, hostnames are case sensitive. Make sure they match.", string(nodeName))
+			klog.Errorf("DiscoverNode succeeded, but CACHE missed for node=%s. If this is a Linux VM, hostnames are case sensitive. Make sure they match.", string(nodeName))
 			return []v1.NodeAddress{}, ErrNodeNotFound
 		}
-		glog.V(2).Info("instances.NodeAddresses() FOUND with ", string(nodeName))
+		klog.V(2).Info("instances.NodeAddresses() FOUND with ", string(nodeName))
 		return i.nodeManager.nodeNameMap[string(nodeName)].NodeAddresses, nil
 	}
 
-	glog.V(4).Info("instances.NodeAddresses() NOT FOUND with ", string(nodeName))
+	klog.V(4).Info("instances.NodeAddresses() NOT FOUND with ", string(nodeName))
 	return []v1.NodeAddress{}, ErrNodeNotFound
 }
 
@@ -72,21 +72,21 @@ func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) 
 // identified by providerID. Only the public/private IPv4 addresses will be
 // considered for now.
 func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
-	glog.V(4).Info("instances.NodeAddressesByProviderID() called with ", providerID)
+	klog.V(4).Info("instances.NodeAddressesByProviderID() called with ", providerID)
 
 	// Check if node has been discovered already
 	uid := GetUUIDFromProviderID(providerID)
 	if node, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
-		glog.V(2).Info("instances.NodeAddressesByProviderID() CACHED with ", uid)
+		klog.V(2).Info("instances.NodeAddressesByProviderID() CACHED with ", uid)
 		return node.NodeAddresses, nil
 	}
 
 	if err := i.nodeManager.DiscoverNode(uid, FindVMByUUID); err == nil {
-		glog.V(2).Info("instances.NodeAddressesByProviderID() FOUND with ", uid)
+		klog.V(2).Info("instances.NodeAddressesByProviderID() FOUND with ", uid)
 		return i.nodeManager.nodeUUIDMap[uid].NodeAddresses, nil
 	}
 
-	glog.V(4).Info("instances.NodeAddressesByProviderID() NOT FOUND with ", uid)
+	klog.V(4).Info("instances.NodeAddressesByProviderID() NOT FOUND with ", uid)
 	return []v1.NodeAddress{}, ErrNodeNotFound
 }
 
@@ -97,80 +97,80 @@ func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 // When nodeName identifies more than one instance, only the first will be
 // considered.
 func (i *instances) ExternalID(ctx context.Context, nodeName types.NodeName) (string, error) {
-	glog.V(4).Info("instances.ExternalID() called with ", nodeName)
+	klog.V(4).Info("instances.ExternalID() called with ", nodeName)
 	return i.InstanceID(ctx, nodeName)
 }
 
 // InstanceID returns the cloud provider ID of the instance identified by nodeName.
 func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
-	glog.V(4).Info("instances.InstanceID() called with ", nodeName)
+	klog.V(4).Info("instances.InstanceID() called with ", nodeName)
 
 	// Check if node has been discovered already
 	if node, ok := i.nodeManager.nodeNameMap[string(nodeName)]; ok {
-		glog.V(2).Info("instances.InstanceID() CACHED with ", string(nodeName))
+		klog.V(2).Info("instances.InstanceID() CACHED with ", string(nodeName))
 		return node.UUID, nil
 	}
 
 	if err := i.nodeManager.DiscoverNode(string(nodeName), FindVMByName); err == nil {
 		if i.nodeManager.nodeNameMap[string(nodeName)] == nil {
-			glog.Errorf("DiscoverNode succeeded, but CACHE missed for node=%s. If this is a Linux VM, hostnames are case sensitive. Make sure they match.", string(nodeName))
+			klog.Errorf("DiscoverNode succeeded, but CACHE missed for node=%s. If this is a Linux VM, hostnames are case sensitive. Make sure they match.", string(nodeName))
 			return "", ErrNodeNotFound
 		}
-		glog.V(2).Infof("instances.InstanceID() FOUND with %s", string(nodeName))
+		klog.V(2).Infof("instances.InstanceID() FOUND with %s", string(nodeName))
 		return i.nodeManager.nodeNameMap[string(nodeName)].UUID, nil
 	}
 
-	glog.V(4).Info("instances.InstanceID() NOT FOUND with ", string(nodeName))
+	klog.V(4).Info("instances.InstanceID() NOT FOUND with ", string(nodeName))
 	return "", ErrNodeNotFound
 }
 
 // InstanceType returns the type of the instance identified by name.
 func (i *instances) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
-	glog.V(4).Info("instances.InstanceType() called")
+	klog.V(4).Info("instances.InstanceType() called")
 	return "vsphere-vm", nil
 }
 
 // InstanceTypeByProviderID returns the type of the instance identified by providerID.
 func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
-	glog.V(4).Info("instances.InstanceTypeByProviderID() called")
+	klog.V(4).Info("instances.InstanceTypeByProviderID() called")
 	return "vsphere-vm", nil
 }
 
 // AddSSHKeyToAllInstances is not implemented; it always returns an error.
 func (i *instances) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
-	glog.V(4).Info("instances.AddSSHKeyToAllInstances() called")
+	klog.V(4).Info("instances.AddSSHKeyToAllInstances() called")
 	return cloudprovider.NotImplemented
 }
 
 // CurrentNodeName returns hostname as a NodeName value.
 func (i *instances) CurrentNodeName(ctx context.Context, hostname string) (types.NodeName, error) {
-	glog.V(4).Info("instances.CurrentNodeName() called")
+	klog.V(4).Info("instances.CurrentNodeName() called")
 	return types.NodeName(hostname), nil
 }
 
 // InstanceExistsByProviderID returns true if the instance identified by
 // providerID is running.
 func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
-	glog.V(4).Info("instances.InstanceExistsByProviderID() called with ", providerID)
+	klog.V(4).Info("instances.InstanceExistsByProviderID() called with ", providerID)
 
 	// Check if node has been discovered already
 	uid := GetUUIDFromProviderID(providerID)
 	if _, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
-		glog.V(2).Info("instances.InstanceExistsByProviderID() CACHED with ", uid)
+		klog.V(2).Info("instances.InstanceExistsByProviderID() CACHED with ", uid)
 		return true, nil
 	}
 
 	if err := i.nodeManager.DiscoverNode(uid, FindVMByUUID); err == nil {
-		glog.V(2).Info("instances.InstanceExistsByProviderID() EXISTS with ", uid)
+		klog.V(2).Info("instances.InstanceExistsByProviderID() EXISTS with ", uid)
 		return true, err
 	}
 
-	glog.V(4).Info("instances.InstanceExistsByProviderID() NOT FOUND with ", uid)
+	klog.V(4).Info("instances.InstanceExistsByProviderID() NOT FOUND with ", uid)
 	return false, nil
 }
 
 // InstanceShutdownByProviderID returns true if the instance is in safe state to detach volumes
 func (i *instances) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
-	glog.V(4).Info("instances.InstanceShutdownByProviderID() called")
+	klog.V(4).Info("instances.InstanceShutdownByProviderID() called")
 	return false, cloudprovider.NotImplemented
 }

--- a/pkg/cloudprovider/vsphere/server/server.go
+++ b/pkg/cloudprovider/vsphere/server/server.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"net"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -64,7 +64,7 @@ func (s *server) Start() {
 	go func() {
 		lis, err := net.Listen("tcp", s.binding)
 		if err != nil {
-			glog.Fatalf("Server Listen() failed: %s", err)
+			klog.Fatalf("Server Listen() failed: %s", err)
 
 		}
 

--- a/pkg/cloudprovider/vsphere/zones.go
+++ b/pkg/cloudprovider/vsphere/zones.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/vmware/govmomi/vim25/mo"
 
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -39,40 +39,40 @@ func newZones(nodeManager *NodeManager, zone string, region string) cloudprovide
 
 // GetZone implements Zones.GetZone for In-Tree providers
 func (z *zones) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
-	glog.V(4).Info("zones.GetZone() called")
+	klog.V(4).Info("zones.GetZone() called")
 
 	zone := cloudprovider.Zone{}
 
 	nodeName, err := os.Hostname()
 	if err != nil {
-		glog.V(2).Info("Failed to get hostname. Err: ", err)
+		klog.V(2).Info("Failed to get hostname. Err: ", err)
 		return zone, err
 	}
 
 	node, ok := z.nodeManager.nodeNameMap[nodeName]
 	if !ok {
-		glog.V(2).Info("zones.GetZone() NOT FOUND with ", nodeName)
+		klog.V(2).Info("zones.GetZone() NOT FOUND with ", nodeName)
 		return zone, ErrVMNotFound
 	}
 
 	vmHost, err := node.vm.HostSystem(ctx)
 	if err != nil {
-		glog.Errorf("Failed to get host system for VM: %q. err: %+v", node.vm.InventoryPath, err)
+		klog.Errorf("Failed to get host system for VM: %q. err: %+v", node.vm.InventoryPath, err)
 		return zone, err
 	}
 
 	var oHost mo.HostSystem
 	err = vmHost.Properties(ctx, vmHost.Reference(), []string{"summary"}, &oHost)
 	if err != nil {
-		glog.Errorf("Failed to get host system properties. err: %+v", err)
+		klog.Errorf("Failed to get host system properties. err: %+v", err)
 		return zone, err
 	}
-	glog.V(4).Infof("Host owning VM is %s", oHost.Summary.Config.Name)
+	klog.V(4).Infof("Host owning VM is %s", oHost.Summary.Config.Name)
 
 	zoneResult, err := z.nodeManager.connectionManager.LookupZoneByMoref(
 		ctx, node.dataCenter, vmHost.Reference(), z.zone, z.region, true)
 	if err != nil {
-		glog.Errorf("Failed to get host system properties. err: %+v", err)
+		klog.Errorf("Failed to get host system properties. err: %+v", err)
 		return zone, err
 	}
 
@@ -86,34 +86,34 @@ func (z *zones) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 
 // GetZoneByNodeName implements Zones.GetZone for Out-Tree providers
 func (z *zones) GetZoneByNodeName(ctx context.Context, nodeName k8stypes.NodeName) (cloudprovider.Zone, error) {
-	glog.V(4).Info("zones.GetZoneByNodeName() called with ", string(nodeName))
+	klog.V(4).Info("zones.GetZoneByNodeName() called with ", string(nodeName))
 
 	zone := cloudprovider.Zone{}
 
 	node, ok := z.nodeManager.nodeNameMap[string(nodeName)]
 	if !ok {
-		glog.V(2).Info("zones.GetZoneByNodeName() NOT FOUND with ", string(nodeName))
+		klog.V(2).Info("zones.GetZoneByNodeName() NOT FOUND with ", string(nodeName))
 		return zone, ErrVMNotFound
 	}
 
 	vmHost, err := node.vm.HostSystem(ctx)
 	if err != nil {
-		glog.Errorf("Failed to get host system for VM: %q. err: %+v", node.vm.InventoryPath, err)
+		klog.Errorf("Failed to get host system for VM: %q. err: %+v", node.vm.InventoryPath, err)
 		return zone, err
 	}
 
 	var oHost mo.HostSystem
 	err = vmHost.Properties(ctx, vmHost.Reference(), []string{"summary"}, &oHost)
 	if err != nil {
-		glog.Errorf("Failed to get host system properties. err: %+v", err)
+		klog.Errorf("Failed to get host system properties. err: %+v", err)
 		return zone, err
 	}
-	glog.V(4).Infof("Host owning VM is %s", oHost.Summary.Config.Name)
+	klog.V(4).Infof("Host owning VM is %s", oHost.Summary.Config.Name)
 
 	zoneResult, err := z.nodeManager.connectionManager.LookupZoneByMoref(
 		ctx, node.dataCenter, vmHost.Reference(), z.zone, z.region, true)
 	if err != nil {
-		glog.Errorf("Failed to get host system properties. err: %+v", err)
+		klog.Errorf("Failed to get host system properties. err: %+v", err)
 		return zone, err
 	}
 
@@ -125,35 +125,35 @@ func (z *zones) GetZoneByNodeName(ctx context.Context, nodeName k8stypes.NodeNam
 
 // GetZoneByProviderID implements Zones.GetZone for Out-Tree providers
 func (z *zones) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
-	glog.V(4).Info("zones.GetZoneByProviderID() called with ", providerID)
+	klog.V(4).Info("zones.GetZoneByProviderID() called with ", providerID)
 
 	zone := cloudprovider.Zone{}
 	uid := GetUUIDFromProviderID(providerID)
 
 	node, ok := z.nodeManager.nodeUUIDMap[uid]
 	if !ok {
-		glog.V(2).Info("zones.GetZoneByProviderID() NOT FOUND with ", uid)
+		klog.V(2).Info("zones.GetZoneByProviderID() NOT FOUND with ", uid)
 		return zone, ErrVMNotFound
 	}
 
 	vmHost, err := node.vm.HostSystem(ctx)
 	if err != nil {
-		glog.Errorf("Failed to get host system for VM: %q. err: %+v", node.vm.InventoryPath, err)
+		klog.Errorf("Failed to get host system for VM: %q. err: %+v", node.vm.InventoryPath, err)
 		return zone, err
 	}
 
 	var oHost mo.HostSystem
 	err = vmHost.Properties(ctx, vmHost.Reference(), []string{"summary"}, &oHost)
 	if err != nil {
-		glog.Errorf("Failed to get host system properties. err: %+v", err)
+		klog.Errorf("Failed to get host system properties. err: %+v", err)
 		return zone, err
 	}
-	glog.V(4).Infof("Host owning VM is %s", oHost.Summary.Config.Name)
+	klog.V(4).Infof("Host owning VM is %s", oHost.Summary.Config.Name)
 
 	zoneResult, err := z.nodeManager.connectionManager.LookupZoneByMoref(
 		ctx, node.dataCenter, vmHost.Reference(), z.zone, z.region, true)
 	if err != nil {
-		glog.Errorf("Failed to get host system properties. err: %+v", err)
+		klog.Errorf("Failed to get host system properties. err: %+v", err)
 		return zone, err
 	}
 

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	"gopkg.in/gcfg.v1"
 )
@@ -104,7 +104,7 @@ func ConfigFromEnv() (cfg Config, ok bool) {
 		RoundTripCount = DefaultRoundTripperCount
 	}
 	if err != nil {
-		glog.Fatalf("Failed to parse VSPHERE_ROUNDTRIP_COUNT: %s", err)
+		klog.Fatalf("Failed to parse VSPHERE_ROUNDTRIP_COUNT: %s", err)
 	}
 	cfg.Global.RoundTripperCount = RoundTripCount
 
@@ -115,7 +115,7 @@ func ConfigFromEnv() (cfg Config, ok bool) {
 		InsecureFlag = false
 	}
 	if err != nil {
-		glog.Errorf("Failed to parse VSPHERE_INSECURE: %s", err)
+		klog.Errorf("Failed to parse VSPHERE_INSECURE: %s", err)
 		InsecureFlag = false
 	}
 	cfg.Global.InsecureFlag = InsecureFlag
@@ -127,7 +127,7 @@ func ConfigFromEnv() (cfg Config, ok bool) {
 		APIDisable = true
 	}
 	if err != nil {
-		glog.Errorf("Failed to parse VSPHERE_API_DISABLE: %s", err)
+		klog.Errorf("Failed to parse VSPHERE_API_DISABLE: %s", err)
 		APIDisable = true
 	}
 	cfg.Global.APIDisable = APIDisable
@@ -270,9 +270,9 @@ func fixUpConfigFromFile(cfg *Config) error {
 
 	// vsphere.conf is no longer supported in the old format.
 	for vcServer, vcConfig := range cfg.VirtualCenter {
-		glog.V(4).Infof("Initializing vc server %s", vcServer)
+		klog.V(4).Infof("Initializing vc server %s", vcServer)
 		if vcServer == "" {
-			glog.Error(InvalidVCenterIPErrMsg)
+			klog.Error(InvalidVCenterIPErrMsg)
 			return ErrInvalidVCenterIP
 		}
 
@@ -280,14 +280,14 @@ func fixUpConfigFromFile(cfg *Config) error {
 			if vcConfig.User == "" {
 				vcConfig.User = cfg.Global.User
 				if vcConfig.User == "" {
-					glog.Errorf("vcConfig.User is empty for vc %s!", vcServer)
+					klog.Errorf("vcConfig.User is empty for vc %s!", vcServer)
 					return ErrUsernameMissing
 				}
 			}
 			if vcConfig.Password == "" {
 				vcConfig.Password = cfg.Global.Password
 				if vcConfig.Password == "" {
-					glog.Errorf("vcConfig.Password is empty for vc %s!", vcServer)
+					klog.Errorf("vcConfig.Password is empty for vc %s!", vcServer)
 					return ErrPasswordMissing
 				}
 			}

--- a/pkg/common/connectionmanager/connectionmanager.go
+++ b/pkg/common/connectionmanager/connectionmanager.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"k8s.io/client-go/listers/core/v1"
 
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
@@ -43,7 +43,7 @@ const (
 
 func NewConnectionManager(config *vcfg.Config, secretLister v1.SecretLister) *ConnectionManager {
 	if secretLister != nil {
-		glog.V(2).Info("NewConnectionManager with SecretLister")
+		klog.V(2).Info("NewConnectionManager with SecretLister")
 		return &ConnectionManager{
 			VsphereInstanceMap: generateInstanceMap(config),
 			credentialManager: &cm.SecretCredentialManager{
@@ -57,7 +57,7 @@ func NewConnectionManager(config *vcfg.Config, secretLister v1.SecretLister) *Co
 		}
 	}
 	if config.Global.SecretsDirectory != "" {
-		glog.V(2).Info("NewConnectionManager generic CO")
+		klog.V(2).Info("NewConnectionManager generic CO")
 		return &ConnectionManager{
 			VsphereInstanceMap: generateInstanceMap(config),
 			credentialManager: &cm.SecretCredentialManager{
@@ -70,7 +70,7 @@ func NewConnectionManager(config *vcfg.Config, secretLister v1.SecretLister) *Co
 		}
 	}
 
-	glog.V(2).Info("NewConnectionManager creds from config")
+	klog.V(2).Info("NewConnectionManager creds from config")
 	return &ConnectionManager{
 		VsphereInstanceMap: generateInstanceMap(config),
 		credentialManager: &cm.SecretCredentialManager{
@@ -135,17 +135,17 @@ func (cm *ConnectionManager) ConnectByInstance(ctx context.Context, vsphereInsta
 	}
 
 	if !vclib.IsInvalidCredentialsError(err) || cm.credentialManager == nil {
-		glog.Errorf("Cannot connect to vCenter with err: %v", err)
+		klog.Errorf("Cannot connect to vCenter with err: %v", err)
 		return err
 	}
 
-	glog.V(2).Infof("Invalid credentials. Cannot connect to server %q. "+
+	klog.V(2).Infof("Invalid credentials. Cannot connect to server %q. "+
 		"Fetching credentials from secrets.", vsphereInstance.Conn.Hostname)
 
 	// Get latest credentials from SecretCredentialManager
 	credentials, err := cm.credentialManager.GetCredential(vsphereInstance.Conn.Hostname)
 	if err != nil {
-		glog.Error("Failed to get credentials from Secret Credential Manager with err:", err)
+		klog.Error("Failed to get credentials from Secret Credential Manager with err:", err)
 		return err
 	}
 	vsphereInstance.Conn.UpdateCredentials(credentials.User, credentials.Password)
@@ -167,9 +167,9 @@ func (cm *ConnectionManager) Verify() error {
 	for vcServer := range cm.VsphereInstanceMap {
 		err := cm.Connect(context.Background(), vcServer)
 		if err == nil {
-			glog.V(3).Infof("vCenter connect %s succeeded.", vcServer)
+			klog.V(3).Infof("vCenter connect %s succeeded.", vcServer)
 		} else {
-			glog.Errorf("vCenter %s failed. Err: %q", vcServer, err)
+			klog.Errorf("vCenter %s failed. Err: %q", vcServer, err)
 			return err
 		}
 	}
@@ -180,9 +180,9 @@ func (cm *ConnectionManager) VerifyWithContext(ctx context.Context) error {
 	for vcServer := range cm.VsphereInstanceMap {
 		err := cm.Connect(ctx, vcServer)
 		if err == nil {
-			glog.V(3).Infof("vCenter connect %s succeeded.", vcServer)
+			klog.V(3).Infof("vCenter connect %s succeeded.", vcServer)
 		} else {
-			glog.Errorf("vCenter %s failed. Err: %q", vcServer, err)
+			klog.Errorf("vCenter %s failed. Err: %q", vcServer, err)
 			return err
 		}
 	}

--- a/pkg/common/connectionmanager/list.go
+++ b/pkg/common/connectionmanager/list.go
@@ -22,14 +22,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	vclib "k8s.io/cloud-provider-vsphere/pkg/common/vclib"
 )
 
 // ListAllVCandDCPairs returns all VC/DC pairs
 func (cm *ConnectionManager) ListAllVCandDCPairs(ctx context.Context) ([]*ListDiscoveryInfo, error) {
-	glog.V(4).Infof("ListAllVCandDCPairs called")
+	klog.V(4).Infof("ListAllVCandDCPairs called")
 
 	listOfVCAndDCPairs := make([]*ListDiscoveryInfo, 0)
 
@@ -46,14 +46,14 @@ func (cm *ConnectionManager) ListAllVCandDCPairs(ctx context.Context) ([]*ListDi
 		}
 
 		if err != nil {
-			glog.Error("Connect error vc:", err)
+			klog.Error("Connect error vc:", err)
 			continue
 		}
 
 		if vsi.Cfg.Datacenters == "" {
 			datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.Conn)
 			if err != nil {
-				glog.Error("GetAllDatacenter error dc:", err)
+				klog.Error("GetAllDatacenter error dc:", err)
 				continue
 			}
 		} else {
@@ -65,7 +65,7 @@ func (cm *ConnectionManager) ListAllVCandDCPairs(ctx context.Context) ([]*ListDi
 				}
 				datacenterObj, err := vclib.GetDatacenter(ctx, vsi.Conn, dc)
 				if err != nil {
-					glog.Error("GetDatacenter error dc:", err)
+					klog.Error("GetDatacenter error dc:", err)
 					continue
 				}
 				datacenterObjs = append(datacenterObjs, datacenterObj)

--- a/pkg/common/connectionmanager/zones.go
+++ b/pkg/common/connectionmanager/zones.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
@@ -46,32 +46,32 @@ const (
 // WhichVCandDCByZone gets the corresponding VC+DC combo that supports the availability zone
 func (cm *ConnectionManager) WhichVCandDCByZone(ctx context.Context,
 	zoneLabel string, regionLabel string, zoneLooking string, regionLooking string) (*ZoneDiscoveryInfo, error) {
-	glog.V(4).Infof("WhichVCandDCByZone called with zone: %s and region: %s", zoneLooking, regionLooking)
+	klog.V(4).Infof("WhichVCandDCByZone called with zone: %s and region: %s", zoneLooking, regionLooking)
 
 	// Need at least one VC
 	numOfVCs := len(cm.VsphereInstanceMap)
 	if numOfVCs == 0 {
 		err := ErrMustHaveAtLeastOneVCDC
-		glog.Errorf("%v", err)
+		klog.Errorf("%v", err)
 		return nil, err
 	}
 
 	if numOfVCs == 1 {
-		glog.V(4).Info("Single VC Detected")
+		klog.V(4).Info("Single VC Detected")
 		return cm.getDIFromSingleVC(ctx, zoneLabel, regionLabel, zoneLooking, regionLooking)
 	}
 
-	glog.V(4).Info("Multi VC Detected")
+	klog.V(4).Info("Multi VC Detected")
 	return cm.getDIFromMultiVCorDC(ctx, zoneLabel, regionLabel, zoneLooking, regionLooking)
 }
 
 func (cm *ConnectionManager) getDIFromSingleVC(ctx context.Context,
 	zoneLabel string, regionLabel string, zoneLooking string, regionLooking string) (*ZoneDiscoveryInfo, error) {
-	glog.V(4).Infof("getDIFromSingleVC called with zone: %s and region: %s", zoneLooking, regionLooking)
+	klog.V(4).Infof("getDIFromSingleVC called with zone: %s and region: %s", zoneLooking, regionLooking)
 
 	if len(cm.VsphereInstanceMap) != 1 {
 		err := ErrUnsupportedConfiguration
-		glog.Errorf("%v", err)
+		klog.Errorf("%v", err)
 		return nil, err
 	}
 
@@ -94,22 +94,22 @@ func (cm *ConnectionManager) getDIFromSingleVC(ctx context.Context,
 
 	numOfDc, err := vclib.GetNumberOfDatacenters(ctx, tmpVsi.Conn)
 	if err != nil {
-		glog.Errorf("%v", err)
+		klog.Errorf("%v", err)
 		return nil, err
 	}
 
 	// More than 1 DC in this VC
 	if numOfDc > 1 {
-		glog.V(3).Info("Multi Datacenter configuration detected")
+		klog.V(3).Info("Multi Datacenter configuration detected")
 		return cm.getDIFromMultiVCorDC(ctx, zoneLabel, regionLabel, zoneLooking, regionLooking)
 	}
 
 	// We are sure this is single VC and DC
-	glog.V(3).Info("Single vCenter/Datacenter configuration detected")
+	klog.V(3).Info("Single vCenter/Datacenter configuration detected")
 
 	datacenterObjs, err := vclib.GetAllDatacenter(ctx, tmpVsi.Conn)
 	if err != nil {
-		glog.Error("GetAllDatacenter failed. Err:", err)
+		klog.Error("GetAllDatacenter failed. Err:", err)
 		return nil, err
 	}
 
@@ -123,11 +123,11 @@ func (cm *ConnectionManager) getDIFromSingleVC(ctx context.Context,
 
 func (cm *ConnectionManager) getDIFromMultiVCorDC(ctx context.Context,
 	zoneLabel string, regionLabel string, zoneLooking string, regionLooking string) (*ZoneDiscoveryInfo, error) {
-	glog.V(4).Infof("getDIFromMultiVCorDC called with zone: %s and region: %s", zoneLooking, regionLooking)
+	klog.V(4).Infof("getDIFromMultiVCorDC called with zone: %s and region: %s", zoneLooking, regionLooking)
 
 	if len(zoneLabel) == 0 || len(regionLabel) == 0 || len(zoneLooking) == 0 || len(regionLooking) == 0 {
 		err := ErrMultiVCRequiresZones
-		glog.Errorf("%v", err)
+		klog.Errorf("%v", err)
 		return nil, err
 	}
 
@@ -141,19 +141,19 @@ func (cm *ConnectionManager) getDIFromMultiVCorDC(ctx context.Context,
 	// Mutli VC/DC configurations really shouldn't be using individual zone/region labels on Hosts
 	// Searching for labels per host is expensive in this configuration
 	// Consider using zone/region on Datacenters, Clusters, or ResourcePools
-	glog.Warning("Mutli VC/DC configurations really shouldn't be using individual zone/region labels on Hosts")
-	glog.Warning("Searching for labels per host is expensive in this configuration")
-	glog.Warning("Consider using zone/region on Datacenters, Clusters, or ResourcePools")
+	klog.Warning("Mutli VC/DC configurations really shouldn't be using individual zone/region labels on Hosts")
+	klog.Warning("Searching for labels per host is expensive in this configuration")
+	klog.Warning("Consider using zone/region on Datacenters, Clusters, or ResourcePools")
 	return cm.getDIFromMultiVCorDCVM(ctx, zoneLabel, regionLabel, zoneLooking, regionLooking)
 }
 
 func (cm *ConnectionManager) getDIFromMultiVCorDCNonVM(ctx context.Context,
 	zoneLabel string, regionLabel string, zoneLooking string, regionLooking string) (*ZoneDiscoveryInfo, error) {
-	glog.V(4).Infof("getDIFromMultiVCorDCNonVM called with zone: %s and region: %s", zoneLooking, regionLooking)
+	klog.V(4).Infof("getDIFromMultiVCorDCNonVM called with zone: %s and region: %s", zoneLooking, regionLooking)
 
 	if len(zoneLabel) == 0 || len(regionLabel) == 0 || len(zoneLooking) == 0 || len(regionLooking) == 0 {
 		err := ErrMultiVCRequiresZones
-		glog.Errorf("%v", err)
+		klog.Errorf("%v", err)
 		return nil, err
 	}
 
@@ -212,7 +212,7 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCNonVM(ctx context.Context,
 			}
 
 			if err != nil {
-				glog.Error("getDIFromMultiVCorDCNonVM error vc:", err)
+				klog.Error("getDIFromMultiVCorDCNonVM error vc:", err)
 				setGlobalErr(err)
 				continue
 			}
@@ -220,7 +220,7 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCNonVM(ctx context.Context,
 			if vsi.Cfg.Datacenters == "" {
 				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.Conn)
 				if err != nil {
-					glog.Error("getDIFromMultiVCorDCNonVM error dc:", err)
+					klog.Error("getDIFromMultiVCorDCNonVM error dc:", err)
 					setGlobalErr(err)
 					continue
 				}
@@ -233,7 +233,7 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCNonVM(ctx context.Context,
 					}
 					datacenterObj, err := vclib.GetDatacenter(ctx, vsi.Conn, dc)
 					if err != nil {
-						glog.Error("getDIFromMultiVCorDCNonVM error dc:", err)
+						klog.Error("getDIFromMultiVCorDCNonVM error dc:", err)
 						setGlobalErr(err)
 						continue
 					}
@@ -252,14 +252,14 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCNonVM(ctx context.Context,
 
 				clusterList, err := finder.ClusterComputeResourceList(ctx, "*")
 				if err != nil {
-					glog.Errorf("ClusterComputeResourceList failed in vc=%s and datacenter=%s: %v",
+					klog.Errorf("ClusterComputeResourceList failed in vc=%s and datacenter=%s: %v",
 						vc, datacenterObj.Name(), err)
 					setGlobalErr(err)
 					continue
 				}
 
 				for _, cluster := range clusterList {
-					glog.V(4).Infof("Finding zone in vc=%s and datacenter=%s and cluster=%s",
+					klog.V(4).Infof("Finding zone in vc=%s and datacenter=%s and cluster=%s",
 						vc, datacenterObj.Name(), cluster.Name())
 					queueChannel <- &zoneSearch{
 						vc:         vc,
@@ -278,20 +278,20 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCNonVM(ctx context.Context,
 		go func() {
 			for res := range queueChannel {
 
-				glog.V(3).Infof("Checking zones for cluster: %s", res.cluster.Name())
+				klog.V(3).Infof("Checking zones for cluster: %s", res.cluster.Name())
 				result, err := cm.LookupZoneByMoref(ctx, res.datacenter, res.cluster.Reference(), zoneLabel, regionLabel, true)
 				if err != nil {
-					glog.Errorf("Failed to find zone: %s and region: %s for cluster %s", zoneLabel, regionLabel, res.cluster.Name())
+					klog.Errorf("Failed to find zone: %s and region: %s for cluster %s", zoneLabel, regionLabel, res.cluster.Name())
 					continue
 				}
 
 				if !strings.EqualFold(result[ZoneLabel], zoneLooking) ||
 					!strings.EqualFold(result[RegionLabel], regionLooking) {
-					glog.V(4).Infof("Does not match region: %s and zone: %s", result[RegionLabel], result[ZoneLabel])
+					klog.V(4).Infof("Does not match region: %s and zone: %s", result[RegionLabel], result[ZoneLabel])
 					continue
 				}
 
-				glog.Infof("Found zone: %s and region: %s for cluster %s", zoneLooking, regionLooking, res.cluster.Name())
+				klog.Infof("Found zone: %s and region: %s for cluster %s", zoneLooking, regionLooking, res.cluster.Name())
 				zoneInfo = &ZoneDiscoveryInfo{
 					VcServer:   res.vc,
 					DataCenter: res.datacenter,
@@ -311,17 +311,17 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCNonVM(ctx context.Context,
 		return nil, *globalErr
 	}
 
-	glog.V(4).Infof("getDIFromMultiVCorDCNonVM: zone: %s and region: %s not found", zoneLabel, regionLabel)
+	klog.V(4).Infof("getDIFromMultiVCorDCNonVM: zone: %s and region: %s not found", zoneLabel, regionLabel)
 	return nil, vclib.ErrNoZoneRegionFound
 }
 
 func (cm *ConnectionManager) getDIFromMultiVCorDCVM(ctx context.Context,
 	zoneLabel string, regionLabel string, zoneLooking string, regionLooking string) (*ZoneDiscoveryInfo, error) {
-	glog.V(4).Infof("getDIFromMultiVCorDCVM called with zone: %s and region: %s", zoneLooking, regionLooking)
+	klog.V(4).Infof("getDIFromMultiVCorDCVM called with zone: %s and region: %s", zoneLooking, regionLooking)
 
 	if len(zoneLabel) == 0 || len(regionLabel) == 0 || len(zoneLooking) == 0 || len(regionLooking) == 0 {
 		err := ErrMultiVCRequiresZones
-		glog.Errorf("%v", err)
+		klog.Errorf("%v", err)
 		return nil, err
 	}
 
@@ -380,7 +380,7 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCVM(ctx context.Context,
 			}
 
 			if err != nil {
-				glog.Error("getDIFromMultiVCorDCVM error vc:", err)
+				klog.Error("getDIFromMultiVCorDCVM error vc:", err)
 				setGlobalErr(err)
 				continue
 			}
@@ -388,7 +388,7 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCVM(ctx context.Context,
 			if vsi.Cfg.Datacenters == "" {
 				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.Conn)
 				if err != nil {
-					glog.Error("getDIFromMultiVCorDCVM error dc:", err)
+					klog.Error("getDIFromMultiVCorDCVM error dc:", err)
 					setGlobalErr(err)
 					continue
 				}
@@ -401,7 +401,7 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCVM(ctx context.Context,
 					}
 					datacenterObj, err := vclib.GetDatacenter(ctx, vsi.Conn, dc)
 					if err != nil {
-						glog.Error("getDIFromMultiVCorDCVM error dc:", err)
+						klog.Error("getDIFromMultiVCorDCVM error dc:", err)
 						setGlobalErr(err)
 						continue
 					}
@@ -420,12 +420,12 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCVM(ctx context.Context,
 
 				hostList, err := finder.HostSystemList(ctx, "*/*")
 				if err != nil {
-					glog.Errorf("HostSystemList failed: %v", err)
+					klog.Errorf("HostSystemList failed: %v", err)
 					continue
 				}
 
 				for _, host := range hostList {
-					glog.V(3).Infof("Finding zone in vc=%s and datacenter=%s for host: %s", vc, datacenterObj.Name(), host.Name())
+					klog.V(3).Infof("Finding zone in vc=%s and datacenter=%s for host: %s", vc, datacenterObj.Name(), host.Name())
 					queueChannel <- &zoneSearch{
 						vc:         vc,
 						datacenter: datacenterObj,
@@ -443,20 +443,20 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCVM(ctx context.Context,
 		go func() {
 			for res := range queueChannel {
 
-				glog.V(3).Infof("Checking zones for host: %s", res.host.Name())
+				klog.V(3).Infof("Checking zones for host: %s", res.host.Name())
 				result, err := cm.LookupZoneByMoref(ctx, res.datacenter, res.host.Reference(), zoneLabel, regionLabel, false)
 				if err == nil {
-					glog.Errorf("Failed to find zone: %s and region: %s for host %s", zoneLabel, regionLabel, res.host.Name())
+					klog.Errorf("Failed to find zone: %s and region: %s for host %s", zoneLabel, regionLabel, res.host.Name())
 					continue
 				}
 
 				if !strings.EqualFold(result[ZoneLabel], zoneLooking) ||
 					!strings.EqualFold(result[RegionLabel], regionLooking) {
-					glog.V(4).Infof("Does not match region: %s and zone: %s", result[RegionLabel], result[ZoneLabel])
+					klog.V(4).Infof("Does not match region: %s and zone: %s", result[RegionLabel], result[ZoneLabel])
 					continue
 				}
 
-				glog.Infof("Found zone: %s and region: %s for host %s", zoneLooking, regionLooking, res.host.Name())
+				klog.Infof("Found zone: %s and region: %s for host %s", zoneLooking, regionLooking, res.host.Name())
 				zoneInfo = &ZoneDiscoveryInfo{
 					VcServer:   res.vc,
 					DataCenter: res.datacenter,
@@ -476,7 +476,7 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCVM(ctx context.Context,
 		return nil, *globalErr
 	}
 
-	glog.V(4).Infof("getDIFromMultiVCorDCVM: zone: %s and region: %s not found", zoneLabel, regionLabel)
+	klog.V(4).Infof("getDIFromMultiVCorDCVM: zone: %s and region: %s not found", zoneLabel, regionLabel)
 	return nil, vclib.ErrNoZoneRegionFound
 }
 
@@ -508,7 +508,7 @@ func (cm *ConnectionManager) LookupZoneByMoref(ctx context.Context, dataCenter *
 	vsi := cm.VsphereInstanceMap[vcServer]
 	if vsi == nil {
 		err := ErrConnectionNotFound
-		glog.Errorf("Unable to find Connection for %s", vcServer)
+		klog.Errorf("Unable to find Connection for %s", vcServer)
 		return nil, err
 	}
 
@@ -522,7 +522,7 @@ func (cm *ConnectionManager) LookupZoneByMoref(ctx context.Context, dataCenter *
 			// example result: ["Folder", "Datacenter", "Cluster", "Host"]
 			objects, err = mo.Ancestors(ctx, dataCenter.Client(), pc, moRef)
 			if err != nil {
-				glog.Errorf("Ancestors failed for %s with err %v", moRef, err)
+				klog.Errorf("Ancestors failed for %s with err %v", moRef, err)
 				return err
 			}
 		} else {
@@ -530,7 +530,7 @@ func (cm *ConnectionManager) LookupZoneByMoref(ctx context.Context, dataCenter *
 			pc := property.DefaultCollector(dataCenter.Client())
 			err = pc.RetrieveOne(ctx, moRef, []string{"summary"}, &moHost)
 			if err != nil {
-				glog.Errorf("RetrieveOne failed for %s with err %v", moRef, err)
+				klog.Errorf("RetrieveOne failed for %s with err %v", moRef, err)
 				return err
 			}
 			objects = make([]mo.ManagedEntity, 0)
@@ -540,26 +540,26 @@ func (cm *ConnectionManager) LookupZoneByMoref(ctx context.Context, dataCenter *
 		// search the hierarchy, example order: ["Host", "Cluster", "Datacenter", "Folder"]
 		for i := range objects {
 			obj := objects[len(objects)-1-i]
-			glog.V(4).Infof("Name: %s, Type: %s", obj.Self.Value, obj.Self.Type)
+			klog.V(4).Infof("Name: %s, Type: %s", obj.Self.Value, obj.Self.Type)
 			tags, err := client.ListAttachedTags(ctx, obj)
 			if err != nil {
-				glog.Errorf("Cannot list attached tags. Err: %v", err)
+				klog.Errorf("Cannot list attached tags. Err: %v", err)
 				return err
 			}
 			for _, value := range tags {
 				tag, err := client.GetTag(ctx, value)
 				if err != nil {
-					glog.Errorf("Zones Get tag %s: %s", value, err)
+					klog.Errorf("Zones Get tag %s: %s", value, err)
 					return err
 				}
 				category, err := client.GetCategory(ctx, tag.CategoryID)
 				if err != nil {
-					glog.Errorf("Zones Get category %s error", value)
+					klog.Errorf("Zones Get category %s error", value)
 					return err
 				}
 
 				found := func() {
-					glog.V(2).Infof("Found %s tag (%s) attached to %s", category.Name, tag.Name, moRef)
+					klog.V(2).Infof("Found %s tag (%s) attached to %s", category.Name, tag.Name, moRef)
 				}
 				switch {
 				case category.Name == zoneLabel:
@@ -590,7 +590,7 @@ func (cm *ConnectionManager) LookupZoneByMoref(ctx context.Context, dataCenter *
 		return nil
 	})
 	if err != nil {
-		glog.Errorf("Get zone for mo: %s: %s", moRef, err)
+		klog.Errorf("Get zone for mo: %s: %s", moRef, err)
 		return nil, err
 	}
 	return result, nil

--- a/pkg/common/kubernetes/kubernetes.go
+++ b/pkg/common/kubernetes/kubernetes.go
@@ -19,7 +19,7 @@ package kubernetes
 import (
 	"os"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -35,19 +35,19 @@ func NewClient(name string) (clientset.Interface, error) {
 
 	var config *restclient.Config
 	if kubecfgPath != "" {
-		glog.V(2).Info("k8s client using kubeconfig")
+		klog.V(2).Info("k8s client using kubeconfig")
 		var err error
 		config, err = clientcmd.BuildConfigFromFlags("", kubecfgPath)
 		if err != nil {
-			glog.Errorf("BuildConfigFromFlags failed %q", err)
+			klog.Errorf("BuildConfigFromFlags failed %q", err)
 			return nil, err
 		}
 	} else {
-		glog.V(2).Info("k8s client using in-cluster config")
+		klog.V(2).Info("k8s client using in-cluster config")
 		var err error
 		config, err = restclient.InClusterConfig()
 		if err != nil {
-			glog.Errorf("InClusterConfig failed %q", err)
+			klog.Errorf("InClusterConfig failed %q", err)
 			return nil, err
 		}
 	}
@@ -61,7 +61,7 @@ func NewClient(name string) (clientset.Interface, error) {
 func NewClientOrDie(name string) clientset.Interface {
 	client, err := NewClient(name)
 	if err != nil {
-		glog.Fatalf("InClusterConfig failed %q", err)
+		klog.Fatalf("InClusterConfig failed %q", err)
 	}
 
 	return client

--- a/pkg/common/vclib/datastore.go
+++ b/pkg/common/vclib/datastore.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -60,7 +60,7 @@ func (ds *Datastore) CreateDirectory(ctx context.Context, directoryPath string, 
 		}
 		return err
 	}
-	glog.V(LogLevel).Infof("Created dir with path as %+q", directoryPath)
+	klog.V(LogLevel).Infof("Created dir with path as %+q", directoryPath)
 	return nil
 }
 
@@ -70,7 +70,7 @@ func (ds *Datastore) GetType(ctx context.Context) (string, error) {
 	pc := property.DefaultCollector(ds.Client())
 	err := pc.RetrieveOne(ctx, ds.Datastore.Reference(), []string{"summary"}, &dsMo)
 	if err != nil {
-		glog.Errorf("Failed to retrieve datastore summary property. err: %v", err)
+		klog.Errorf("Failed to retrieve datastore summary property. err: %v", err)
 		return "", err
 	}
 	return dsMo.Summary.Type, nil
@@ -82,7 +82,7 @@ func (ds *Datastore) GetName(ctx context.Context) (string, error) {
 	pc := property.DefaultCollector(ds.Client())
 	err := pc.RetrieveOne(ctx, ds.Datastore.Reference(), []string{DatastoreInfoProperty}, &dsMo)
 	if err != nil {
-		glog.Errorf("Failed to retrieve datastore info property. err: %v", err)
+		klog.Errorf("Failed to retrieve datastore info property. err: %v", err)
 		return "", err
 	}
 	return dsMo.Info.GetDatastoreInfo().Name, nil
@@ -93,7 +93,7 @@ func (ds *Datastore) GetName(ctx context.Context) (string, error) {
 func (ds *Datastore) IsCompatibleWithStoragePolicy(ctx context.Context, storagePolicyID string) (bool, string, error) {
 	pbmClient, err := NewPbmClient(ctx, ds.Client())
 	if err != nil {
-		glog.Errorf("Failed to get new PbmClient Object. err: %v", err)
+		klog.Errorf("Failed to get new PbmClient Object. err: %v", err)
 		return false, "", err
 	}
 	return pbmClient.IsDatastoreCompatible(ctx, storagePolicyID, ds)
@@ -105,7 +105,7 @@ func (ds *Datastore) ListFirstClassDisks(ctx context.Context) ([]*FirstClassDisk
 
 	oids, err := m.List(ctx, ds.Reference())
 	if err != nil {
-		glog.Errorf("Failed to list disks. Err: %v", err)
+		klog.Errorf("Failed to list disks. Err: %v", err)
 		return nil, err
 	}
 
@@ -134,7 +134,7 @@ func (ds *Datastore) GetFirstClassDisk(ctx context.Context, diskID string, findB
 
 	oids, err := m.List(ctx, ds.Reference())
 	if err != nil {
-		glog.Errorf("Failed to list disks. Err: %v", err)
+		klog.Errorf("Failed to list disks. Err: %v", err)
 		return nil, err
 	}
 
@@ -165,7 +165,7 @@ func (dsi *DatastoreInfo) ListFirstClassDiskInfos(ctx context.Context) ([]*First
 
 	oids, err := m.List(ctx, dsi.Reference())
 	if err != nil {
-		glog.Errorf("Failed to list disks. Err: %v", err)
+		klog.Errorf("Failed to list disks. Err: %v", err)
 		return nil, err
 	}
 
@@ -198,7 +198,7 @@ func (dsi *DatastoreInfo) GetFirstClassDiskInfo(ctx context.Context, diskID stri
 
 	oids, err := m.List(ctx, dsi.Reference())
 	if err != nil {
-		glog.Errorf("Failed to list disks. Err: %v", err)
+		klog.Errorf("Failed to list disks. Err: %v", err)
 		return nil, err
 	}
 

--- a/pkg/common/vclib/folder.go
+++ b/pkg/common/vclib/folder.go
@@ -19,7 +19,7 @@ package vclib
 import (
 	"context"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/vmware/govmomi/object"
 )
 
@@ -33,7 +33,7 @@ type Folder struct {
 func (folder *Folder) GetVirtualMachines(ctx context.Context) ([]*VirtualMachine, error) {
 	vmFolders, err := folder.Children(ctx)
 	if err != nil {
-		glog.Errorf("Failed to get children from Folder: %s. err: %+v", folder.InventoryPath, err)
+		klog.Errorf("Failed to get children from Folder: %s. err: %+v", folder.InventoryPath, err)
 		return nil, err
 	}
 	var vmObjList []*VirtualMachine

--- a/pkg/common/vclib/pbm.go
+++ b/pkg/common/vclib/pbm.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/vmware/govmomi/pbm"
 
 	pbmtypes "github.com/vmware/govmomi/pbm/types"
@@ -36,7 +36,7 @@ type PbmClient struct {
 func NewPbmClient(ctx context.Context, client *vim25.Client) (*PbmClient, error) {
 	pbmClient, err := pbm.NewClient(ctx, client)
 	if err != nil {
-		glog.Errorf("Failed to create new Pbm Client. err: %+v", err)
+		klog.Errorf("Failed to create new Pbm Client. err: %+v", err)
 		return nil, err
 	}
 	return &PbmClient{pbmClient}, nil
@@ -60,7 +60,7 @@ func (pbmClient *PbmClient) IsDatastoreCompatible(ctx context.Context, storagePo
 	}
 	compatibilityResult, err := pbmClient.CheckRequirements(ctx, hubs, nil, req)
 	if err != nil {
-		glog.Errorf("Error occurred for CheckRequirements call. err %+v", err)
+		klog.Errorf("Error occurred for CheckRequirements call. err %+v", err)
 		return false, "", err
 	}
 	if compatibilityResult != nil && len(compatibilityResult) > 0 {
@@ -70,7 +70,7 @@ func (pbmClient *PbmClient) IsDatastoreCompatible(ctx context.Context, storagePo
 		}
 		dsName, err := datastore.ObjectName(ctx)
 		if err != nil {
-			glog.Error("Failed to get datastore ObjectName")
+			klog.Error("Failed to get datastore ObjectName")
 			return false, "", err
 		}
 		if compatibilityResult[0].Error[0].LocalizedMessage == "" {
@@ -92,7 +92,7 @@ func (pbmClient *PbmClient) GetCompatibleDatastores(ctx context.Context, dc *Dat
 	)
 	compatibilityResult, err := pbmClient.GetPlacementCompatibilityResult(ctx, storagePolicyID, datastores)
 	if err != nil {
-		glog.Errorf("Error occurred while retrieving placement compatibility result for datastores: %+v with storagePolicyID: %s. err: %+v", datastores, storagePolicyID, err)
+		klog.Errorf("Error occurred while retrieving placement compatibility result for datastores: %+v with storagePolicyID: %s. err: %+v", datastores, storagePolicyID, err)
 		return nil, "", err
 	}
 	compatibleHubs := compatibilityResult.CompatibleDatastores()
@@ -114,7 +114,7 @@ func (pbmClient *PbmClient) GetCompatibleDatastores(ctx context.Context, dc *Dat
 	}
 	// Return an error if there are no compatible datastores.
 	if len(compatibleHubs) < 1 {
-		glog.Errorf("No compatible datastores found that satisfy the storage policy requirements: %s", storagePolicyID)
+		klog.Errorf("No compatible datastores found that satisfy the storage policy requirements: %s", storagePolicyID)
 		return nil, localizedMessagesForNotCompatibleDatastores, fmt.Errorf("No compatible datastores found that satisfy the storage policy requirements")
 	}
 	return compatibleDatastoreList, localizedMessagesForNotCompatibleDatastores, nil
@@ -138,7 +138,7 @@ func (pbmClient *PbmClient) GetPlacementCompatibilityResult(ctx context.Context,
 	}
 	res, err := pbmClient.CheckRequirements(ctx, hubs, nil, req)
 	if err != nil {
-		glog.Errorf("Error occurred for CheckRequirements call. err: %+v", err)
+		klog.Errorf("Error occurred for CheckRequirements call. err: %+v", err)
 		return nil, err
 	}
 	return res, nil
@@ -162,7 +162,7 @@ func getDsMorNameMap(ctx context.Context, datastores []*DatastoreInfo) map[strin
 		if err == nil {
 			dsMorNameMap[ds.Reference().Value] = dsObjectName
 		} else {
-			glog.Errorf("Error occurred while getting datastore object name. err: %+v", err)
+			klog.Errorf("Error occurred while getting datastore object name. err: %+v", err)
 		}
 	}
 	return dsMorNameMap

--- a/pkg/common/vclib/storagepod.go
+++ b/pkg/common/vclib/storagepod.go
@@ -19,7 +19,7 @@ package vclib
 import (
 	"context"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
@@ -46,7 +46,7 @@ type StoragePodInfo struct {
 // PopulateChildDatastoreInfos discovers the child DatastoreInfos backed by this StoragePodInfo
 func (spi *StoragePodInfo) PopulateChildDatastoreInfos(ctx context.Context, refresh bool) error {
 	if refresh {
-		glog.Infof("Re-discover datastore infos")
+		klog.Infof("Re-discover datastore infos")
 	}
 	if len(spi.DatastoreInfos) > 0 && !refresh {
 		return nil
@@ -54,7 +54,7 @@ func (spi *StoragePodInfo) PopulateChildDatastoreInfos(ctx context.Context, refr
 
 	err := spi.PopulateChildDatastores(ctx, false)
 	if err != nil {
-		glog.Errorf("PopulateChildDatastores failed. Err: %v", err)
+		klog.Errorf("PopulateChildDatastores failed. Err: %v", err)
 		return err
 	}
 
@@ -68,7 +68,7 @@ func (spi *StoragePodInfo) PopulateChildDatastoreInfos(ctx context.Context, refr
 	properties := []string{DatastoreInfoProperty}
 	err = pc.Retrieve(ctx, dsList, properties, &dsMoList)
 	if err != nil {
-		glog.Errorf("Failed to get Datastore managed objects from datastore objects."+
+		klog.Errorf("Failed to get Datastore managed objects from datastore objects."+
 			" dsObjList: %+v, properties: %+v, err: %v", dsList, properties, err)
 		return err
 	}
@@ -91,7 +91,7 @@ func (spi *StoragePodInfo) PopulateChildDatastoreInfos(ctx context.Context, refr
 func (spi *StoragePodInfo) ListFirstClassDisksInfo(ctx context.Context) ([]*FirstClassDiskInfo, error) {
 	err := spi.PopulateChildDatastoreInfos(ctx, false)
 	if err != nil {
-		glog.Errorf("PopulateChildDatastoreInfos failed. Err: %v", err)
+		klog.Errorf("PopulateChildDatastoreInfos failed. Err: %v", err)
 		return nil, err
 	}
 
@@ -101,7 +101,7 @@ func (spi *StoragePodInfo) ListFirstClassDisksInfo(ctx context.Context) ([]*Firs
 	for _, child := range spi.DatastoreInfos {
 		oids, err := m.List(ctx, child)
 		if err != nil {
-			glog.Errorf("Failed to list disks. Err: %v", err)
+			klog.Errorf("Failed to list disks. Err: %v", err)
 			return nil, err
 		}
 
@@ -132,7 +132,7 @@ func (spi *StoragePodInfo) ListFirstClassDisksInfo(ctx context.Context) ([]*Firs
 func (spi *StoragePodInfo) GetFirstClassDiskInfo(ctx context.Context, diskID string, findBy FindFCD) (*FirstClassDiskInfo, error) {
 	err := spi.PopulateChildDatastoreInfos(ctx, false)
 	if err != nil {
-		glog.Errorf("PopulateChildDatastoreInfos failed. Err: %v", err)
+		klog.Errorf("PopulateChildDatastoreInfos failed. Err: %v", err)
 		return nil, err
 	}
 
@@ -141,7 +141,7 @@ func (spi *StoragePodInfo) GetFirstClassDiskInfo(ctx context.Context, diskID str
 	for _, child := range spi.DatastoreInfos {
 		oids, err := m.List(ctx, child)
 		if err != nil {
-			glog.Errorf("Failed to list disks. Err: %v", err)
+			klog.Errorf("Failed to list disks. Err: %v", err)
 			return nil, err
 		}
 
@@ -175,7 +175,7 @@ func (spi *StoragePodInfo) GetFirstClassDiskInfo(ctx context.Context, diskID str
 func (spi *StoragePodInfo) GetDatastoreThatOwnsFCD(ctx context.Context, diskID string) (*DatastoreInfo, error) {
 	err := spi.PopulateChildDatastoreInfos(ctx, false)
 	if err != nil {
-		glog.Errorf("PopulateChildDatastoreInfos failed. Err: %v", err)
+		klog.Errorf("PopulateChildDatastoreInfos failed. Err: %v", err)
 		return nil, err
 	}
 
@@ -184,7 +184,7 @@ func (spi *StoragePodInfo) GetDatastoreThatOwnsFCD(ctx context.Context, diskID s
 	for _, child := range spi.DatastoreInfos {
 		oids, err := m.List(ctx, child)
 		if err != nil {
-			glog.Errorf("Failed to list disks. Err: %v", err)
+			klog.Errorf("Failed to list disks. Err: %v", err)
 			return nil, err
 		}
 
@@ -206,7 +206,7 @@ func (spi *StoragePodInfo) GetDatastoreThatOwnsFCD(ctx context.Context, diskID s
 // PopulateChildDatastores discovers the child Datastores backed by this StoragePod
 func (sp *StoragePod) PopulateChildDatastores(ctx context.Context, refresh bool) error {
 	if refresh {
-		glog.Infof("Re-discover datastores")
+		klog.Infof("Re-discover datastores")
 	}
 	if len(sp.Datastores) > 0 && !refresh {
 		return nil
@@ -214,7 +214,7 @@ func (sp *StoragePod) PopulateChildDatastores(ctx context.Context, refresh bool)
 
 	children, err := sp.Children(ctx)
 	if err != nil {
-		glog.Errorf("Failed to list disks. Err: %v", err)
+		klog.Errorf("Failed to list disks. Err: %v", err)
 		return err
 	}
 
@@ -233,7 +233,7 @@ func (sp *StoragePod) PopulateChildDatastores(ctx context.Context, refresh bool)
 func (sp *StoragePod) ListFirstClassDisks(ctx context.Context) ([]*FirstClassDisk, error) {
 	err := sp.PopulateChildDatastores(ctx, false)
 	if err != nil {
-		glog.Errorf("PopulateChildDatastores failed. Err: %v", err)
+		klog.Errorf("PopulateChildDatastores failed. Err: %v", err)
 		return nil, err
 	}
 
@@ -243,7 +243,7 @@ func (sp *StoragePod) ListFirstClassDisks(ctx context.Context) ([]*FirstClassDis
 	for _, child := range sp.Datastores {
 		oids, err := m.List(ctx, child)
 		if err != nil {
-			glog.Errorf("Failed to list disks. Err: %v", err)
+			klog.Errorf("Failed to list disks. Err: %v", err)
 			return nil, err
 		}
 
@@ -270,7 +270,7 @@ func (sp *StoragePod) ListFirstClassDisks(ctx context.Context) ([]*FirstClassDis
 func (sp *StoragePod) GetFirstClassDisk(ctx context.Context, diskID string, findBy FindFCD) (*FirstClassDisk, error) {
 	err := sp.PopulateChildDatastores(ctx, false)
 	if err != nil {
-		glog.Errorf("PopulateChildDatastores failed. Err: %v", err)
+		klog.Errorf("PopulateChildDatastores failed. Err: %v", err)
 		return nil, err
 	}
 
@@ -279,7 +279,7 @@ func (sp *StoragePod) GetFirstClassDisk(ctx context.Context, diskID string, find
 	for _, child := range sp.Datastores {
 		oids, err := m.List(ctx, child)
 		if err != nil {
-			glog.Errorf("Failed to list disks. Err: %v", err)
+			klog.Errorf("Failed to list disks. Err: %v", err)
 			return nil, err
 		}
 

--- a/pkg/common/vclib/utils.go
+++ b/pkg/common/vclib/utils.go
@@ -22,7 +22,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -140,7 +140,7 @@ func GetPathFromVMDiskPath(vmDiskPath string) string {
 	datastorePathObj := new(object.DatastorePath)
 	isSuccess := datastorePathObj.FromString(vmDiskPath)
 	if !isSuccess {
-		glog.Errorf("Failed to parse vmDiskPath: %s", vmDiskPath)
+		klog.Errorf("Failed to parse vmDiskPath: %s", vmDiskPath)
 		return ""
 	}
 	return datastorePathObj.Path
@@ -151,7 +151,7 @@ func GetDatastorePathObjFromVMDiskPath(vmDiskPath string) (*object.DatastorePath
 	datastorePathObj := new(object.DatastorePath)
 	isSuccess := datastorePathObj.FromString(vmDiskPath)
 	if !isSuccess {
-		glog.Errorf("Failed to parse volPath: %s", vmDiskPath)
+		klog.Errorf("Failed to parse volPath: %s", vmDiskPath)
 		return nil, fmt.Errorf("Failed to parse volPath: %s", vmDiskPath)
 	}
 	return datastorePathObj, nil

--- a/pkg/common/vclib/virtualmachine.go
+++ b/pkg/common/vclib/virtualmachine.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
@@ -52,7 +52,7 @@ func (vm *VirtualMachine) IsDiskAttached(ctx context.Context, diskPath string) (
 func (vm *VirtualMachine) DeleteVM(ctx context.Context) error {
 	destroyTask, err := vm.Destroy(ctx)
 	if err != nil {
-		glog.Errorf("Failed to delete the VM: %q. err: %+v", vm.InventoryPath, err)
+		klog.Errorf("Failed to delete the VM: %q. err: %+v", vm.InventoryPath, err)
 		return err
 	}
 	return destroyTask.Wait(ctx)
@@ -69,7 +69,7 @@ func (vm *VirtualMachine) AttachDisk(ctx context.Context, vmDiskPath string, vol
 	vmDiskPath = RemoveStorageClusterORFolderNameFromVDiskPath(vmDiskPath)
 	attached, err := vm.IsDiskAttached(ctx, vmDiskPath)
 	if err != nil {
-		glog.Errorf("Error occurred while checking if disk is attached on VM: %q. vmDiskPath: %q, err: %+v", vm.InventoryPath, vmDiskPath, err)
+		klog.Errorf("Error occurred while checking if disk is attached on VM: %q. vmDiskPath: %q, err: %+v", vm.InventoryPath, vmDiskPath, err)
 		return "", err
 	}
 	// If disk is already attached, return the disk UUID
@@ -81,31 +81,31 @@ func (vm *VirtualMachine) AttachDisk(ctx context.Context, vmDiskPath string, vol
 	if volumeOptions.StoragePolicyName != "" {
 		pbmClient, err := NewPbmClient(ctx, vm.Client())
 		if err != nil {
-			glog.Errorf("Error occurred while creating new pbmClient. err: %+v", err)
+			klog.Errorf("Error occurred while creating new pbmClient. err: %+v", err)
 			return "", err
 		}
 
 		volumeOptions.StoragePolicyID, err = pbmClient.ProfileIDByName(ctx, volumeOptions.StoragePolicyName)
 		if err != nil {
-			glog.Errorf("Failed to get Profile ID by name: %s. err: %+v", volumeOptions.StoragePolicyName, err)
+			klog.Errorf("Failed to get Profile ID by name: %s. err: %+v", volumeOptions.StoragePolicyName, err)
 			return "", err
 		}
 	}
 
 	dsObj, err := vm.Datacenter.GetDatastoreByPath(ctx, vmDiskPathCopy)
 	if err != nil {
-		glog.Errorf("Failed to get datastore from vmDiskPath: %q. err: %+v", vmDiskPath, err)
+		klog.Errorf("Failed to get datastore from vmDiskPath: %q. err: %+v", vmDiskPath, err)
 		return "", err
 	}
 	// If disk is not attached, create a disk spec for disk to be attached to the VM.
 	disk, newSCSIController, err := vm.CreateDiskSpec(ctx, vmDiskPath, dsObj.Datastore, volumeOptions)
 	if err != nil {
-		glog.Errorf("Error occurred while creating disk spec. err: %+v", err)
+		klog.Errorf("Error occurred while creating disk spec. err: %+v", err)
 		return "", err
 	}
 	vmDevices, err := vm.Device(ctx)
 	if err != nil {
-		glog.Errorf("Failed to retrieve VM devices for VM: %q. err: %+v", vm.InventoryPath, err)
+		klog.Errorf("Failed to retrieve VM devices for VM: %q. err: %+v", vm.InventoryPath, err)
 		return "", err
 	}
 	virtualMachineConfigSpec := types.VirtualMachineConfigSpec{}
@@ -125,7 +125,7 @@ func (vm *VirtualMachine) AttachDisk(ctx context.Context, vmDiskPath string, vol
 	task, err := vm.Reconfigure(ctx, virtualMachineConfigSpec)
 	if err != nil {
 		RecordvSphereMetric(APIAttachVolume, requestTime, err)
-		glog.Errorf("Failed to attach the disk with storagePolicy: %q on VM: %q. err - %+v", volumeOptions.StoragePolicyID, vm.InventoryPath, err)
+		klog.Errorf("Failed to attach the disk with storagePolicy: %q on VM: %q. err - %+v", volumeOptions.StoragePolicyID, vm.InventoryPath, err)
 		if newSCSIController != nil {
 			vm.deleteController(ctx, newSCSIController, vmDevices)
 		}
@@ -134,7 +134,7 @@ func (vm *VirtualMachine) AttachDisk(ctx context.Context, vmDiskPath string, vol
 	err = task.Wait(ctx)
 	RecordvSphereMetric(APIAttachVolume, requestTime, err)
 	if err != nil {
-		glog.Errorf("Failed to attach the disk with storagePolicy: %+q on VM: %q. err - %+v", volumeOptions.StoragePolicyID, vm.InventoryPath, err)
+		klog.Errorf("Failed to attach the disk with storagePolicy: %+q on VM: %q. err - %+v", volumeOptions.StoragePolicyID, vm.InventoryPath, err)
 		if newSCSIController != nil {
 			vm.deleteController(ctx, newSCSIController, vmDevices)
 		}
@@ -144,7 +144,7 @@ func (vm *VirtualMachine) AttachDisk(ctx context.Context, vmDiskPath string, vol
 	// Once disk is attached, get the disk UUID.
 	diskUUID, err := vm.Datacenter.GetVirtualDiskPage83Data(ctx, vmDiskPath)
 	if err != nil {
-		glog.Errorf("Error occurred while getting Disk Info from VM: %q. err: %v", vm.InventoryPath, err)
+		klog.Errorf("Error occurred while getting Disk Info from VM: %q. err: %v", vm.InventoryPath, err)
 		vm.DetachDisk(ctx, vmDiskPath)
 		if newSCSIController != nil {
 			vm.deleteController(ctx, newSCSIController, vmDevices)
@@ -159,11 +159,11 @@ func (vm *VirtualMachine) DetachDisk(ctx context.Context, vmDiskPath string) err
 	vmDiskPath = RemoveStorageClusterORFolderNameFromVDiskPath(vmDiskPath)
 	device, err := vm.getVirtualDeviceByPath(ctx, vmDiskPath)
 	if err != nil {
-		glog.Errorf("Disk ID not found for VM: %q with diskPath: %q", vm.InventoryPath, vmDiskPath)
+		klog.Errorf("Disk ID not found for VM: %q with diskPath: %q", vm.InventoryPath, vmDiskPath)
 		return err
 	}
 	if device == nil {
-		glog.Warningf("No virtual device found with diskPath: %q on VM: %q", vmDiskPath, vm.InventoryPath)
+		klog.Warningf("No virtual device found with diskPath: %q on VM: %q", vmDiskPath, vm.InventoryPath)
 		return nil
 	}
 	// Detach disk from VM
@@ -171,7 +171,7 @@ func (vm *VirtualMachine) DetachDisk(ctx context.Context, vmDiskPath string) err
 	err = vm.RemoveDevice(ctx, true, device)
 	RecordvSphereMetric(APIDetachVolume, requestTime, err)
 	if err != nil {
-		glog.Errorf("Error occurred while removing disk device for VM: %q. err: %v", vm.InventoryPath, err)
+		klog.Errorf("Error occurred while removing disk device for VM: %q. err: %v", vm.InventoryPath, err)
 		return err
 	}
 	return nil
@@ -181,7 +181,7 @@ func (vm *VirtualMachine) DetachDisk(ctx context.Context, vmDiskPath string) err
 func (vm *VirtualMachine) GetResourcePool(ctx context.Context) (*object.ResourcePool, error) {
 	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{"resourcePool"})
 	if err != nil {
-		glog.Errorf("Failed to get resource pool from VM: %q. err: %+v", vm.InventoryPath, err)
+		klog.Errorf("Failed to get resource pool from VM: %q. err: %+v", vm.InventoryPath, err)
 		return nil, err
 	}
 	return object.NewResourcePool(vm.Client(), vmMoList[0].ResourcePool.Reference()), nil
@@ -192,7 +192,7 @@ func (vm *VirtualMachine) GetResourcePool(ctx context.Context) (*object.Resource
 func (vm *VirtualMachine) IsActive(ctx context.Context) (bool, error) {
 	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{"summary"})
 	if err != nil {
-		glog.Errorf("Failed to get VM Managed object with property summary. err: +%v", err)
+		klog.Errorf("Failed to get VM Managed object with property summary. err: +%v", err)
 		return false, err
 	}
 	if vmMoList[0].Summary.Runtime.PowerState == ActivePowerState {
@@ -206,14 +206,14 @@ func (vm *VirtualMachine) IsActive(ctx context.Context) (bool, error) {
 func (vm *VirtualMachine) GetAllAccessibleDatastores(ctx context.Context) ([]*DatastoreInfo, error) {
 	host, err := vm.HostSystem(ctx)
 	if err != nil {
-		glog.Errorf("Failed to get host system for VM: %q. err: %+v", vm.InventoryPath, err)
+		klog.Errorf("Failed to get host system for VM: %q. err: %+v", vm.InventoryPath, err)
 		return nil, err
 	}
 	var hostSystemMo mo.HostSystem
 	s := object.NewSearchIndex(vm.Client())
 	err = s.Properties(ctx, host.Reference(), []string{DatastoreProperty}, &hostSystemMo)
 	if err != nil {
-		glog.Errorf("Failed to retrieve datastores for host: %+v. err: %+v", host, err)
+		klog.Errorf("Failed to retrieve datastores for host: %+v. err: %+v", host, err)
 		return nil, err
 	}
 	var dsRefList []types.ManagedObjectReference
@@ -226,11 +226,11 @@ func (vm *VirtualMachine) GetAllAccessibleDatastores(ctx context.Context) ([]*Da
 	properties := []string{DatastoreInfoProperty}
 	err = pc.Retrieve(ctx, dsRefList, properties, &dsMoList)
 	if err != nil {
-		glog.Errorf("Failed to get Datastore managed objects from datastore objects."+
+		klog.Errorf("Failed to get Datastore managed objects from datastore objects."+
 			" dsObjList: %+v, properties: %+v, err: %v", dsRefList, properties, err)
 		return nil, err
 	}
-	glog.V(9).Infof("Result dsMoList: %+v", dsMoList)
+	klog.V(9).Infof("Result dsMoList: %+v", dsMoList)
 	var dsObjList []*DatastoreInfo
 	for _, dsMo := range dsMoList {
 		dsObjList = append(dsObjList,
@@ -247,7 +247,7 @@ func (vm *VirtualMachine) CreateDiskSpec(ctx context.Context, diskPath string, d
 	var newSCSIController types.BaseVirtualDevice
 	vmDevices, err := vm.Device(ctx)
 	if err != nil {
-		glog.Errorf("Failed to retrieve VM devices. err: %+v", err)
+		klog.Errorf("Failed to retrieve VM devices. err: %+v", err)
 		return nil, nil, err
 	}
 	// find SCSI controller of particular type from VM devices
@@ -256,20 +256,20 @@ func (vm *VirtualMachine) CreateDiskSpec(ctx context.Context, diskPath string, d
 	if scsiController == nil {
 		newSCSIController, err = vm.createAndAttachSCSIController(ctx, volumeOptions.SCSIControllerType)
 		if err != nil {
-			glog.Errorf("Failed to create SCSI controller for VM :%q with err: %+v", vm.InventoryPath, err)
+			klog.Errorf("Failed to create SCSI controller for VM :%q with err: %+v", vm.InventoryPath, err)
 			return nil, nil, err
 		}
 		// Get VM device list
 		vmDevices, err := vm.Device(ctx)
 		if err != nil {
-			glog.Errorf("Failed to retrieve VM devices. err: %v", err)
+			klog.Errorf("Failed to retrieve VM devices. err: %v", err)
 			return nil, nil, err
 		}
 		// verify scsi controller in virtual machine
 		scsiControllersOfRequiredType := getSCSIControllersOfType(vmDevices, volumeOptions.SCSIControllerType)
 		scsiController = getAvailableSCSIController(scsiControllersOfRequiredType)
 		if scsiController == nil {
-			glog.Errorf("Cannot find SCSI controller of type: %q in VM", volumeOptions.SCSIControllerType)
+			klog.Errorf("Cannot find SCSI controller of type: %q in VM", volumeOptions.SCSIControllerType)
 			// attempt clean up of scsi controller
 			vm.deleteController(ctx, newSCSIController, vmDevices)
 			return nil, nil, fmt.Errorf("Cannot find SCSI controller of type: %q in VM", volumeOptions.SCSIControllerType)
@@ -278,7 +278,7 @@ func (vm *VirtualMachine) CreateDiskSpec(ctx context.Context, diskPath string, d
 	disk := vmDevices.CreateDisk(scsiController, dsObj.Reference(), diskPath)
 	unitNumber, err := getNextUnitNumber(vmDevices, scsiController)
 	if err != nil {
-		glog.Errorf("Cannot attach disk to VM, unitNumber limit reached - %+v.", err)
+		klog.Errorf("Cannot attach disk to VM, unitNumber limit reached - %+v.", err)
 		return nil, nil, err
 	}
 	*disk.UnitNumber = unitNumber
@@ -307,7 +307,7 @@ func (vm *VirtualMachine) CreateDiskSpec(ctx context.Context, diskPath string, d
 func (vm *VirtualMachine) GetVirtualDiskPath(ctx context.Context) (string, error) {
 	vmDevices, err := vm.Device(ctx)
 	if err != nil {
-		glog.Errorf("Failed to get the devices for VM: %q. err: %+v", vm.InventoryPath, err)
+		klog.Errorf("Failed to get the devices for VM: %q. err: %+v", vm.InventoryPath, err)
 		return "", err
 	}
 	// filter vm devices to retrieve device for the given vmdk file identified by disk path
@@ -327,18 +327,18 @@ func (vm *VirtualMachine) createAndAttachSCSIController(ctx context.Context, dis
 	// Get VM device list
 	vmDevices, err := vm.Device(ctx)
 	if err != nil {
-		glog.Errorf("Failed to retrieve VM devices for VM: %q. err: %+v", vm.InventoryPath, err)
+		klog.Errorf("Failed to retrieve VM devices for VM: %q. err: %+v", vm.InventoryPath, err)
 		return nil, err
 	}
 	allSCSIControllers := getSCSIControllers(vmDevices)
 	if len(allSCSIControllers) >= SCSIControllerLimit {
 		// we reached the maximum number of controllers we can attach
-		glog.Errorf("SCSI Controller Limit of %d has been reached, cannot create another SCSI controller", SCSIControllerLimit)
+		klog.Errorf("SCSI Controller Limit of %d has been reached, cannot create another SCSI controller", SCSIControllerLimit)
 		return nil, fmt.Errorf("SCSI Controller Limit of %d has been reached, cannot create another SCSI controller", SCSIControllerLimit)
 	}
 	newSCSIController, err := vmDevices.CreateSCSIController(diskControllerType)
 	if err != nil {
-		glog.Errorf("Failed to create new SCSI controller on VM: %q. err: %+v", vm.InventoryPath, err)
+		klog.Errorf("Failed to create new SCSI controller on VM: %q. err: %+v", vm.InventoryPath, err)
 		return nil, err
 	}
 	configNewSCSIController := newSCSIController.(types.BaseVirtualSCSIController).GetVirtualSCSIController()
@@ -349,7 +349,7 @@ func (vm *VirtualMachine) createAndAttachSCSIController(ctx context.Context, dis
 	// add the scsi controller to virtual machine
 	err = vm.AddDevice(context.TODO(), newSCSIController)
 	if err != nil {
-		glog.V(LogLevel).Infof("Cannot add SCSI controller to VM: %q. err: %+v", vm.InventoryPath, err)
+		klog.V(LogLevel).Infof("Cannot add SCSI controller to VM: %q. err: %+v", vm.InventoryPath, err)
 		// attempt clean up of scsi controller
 		vm.deleteController(ctx, newSCSIController, vmDevices)
 		return nil, err
@@ -361,7 +361,7 @@ func (vm *VirtualMachine) createAndAttachSCSIController(ctx context.Context, dis
 func (vm *VirtualMachine) getVirtualDeviceByPath(ctx context.Context, diskPath string) (types.BaseVirtualDevice, error) {
 	vmDevices, err := vm.Device(ctx)
 	if err != nil {
-		glog.Errorf("Failed to get the devices for VM: %q. err: %+v", vm.InventoryPath, err)
+		klog.Errorf("Failed to get the devices for VM: %q. err: %+v", vm.InventoryPath, err)
 		return nil, err
 	}
 
@@ -371,7 +371,7 @@ func (vm *VirtualMachine) getVirtualDeviceByPath(ctx context.Context, diskPath s
 			virtualDevice := device.GetVirtualDevice()
 			if backing, ok := virtualDevice.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
 				if matchVirtualDiskAndVolPath(backing.FileName, diskPath) {
-					glog.V(LogLevel).Infof("Found VirtualDisk backing with filename %q for diskPath %q", backing.FileName, diskPath)
+					klog.V(LogLevel).Infof("Found VirtualDisk backing with filename %q for diskPath %q", backing.FileName, diskPath)
 					return device, nil
 				}
 			}
@@ -418,7 +418,7 @@ func (vm *VirtualMachine) deleteController(ctx context.Context, controllerDevice
 	device := controllerDeviceList[len(controllerDeviceList)-1]
 	err := vm.RemoveDevice(ctx, true, device)
 	if err != nil {
-		glog.Errorf("Error occurred while removing device on VM: %q. err: %+v", vm.InventoryPath, err)
+		klog.Errorf("Error occurred while removing device on VM: %q. err: %+v", vm.InventoryPath, err)
 		return err
 	}
 	return nil

--- a/pkg/common/vclib/volumeoptions.go
+++ b/pkg/common/vclib/volumeoptions.go
@@ -19,7 +19,7 @@ package vclib
 import (
 	"strings"
 
-	"github.com/golang/glog"
+	"k8s.io/klog"
 )
 
 // VolumeOptions specifies various options for a volume.
@@ -59,7 +59,7 @@ func DiskformatValidOptions() string {
 // CheckDiskFormatSupported checks if the diskFormat is valid
 func CheckDiskFormatSupported(diskFormat string) bool {
 	if DiskFormatValidType[diskFormat] == "" {
-		glog.Errorf("Not a valid Disk Format. Valid options are %+q", DiskformatValidOptions())
+		klog.Errorf("Not a valid Disk Format. Valid options are %+q", DiskformatValidOptions())
 		return false
 	}
 	return true
@@ -82,7 +82,7 @@ func CheckControllerSupported(ctrlType string) bool {
 			return true
 		}
 	}
-	glog.Errorf("Not a valid SCSI Controller Type. Valid options are %q", SCSIControllerTypeValidOptions())
+	klog.Errorf("Not a valid SCSI Controller Type. Valid options are %q", SCSIControllerTypeValidOptions())
 	return false
 }
 

--- a/pkg/csi/service/service.go
+++ b/pkg/csi/service/service.go
@@ -96,16 +96,16 @@ func (s *service) BeforeServe(
 	// Get the SP's operating mode.
 	s.mode = csictx.Getenv(ctx, gocsi.EnvVarMode)
 
-	// Set glog level based on CSI debug being enabled
-	glogLevel := "2"
+	// Set klog level based on CSI debug being enabled
+	klogLevel := "2"
 	lvl := log.GetLevel()
 	if lvl == log.DebugLevel {
-		glogLevel = "4"
+		klogLevel = "4"
 	}
 
 	flag.Set("logtostderr", "true")
 	flag.Set("stderrthreshold", "INFO")
-	flag.Set("v", glogLevel)
+	flag.Set("v", klogLevel)
 	flag.Parse()
 
 	if !strings.EqualFold(s.mode, "node") {


### PR DESCRIPTION
**What this PR does / why we need it**:
The kubernetes community is moving away from glog to klog. This updates all components (CCM, CSI, CLI) used to klog.

**Which issue this PR fixes**:
https://github.com/kubernetes/cloud-provider-vsphere/issues/137

**Special notes for your reviewer**:
Tested CCM and CSI on:
- k8s 1.13.1 cluster with 10 worker nodes in 3 zones
- vSphere 6.7u1

**Release note**:
Internal package change
