### PR TITLE
Check for min vCenter version

### DIFF
--- a/pkg/common/connectionmanager/connectionmanager.go
+++ b/pkg/common/connectionmanager/connectionmanager.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"sync"
 
-	"k8s.io/klog"
 	"k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog"
 
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
 	cm "k8s.io/cloud-provider-vsphere/pkg/common/credentialmanager"
@@ -187,4 +187,18 @@ func (cm *ConnectionManager) VerifyWithContext(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// APIVersion returns the version of the vCenter API
+func (cm *ConnectionManager) APIVersion(vcenter string) (string, error) {
+	if err := cm.Connect(context.Background(), vcenter); err != nil {
+		return "", err
+	}
+
+	instance := cm.VsphereInstanceMap[vcenter]
+	if instance == nil || instance.Conn.Client == nil {
+		return "", ErrConnectionNotFound
+	}
+
+	return instance.Conn.Client.ServiceContent.About.ApiVersion, nil
 }

--- a/pkg/common/vclib/connection.go
+++ b/pkg/common/vclib/connection.go
@@ -24,11 +24,11 @@ import (
 	neturl "net/url"
 	"sync"
 
-	"k8s.io/klog"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/sts"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
+	"k8s.io/klog"
 )
 
 // VSphereConnection contains information for connecting to vCenter

--- a/pkg/csi/service/fcd/controller.go
+++ b/pkg/csi/service/fcd/controller.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 
 	"github.com/vmware/govmomi/units"
@@ -70,6 +71,20 @@ func (c *controller) Init(config *vcfg.Config) error {
 	c.cfg = config
 	c.connMgr = connMgr
 	c.informMgr = informMgr
+
+	//VC check... FCD is only supported in 6.5+
+	for vc := range connMgr.VsphereInstanceMap {
+		api, err := connMgr.APIVersion(vc)
+		if err != nil {
+			klog.Errorf("APIVersion failed err=%v", err)
+			return err
+		}
+
+		if err = checkAPI(api); err != nil {
+			klog.Errorf("checkAPI failed err=%v", err)
+			return err
+		}
+	}
 
 	return nil
 }

--- a/pkg/csi/service/fcd/vsphere_helper.go
+++ b/pkg/csi/service/fcd/vsphere_helper.go
@@ -17,7 +17,9 @@ limitations under the License.
 package fcd
 
 import (
+	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,7 +33,34 @@ import (
 const (
 	NUM_OF_CONNECTION_ATTEMPTS     int = 3
 	RETRY_ATTEMPT_DELAY_IN_SECONDS int = 1
+
+	MINIMUM_SUPPORTED_VCENTER_MAJOR int = 6
+	MINIMUM_SUPPORTED_VCENTER_MINOR int = 5
 )
+
+func checkAPI(version string) error {
+	items := strings.Split(version, ".")
+	if len(items) <= 1 {
+		return fmt.Errorf("Invalid API Version format")
+	}
+
+	major, err := strconv.Atoi(items[0])
+	if err != nil {
+		return fmt.Errorf("Invalid Major Version value invalid")
+	}
+	minor, err := strconv.Atoi(items[1])
+	if err != nil {
+		return fmt.Errorf("Invalid Minor Version value invalid")
+	}
+
+	if major < MINIMUM_SUPPORTED_VCENTER_MAJOR {
+		return fmt.Errorf("The minimum supported vCenter is 6.5")
+	}
+	if major == MINIMUM_SUPPORTED_VCENTER_MAJOR && minor < MINIMUM_SUPPORTED_VCENTER_MINOR {
+		return fmt.Errorf("The minimum supported vCenter is 6.5")
+	}
+	return nil
+}
 
 func removePortFromHost(host string) string {
 	result := host

--- a/pkg/csi/service/fcd/vsphere_helper_test.go
+++ b/pkg/csi/service/fcd/vsphere_helper_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fcd
+
+import (
+	"testing"
+)
+
+func TestAPIInvalid(t *testing.T) {
+	err := checkAPI("test")
+	if err == nil {
+		t.Error("Excepted failure. Invalid version string")
+	}
+}
+
+func TestDoesntMeetMinMajorVersion(t *testing.T) {
+	err := checkAPI("5.6.0")
+	if err == nil {
+		t.Error("Excepted failure. Does not meet minimum major version")
+	}
+}
+
+func TestDoesntMeetMinMinorVersion(t *testing.T) {
+	err := checkAPI("6.1.0")
+	if err == nil {
+		t.Error("Excepted failure. Does not meet minimum minor version")
+	}
+}
+
+func TestSupportedVersion(t *testing.T) {
+	err := checkAPI("6.5.0")
+	if err != nil {
+		t.Errorf("This is a supported vCenter version err=%v", err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This checks the minimum vCenter API version (which is 6.5) on the CSI FCD controller. If unsupported, the controller will print an error message and will fail to start the controller service.

I had hopes that we could check clusters within DCs, but quickly realized that there could be clusters that are being used to manage non-Kubernetes earmarked clusters that can be of an older ESX version. Only check that can be done without going through a bunch of hoops is checking the vCenter API version. Docs already outline the support matrix for the CSI driver.

**Which issue this PR fixes**:
https://github.com/kubernetes/cloud-provider-vsphere/issues/139

**Special notes for your reviewer**:
Added go tests to check the boundary cases.

Tested CCM and CSI on:
- k8s 1.13.1 cluster with 10 worker nodes in 3 zones
- vSphere 6.7u1

**Release note**:
NA