### PR TITLE
Bug fix for NodeManager and Photon 2 UUID

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -44,13 +44,7 @@ func TestRegUnregNode(t *testing.T) {
 	}
 	vsphere.connectionManager = cm.NewConnectionManager(&cfg, nil)
 
-	nm := NodeManager{
-		nodeNameMap:       make(map[string]*NodeInfo),
-		nodeUUIDMap:       make(map[string]*NodeInfo),
-		nodeRegUUIDMap:    make(map[string]*v1.Node),
-		vcList:            make(map[string]*VCenterInfo),
-		connectionManager: vsphere.connectionManager,
-	}
+	nm := newNodeManager(vsphere.connectionManager, nil)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name
@@ -117,13 +111,7 @@ func TestDiscoverNodeByName(t *testing.T) {
 	vsphere.connectionManager = cm.NewConnectionManager(&cfg, nil)
 	defer vsphere.connectionManager.Logout()
 
-	nm := NodeManager{
-		nodeNameMap:       make(map[string]*NodeInfo),
-		nodeUUIDMap:       make(map[string]*NodeInfo),
-		nodeRegUUIDMap:    make(map[string]*v1.Node),
-		vcList:            make(map[string]*VCenterInfo),
-		connectionManager: vsphere.connectionManager,
-	}
+	nm := newNodeManager(vsphere.connectionManager, nil)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name
@@ -162,13 +150,7 @@ func TestExport(t *testing.T) {
 	vsphere.connectionManager = cm.NewConnectionManager(&cfg, nil)
 	defer vsphere.connectionManager.Logout()
 
-	nm := NodeManager{
-		nodeNameMap:       make(map[string]*NodeInfo),
-		nodeUUIDMap:       make(map[string]*NodeInfo),
-		nodeRegUUIDMap:    make(map[string]*v1.Node),
-		vcList:            make(map[string]*VCenterInfo),
-		connectionManager: vsphere.connectionManager,
-	}
+	nm := newNodeManager(vsphere.connectionManager, nil)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name

--- a/pkg/cloudprovider/vsphere/util_test.go
+++ b/pkg/cloudprovider/vsphere/util_test.go
@@ -39,3 +39,17 @@ func TestUUIDConvert2(t *testing.T) {
 		t.Errorf("Failed to translate UUID")
 	}
 }
+
+func TestUUIDConvertAndRevert(t *testing.T) {
+	k8sUUID := "42278c9d-79fb-f2af-b060-d7f167fa261c"
+
+	//converts
+	tmpUUID := ConvertK8sUUIDtoNormal(k8sUUID)
+
+	//reverts to original
+	orgUUID := ConvertK8sUUIDtoNormal(tmpUUID)
+
+	if orgUUID != "42278c9d-79fb-f2af-b060-d7f167fa261c" {
+		t.Errorf("Failed to revert UUID")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes:
- a crash in the NodeManager when the VM is not found via UUID introduced accidentally with this PR https://github.com/kubernetes/cloud-provider-vsphere/pull/136 Missing a return statement: https://github.com/kubernetes/cloud-provider-vsphere/pull/143/files#diff-b7f52468613fc2d2fc4b257bed84a46cR138
- a bug with the way Photon 2 reports the UUID which is then passed from the kubelet to the CCM. It does not conform to the way the RHEL, Ubuntu, and etc reports it. The reporting format of the UUID has been fixed in Photon 3 though.

**Which issue this PR fixes**:
https://github.com/kubernetes/cloud-provider-vsphere/issues/142

**Special notes for your reviewer**:
Added go tests to check UUID revert.

Tested CCM and CSI on:
- k8s 1.13.1 cluster with 10 worker nodes in 3 zones
- vSphere 6.7u1
- OS: RHEL

**Release note**:
NA