### PR TITLE
Part 1: Add CSI go tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -493,7 +493,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:324f1888e6b2dcfa1efa164ae9a874e77b40ac5f785e2eb548d3ae86f502731f"
+  digest = "1:def93e6ee66630a1ce72a909c9a5b6079e03bb6cd3bc27ff5b15f6ccc48dfaf8"
   name = "github.com/vmware/govmomi"
   packages = [
     ".",
@@ -537,7 +537,7 @@
     "vslm",
   ]
   pruneopts = "UT"
-  revision = "6712f991d8852a25ae4304a720463301c1ac4c64"
+  revision = "3ee8bd5caec4398650ed36dd12e7c140588151ef"
 
 [[projects]]
   branch = "master"

--- a/pkg/cloudprovider/vsphere/zones_test.go
+++ b/pkg/cloudprovider/vsphere/zones_test.go
@@ -15,6 +15,7 @@ package vsphere
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -113,7 +114,13 @@ func TestZones(t *testing.T) {
 	pc := property.DefaultCollector(vsi.Conn.Client)
 
 	// Tag manager instance
-	m := tags.NewManager(rest.NewClient(vsi.Conn.Client))
+	c := rest.NewClient(vsi.Conn.Client)
+	user := url.UserPassword(vsi.Conn.Username, vsi.Conn.Password)
+	if err := c.Login(ctx, user); err != nil {
+		t.Fatalf("Rest login failed. err=%v", err)
+	}
+
+	m := tags.NewManager(c)
 
 	// Create a region category
 	regionID, err := m.CreateCategory(ctx, &tags.Category{Name: vs.cfg.Labels.Region})

--- a/pkg/common/connectionmanager/zones.go
+++ b/pkg/common/connectionmanager/zones.go
@@ -57,11 +57,11 @@ func (cm *ConnectionManager) WhichVCandDCByZone(ctx context.Context,
 	}
 
 	if numOfVCs == 1 {
-		klog.V(4).Info("Single VC Detected")
+		klog.Info("Single VC Detected")
 		return cm.getDIFromSingleVC(ctx, zoneLabel, regionLabel, zoneLooking, regionLooking)
 	}
 
-	klog.V(4).Info("Multi VC Detected")
+	klog.Info("Multi VC Detected")
 	return cm.getDIFromMultiVCorDC(ctx, zoneLabel, regionLabel, zoneLooking, regionLooking)
 }
 
@@ -100,12 +100,12 @@ func (cm *ConnectionManager) getDIFromSingleVC(ctx context.Context,
 
 	// More than 1 DC in this VC
 	if numOfDc > 1 {
-		klog.V(3).Info("Multi Datacenter configuration detected")
+		klog.Info("Multi Datacenter configuration detected")
 		return cm.getDIFromMultiVCorDC(ctx, zoneLabel, regionLabel, zoneLooking, regionLooking)
 	}
 
 	// We are sure this is single VC and DC
-	klog.V(3).Info("Single vCenter/Datacenter configuration detected")
+	klog.Info("Single vCenter/Datacenter configuration detected")
 
 	datacenterObjs, err := vclib.GetAllDatacenter(ctx, tmpVsi.Conn)
 	if err != nil {
@@ -149,7 +149,7 @@ func (cm *ConnectionManager) getDIFromMultiVCorDC(ctx context.Context,
 
 func (cm *ConnectionManager) getDIFromMultiVCorDCNonVM(ctx context.Context,
 	zoneLabel string, regionLabel string, zoneLooking string, regionLooking string) (*ZoneDiscoveryInfo, error) {
-	klog.V(4).Infof("getDIFromMultiVCorDCNonVM called with zone: %s and region: %s", zoneLooking, regionLooking)
+	klog.Infof("getDIFromMultiVCorDCNonVM called with zone: %s and region: %s", zoneLooking, regionLooking)
 
 	if len(zoneLabel) == 0 || len(regionLabel) == 0 || len(zoneLooking) == 0 || len(regionLooking) == 0 {
 		err := ErrMultiVCRequiresZones
@@ -259,7 +259,7 @@ func (cm *ConnectionManager) getDIFromMultiVCorDCNonVM(ctx context.Context,
 				}
 
 				for _, cluster := range clusterList {
-					klog.V(4).Infof("Finding zone in vc=%s and datacenter=%s and cluster=%s",
+					klog.V(3).Infof("Finding zone in vc=%s and datacenter=%s and cluster=%s",
 						vc, datacenterObj.Name(), cluster.Name())
 					queueChannel <- &zoneSearch{
 						vc:         vc,

--- a/pkg/common/vclib/custom_errors.go
+++ b/pkg/common/vclib/custom_errors.go
@@ -20,24 +20,26 @@ import "errors"
 
 // Error Messages
 const (
-	FileAlreadyExistErrMsg     = "File requested already exist"
-	NoDevicesFoundErrMsg       = "No devices found"
-	DiskNotFoundErrMsg         = "No vSphere disk ID/Name found"
-	InvalidVolumeOptionsErrMsg = "VolumeOptions verification failed"
-	NoVMFoundErrMsg            = "No VM found"
-	NoZoneRegionFoundErrMsg    = "Unable to find the Zone/Region pair"
-	NoDatastoreFoundErrMsg     = "Datastore not found"
-	NoDatacenterFoundErrMsg    = "Datacenter not found"
+	FileAlreadyExistErrMsg         = "File requested already exist"
+	NoDevicesFoundErrMsg           = "No devices found"
+	DiskNotFoundErrMsg             = "No vSphere disk ID/Name found"
+	InvalidVolumeOptionsErrMsg     = "VolumeOptions verification failed"
+	NoVMFoundErrMsg                = "No VM found"
+	NoZoneRegionFoundErrMsg        = "Unable to find the Zone/Region pair"
+	NoDatastoreFoundErrMsg         = "Datastore not found"
+	NoDatacenterFoundErrMsg        = "Datacenter not found"
+	NoDataStoreClustersFoundErrMsg = "No DatastoreClusters Found"
 )
 
 // Error constants
 var (
-	ErrFileAlreadyExist     = errors.New(FileAlreadyExistErrMsg)
-	ErrNoDevicesFound       = errors.New(NoDevicesFoundErrMsg)
-	ErrNoDiskIDFound        = errors.New(DiskNotFoundErrMsg)
-	ErrInvalidVolumeOptions = errors.New(InvalidVolumeOptionsErrMsg)
-	ErrNoVMFound            = errors.New(NoVMFoundErrMsg)
-	ErrNoZoneRegionFound    = errors.New(NoZoneRegionFoundErrMsg)
-	ErrNoDatastoreFound     = errors.New(NoDatastoreFoundErrMsg)
-	ErrNoDatacenterFound    = errors.New(NoDatacenterFoundErrMsg)
+	ErrFileAlreadyExist         = errors.New(FileAlreadyExistErrMsg)
+	ErrNoDevicesFound           = errors.New(NoDevicesFoundErrMsg)
+	ErrNoDiskIDFound            = errors.New(DiskNotFoundErrMsg)
+	ErrInvalidVolumeOptions     = errors.New(InvalidVolumeOptionsErrMsg)
+	ErrNoVMFound                = errors.New(NoVMFoundErrMsg)
+	ErrNoZoneRegionFound        = errors.New(NoZoneRegionFoundErrMsg)
+	ErrNoDatastoreFound         = errors.New(NoDatastoreFoundErrMsg)
+	ErrNoDatacenterFound        = errors.New(NoDatacenterFoundErrMsg)
+	ErrNoDataStoreClustersFound = errors.New(NoDataStoreClustersFoundErrMsg)
 )

--- a/pkg/common/vclib/virtualmachine.go
+++ b/pkg/common/vclib/virtualmachine.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/klog"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+	"k8s.io/klog"
 )
 
 // VirtualMachine extends the govmomi VirtualMachine object

--- a/pkg/csi/service/fcd/controller.go
+++ b/pkg/csi/service/fcd/controller.go
@@ -412,7 +412,7 @@ func (c *controller) ListVolumes(
 
 	stop := total
 	if req.MaxEntries != 0 && stop > int(req.MaxEntries) {
-		stop = start + int(req.MaxEntries)
+		stop = start + int(req.MaxEntries) - 1
 	}
 
 	log.Infof("Start: %d, End: %d, Total: %d", start, stop, total)
@@ -424,12 +424,10 @@ func (c *controller) ListVolumes(
 		msg := fmt.Sprintf("Invalid start token %d. Greater than total items %d.", start, total)
 		log.Errorf(msg)
 		return nil, status.Errorf(codes.Internal, msg)
-	} else if start == stop {
-		subsetFirstClassDisks = firstClassDisks[(start - 1):]
 	} else if stop >= total {
 		subsetFirstClassDisks = firstClassDisks[start:]
 	} else if stop < total {
-		subsetFirstClassDisks = firstClassDisks[start:stop]
+		subsetFirstClassDisks = firstClassDisks[start:(stop + 1)]
 	}
 
 	for _, firstClassDisk := range subsetFirstClassDisks {

--- a/pkg/csi/service/fcd/controller_test.go
+++ b/pkg/csi/service/fcd/controller_test.go
@@ -1,0 +1,621 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fcd
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	lookup "github.com/vmware/govmomi/lookup/simulator"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/simulator/vpx"
+	sts "github.com/vmware/govmomi/sts/simulator"
+	"github.com/vmware/govmomi/vapi/rest"
+	vapi "github.com/vmware/govmomi/vapi/simulator"
+	"github.com/vmware/govmomi/vapi/tags"
+
+	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
+	cm "k8s.io/cloud-provider-vsphere/pkg/common/connectionmanager"
+	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
+)
+
+// configFromSim starts a vcsim instance and returns config for use against the vcsim instance.
+// The vcsim instance is configured with an empty tls.Config.
+func configFromSim(multiDc bool) (vcfg.Config, func()) {
+	return configFromSimWithTLS(new(tls.Config), true, multiDc)
+}
+
+// configFromSimWithTLS starts a vcsim instance and returns config for use against the vcsim instance.
+// The vcsim instance is configured with a tls.Config. The returned client
+// config can be configured to allow/decline insecure connections.
+func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc bool) (vcfg.Config, func()) {
+	var cfg vcfg.Config
+	model := simulator.VPX()
+
+	if multiDc {
+		model.Datacenter = 2
+		model.Datastore = 1
+		model.Cluster = 1
+		model.Host = 0
+	}
+
+	err := model.Create()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	model.Service.TLS = tlsConfig
+	s := model.Service.NewServer()
+
+	// STS simulator
+	path, handler := sts.New(s.URL, vpx.Setting)
+	model.Service.ServeMux.Handle(path, handler)
+
+	// vAPI simulator
+	path, handler = vapi.New(s.URL, nil)
+	model.Service.ServeMux.Handle(path, handler)
+
+	// Lookup Service simulator
+	model.Service.RegisterSDK(lookup.New())
+
+	cfg.Global.InsecureFlag = insecureAllowed
+
+	cfg.Global.VCenterIP = s.URL.Hostname()
+	cfg.Global.VCenterPort = s.URL.Port()
+	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.Password, _ = s.URL.User.Password()
+	// Configure region and zone categories
+	if multiDc {
+		cfg.Global.Datacenters = "DC0,DC1"
+	} else {
+		cfg.Global.Datacenters = vclib.TestDefaultDatacenter
+	}
+	cfg.VirtualCenter = make(map[string]*vcfg.VirtualCenterConfig)
+	cfg.VirtualCenter[s.URL.Hostname()] = &vcfg.VirtualCenterConfig{
+		User:         cfg.Global.User,
+		Password:     cfg.Global.Password,
+		VCenterPort:  cfg.Global.VCenterPort,
+		InsecureFlag: cfg.Global.InsecureFlag,
+		Datacenters:  cfg.Global.Datacenters,
+	}
+
+	// Configure region and zone categories
+	if multiDc {
+		cfg.Labels.Region = "k8s-region"
+		cfg.Labels.Zone = "k8s-zone"
+	}
+
+	return cfg, func() {
+		s.Close()
+		model.Remove()
+	}
+}
+
+func configFromEnvOrSim(multiDc bool) (vcfg.Config, func()) {
+	cfg, ok := vcfg.ConfigFromEnv()
+	if ok {
+		return cfg, func() {}
+	}
+	return configFromSim(multiDc)
+}
+
+func TestCompleteControllerFlow(t *testing.T) {
+	config, cleanup := configFromEnvOrSim(false)
+	defer cleanup()
+
+	connMgr := cm.NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	c := &controller{
+		cfg:     &config,
+		connMgr: connMgr,
+	}
+
+	//context
+	ctx := context.Background()
+
+	// Get a simulator VM
+	myVM := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	vmName := myVM.Name
+	myVM.Guest.HostName = strings.ToLower(vmName)
+
+	// Get a simulator DS
+	myds := simulator.Map.Any("Datastore").(*simulator.Datastore)
+
+	err := connMgr.Connect(ctx, config.Global.VCenterIP)
+	if err != nil {
+		t.Errorf("Failed to Connect to vSphere: %s", err)
+	}
+
+	//create
+	params := make(map[string]string, 0)
+	params[AttributeFirstClassDiskParentType] = string(vclib.TypeDatastore)
+	params[AttributeFirstClassDiskParentName] = myds.Name
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: "test",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 4 * GbInBytes,
+		},
+		Parameters: params,
+	}
+
+	respCreate, err := c.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+
+	volID := respCreate.Volume.VolumeId
+	volName := respCreate.Volume.VolumeContext[AttributeFirstClassDiskName]
+	t.Logf("ID: %s", volID)
+	t.Logf("%s: %s", AttributeFirstClassDiskName, volName)
+	t.Logf("%s: %s", AttributeFirstClassDiskType, respCreate.Volume.VolumeContext[AttributeFirstClassDiskType])
+	t.Logf("%s: %s", AttributeFirstClassDiskParentType, respCreate.Volume.VolumeContext[AttributeFirstClassDiskParentType])
+	t.Logf("%s: %s", AttributeFirstClassDiskParentName, respCreate.Volume.VolumeContext[AttributeFirstClassDiskParentName])
+
+	if !strings.EqualFold("test", volName) {
+		t.Errorf("[CREATE] Name of FCD does not match test != %s", volName)
+	}
+
+	//list
+	respList, err := c.ListVolumes(ctx, &csi.ListVolumesRequest{})
+	if err != nil {
+		t.Errorf("ListVolumes failed: %v", err)
+	} else {
+		if len(respList.Entries) != 1 {
+			t.Error("There should only be a single FCD present")
+		} else {
+			name := respList.Entries[0].Volume.VolumeContext[AttributeFirstClassDiskName]
+			if !strings.EqualFold("test", name) {
+				t.Errorf("[LIST] Name of FCD does not match test != %s", name)
+			}
+		}
+	}
+
+	//publish
+	reqPub := &csi.ControllerPublishVolumeRequest{
+		VolumeId: volID,
+		NodeId:   vmName,
+	}
+	respPub, err := c.ControllerPublishVolume(ctx, reqPub)
+	if err != nil {
+		t.Errorf("ControllerPublishVolume failed: %v", err)
+	} else {
+		pubCon := respPub.GetPublishContext()
+
+		name := pubCon[AttributeFirstClassDiskName]
+		if !strings.EqualFold("test", name) {
+			t.Errorf("[PUB] Name of FCD does not match test != %s", name)
+		}
+	}
+
+	//unpublish
+	reqUnpub := &csi.ControllerUnpublishVolumeRequest{
+		VolumeId: volID,
+		NodeId:   vmName,
+	}
+	_, err = c.ControllerUnpublishVolume(ctx, reqUnpub)
+	if err != nil {
+		t.Errorf("ControllerUnpublishVolume failed: %v", err)
+	}
+
+	//delete
+	reqDelete := &csi.DeleteVolumeRequest{
+		VolumeId: volID,
+	}
+	_, err = c.DeleteVolume(ctx, reqDelete)
+	if err != nil {
+		t.Errorf("DeleteVolume failed: %v", err)
+	}
+}
+
+func TestListBoundaries(t *testing.T) {
+	config, cleanup := configFromEnvOrSim(false)
+	defer cleanup()
+
+	connMgr := cm.NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	c := &controller{
+		cfg:     &config,
+		connMgr: connMgr,
+	}
+
+	//context
+	ctx := context.Background()
+
+	// Get a simulator DS
+	myds := simulator.Map.Any("Datastore").(*simulator.Datastore)
+
+	err := connMgr.Connect(ctx, config.Global.VCenterIP)
+	if err != nil {
+		t.Errorf("Failed to Connect to vSphere: %s", err)
+	}
+
+	//create
+	params := make(map[string]string, 0)
+	params[AttributeFirstClassDiskParentType] = string(vclib.TypeDatastore)
+	params[AttributeFirstClassDiskParentName] = myds.Name
+
+	for i := 1; i <= 11; i++ {
+		volName := fmt.Sprintf("test%d", i)
+		reqCreate := &csi.CreateVolumeRequest{
+			Name: volName,
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: int64(i) * GbInBytes,
+			},
+			Parameters: params,
+		}
+
+		respCreate, err := c.CreateVolume(ctx, reqCreate)
+		if err != nil {
+			t.Fatalf("CreateVolume failed: %v", err)
+		}
+
+		volNameRet := respCreate.Volume.VolumeContext[AttributeFirstClassDiskName]
+		if !strings.EqualFold(volName, volNameRet) {
+			t.Errorf("[CREATE] Name of FCD does not match %s != %s", volName, volNameRet)
+		}
+	}
+
+	// get first 10
+	resp, err := c.ListVolumes(ctx, &csi.ListVolumesRequest{MaxEntries: 10})
+	if err != nil {
+		t.Errorf("ListVolumes [0, 9] failed: %v", err)
+	} else {
+		count := len(resp.Entries)
+		if count != 10 {
+			t.Errorf("Invalid number of volumes listed. Excepting 10 got %d", count)
+		}
+		next := resp.NextToken
+		if !strings.EqualFold("10", next) {
+			t.Errorf("Incorrect next token. Excepting 10 got next=%s", next)
+		}
+	}
+
+	// get the next set which just happens to be the last one
+	resp, err = c.ListVolumes(ctx, &csi.ListVolumesRequest{StartingToken: resp.NextToken})
+	if err != nil {
+		t.Errorf("ListVolumes [10] failed: %v", err)
+	} else {
+		count := len(resp.Entries)
+		if count != 1 {
+			t.Errorf("Invalid number of volumes listed. Excepting 1 got %d", count)
+		}
+		next := resp.NextToken
+		if len(next) != 0 {
+			t.Errorf("Incorrect next token. Excepting empty string got next=%s", next)
+		}
+	}
+
+	// get just the first (index 0)
+	resp, err = c.ListVolumes(ctx, &csi.ListVolumesRequest{StartingToken: "0", MaxEntries: 1})
+	if err != nil {
+		t.Errorf("ListVolumes [0] failed: %v", err)
+	} else {
+		count := len(resp.Entries)
+		if count != 1 {
+			t.Errorf("Invalid number of volumes listed. Excepting 1 got %d", count)
+		}
+		next := resp.NextToken
+		if !strings.EqualFold("1", next) {
+			t.Errorf("Incorrect next token. Excepting 1 got next=%s", next)
+		}
+	}
+
+	// get just the fifth (index 4)
+	resp, err = c.ListVolumes(ctx, &csi.ListVolumesRequest{StartingToken: "4", MaxEntries: 1})
+	if err != nil {
+		t.Errorf("ListVolumes [4] failed: %v", err)
+	} else {
+		count := len(resp.Entries)
+		if count != 1 {
+			t.Errorf("Invalid number of volumes listed. Excepting 1 got %d", count)
+		}
+		next := resp.NextToken
+		if !strings.EqualFold("5", next) {
+			t.Errorf("Incorrect next token. Excepting 5 got next=%s", next)
+		}
+	}
+
+	// break into two even-ish sets... this one starting from 0 with a max of 6 (total 6)
+	resp, err = c.ListVolumes(ctx, &csi.ListVolumesRequest{MaxEntries: 6})
+	if err != nil {
+		t.Errorf("ListVolumes [0-5] failed: %v", err)
+	} else {
+		count := len(resp.Entries)
+		if count != 6 {
+			t.Errorf("Invalid number of volumes listed. Excepting 6 got %d", count)
+		}
+		next := resp.NextToken
+		if !strings.EqualFold("6", next) {
+			t.Errorf("Incorrect next token. Excepting 6 got next=%s", next)
+		}
+	}
+
+	// break into two even-ish sets... this one starting from 6 with a max of 10 (total 5)
+	resp, err = c.ListVolumes(ctx, &csi.ListVolumesRequest{StartingToken: resp.NextToken, MaxEntries: 6})
+	if err != nil {
+		t.Errorf("ListVolumes [6-10] failed: %v", err)
+	} else {
+		count := len(resp.Entries)
+		if count != 5 {
+			t.Errorf("Invalid number of volumes listed. Excepting 5 got %d", count)
+		}
+		next := resp.NextToken
+		if len(next) != 0 {
+			t.Errorf("Incorrect next token. Excepting emptyy string got next=%s", next)
+		}
+	}
+}
+
+func TestListOrder(t *testing.T) {
+	config, cleanup := configFromEnvOrSim(false)
+	defer cleanup()
+
+	connMgr := cm.NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	c := &controller{
+		cfg:     &config,
+		connMgr: connMgr,
+	}
+
+	//context
+	ctx := context.Background()
+
+	// Get a simulator DS
+	myds := simulator.Map.Any("Datastore").(*simulator.Datastore)
+
+	err := connMgr.Connect(ctx, config.Global.VCenterIP)
+	if err != nil {
+		t.Errorf("Failed to Connect to vSphere: %s", err)
+	}
+
+	//create
+	params := make(map[string]string, 0)
+	params[AttributeFirstClassDiskParentType] = string(vclib.TypeDatastore)
+	params[AttributeFirstClassDiskParentName] = myds.Name
+
+	for i := 1; i <= 11; i++ {
+		volName := fmt.Sprintf("test%d", i)
+		reqCreate := &csi.CreateVolumeRequest{
+			Name: volName,
+			CapacityRange: &csi.CapacityRange{
+				RequiredBytes: int64(i) * GbInBytes,
+			},
+			Parameters: params,
+		}
+
+		respCreate, err := c.CreateVolume(ctx, reqCreate)
+		if err != nil {
+			t.Fatalf("CreateVolume failed: %v", err)
+		}
+
+		volNameRet := respCreate.Volume.VolumeContext[AttributeFirstClassDiskName]
+		if !strings.EqualFold(volName, volNameRet) {
+			t.Errorf("[CREATE] Name of FCD does not match %s != %s", volName, volNameRet)
+		}
+	}
+
+	// order should be repeatable
+	// first call
+	respFirst, err := c.ListVolumes(ctx, &csi.ListVolumesRequest{})
+	if err != nil {
+		t.Errorf("[FIRST] ListVolumes failed: %v", err)
+	}
+	countFirst := len(respFirst.Entries)
+	if countFirst != 11 {
+		t.Errorf("There should 11 FCD present count=%d", countFirst)
+	}
+
+	// second call
+	respSecond, err := c.ListVolumes(ctx, &csi.ListVolumesRequest{})
+	if err != nil {
+		t.Errorf("[SECOND] ListVolumes failed: %v", err)
+	}
+	countSecond := len(respSecond.Entries)
+	if countFirst != 11 {
+		t.Errorf("There should 11 FCD present count=%d", countSecond)
+	}
+
+	for i := 0; i < 11; i++ {
+		firstName := respFirst.Entries[i].Volume.VolumeContext[AttributeFirstClassDiskName]
+		secondName := respSecond.Entries[i].Volume.VolumeContext[AttributeFirstClassDiskName]
+
+		if !strings.EqualFold(firstName, secondName) {
+			t.Errorf("FirstName(%s) != SecondName(%s)", firstName, secondName)
+		}
+	}
+}
+
+func TestZoneSupport(t *testing.T) {
+	// context
+	ctx := context.Background()
+
+	// Start vcsim
+	config, cleanup := configFromEnvOrSim(true)
+	defer cleanup()
+
+	connMgr := cm.NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	c := &controller{
+		cfg:     &config,
+		connMgr: connMgr,
+	}
+
+	err := connMgr.Connect(ctx, config.Global.VCenterIP)
+	if err != nil {
+		t.Errorf("Failed to Connect to vSphere: %s", err)
+	}
+
+	// Get the vSphere Instance
+	vsi := connMgr.VsphereInstanceMap[config.Global.VCenterIP]
+
+	// Tag manager instance
+	restClient := rest.NewClient(vsi.Conn.Client)
+	user := url.UserPassword(vsi.Conn.Username, vsi.Conn.Password)
+	if err := restClient.Login(ctx, user); err != nil {
+		t.Fatalf("Rest login failed. err=%v", err)
+	}
+
+	m := tags.NewManager(restClient)
+
+	/*
+	 * START SETUP
+	 */
+	// Create a region category
+	regionID, err := m.CreateCategory(ctx, &tags.Category{Name: config.Labels.Region})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a region tag
+	regionID, err = m.CreateTag(ctx, &tags.Tag{CategoryID: regionID, Name: "k8s-region-US"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a zone category
+	zoneID, err := m.CreateCategory(ctx, &tags.Category{Name: config.Labels.Zone})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a zone tags
+	zoneIDwest, err := m.CreateTag(ctx, &tags.Tag{CategoryID: zoneID, Name: "k8s-zone-US-west"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	zoneIDeast, err := m.CreateTag(ctx, &tags.Tag{CategoryID: zoneID, Name: "k8s-zone-US-east"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup a multi-DC environment with zones!
+	// Setup DC0
+	dc0, err := vclib.GetDatacenter(ctx, vsi.Conn, "DC0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach tag to DC0
+	if err = m.AttachTag(ctx, regionID, dc0); err != nil {
+		t.Fatal(err)
+	}
+	if err = m.AttachTag(ctx, zoneIDwest, dc0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup DC1
+	dc1, err := vclib.GetDatacenter(ctx, vsi.Conn, "DC1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach tag to DC1
+	if err = m.AttachTag(ctx, regionID, dc1); err != nil {
+		t.Fatal(err)
+	}
+	if err = m.AttachTag(ctx, zoneIDeast, dc1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get a single Datastore to target
+	stores, err := dc1.GetAllDatastores(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(stores) == 0 {
+		t.Fatal("No Datastores Found")
+	}
+
+	// Get the first Datastore
+	var datastoreName string
+	for _, store := range stores {
+		datastoreName, err = store.Datastore.GetName(ctx)
+		if err != nil {
+			continue //failed to get name. try the next one.
+		}
+		break
+	}
+	if len(datastoreName) == 0 {
+		t.Fatal("Failed to get a Datastore name")
+	}
+	/*
+	 * END SETUP
+	 */
+
+	//create
+	params := make(map[string]string, 0)
+	params[AttributeFirstClassDiskParentType] = string(vclib.TypeDatastore)
+	params[AttributeFirstClassDiskParentName] = datastoreName
+
+	reqCreate := &csi.CreateVolumeRequest{
+		Name: "test",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 4 * GbInBytes,
+		},
+		Parameters: params,
+		AccessibilityRequirements: &csi.TopologyRequirement{
+			Requisite: make([]*csi.Topology, 0),
+		},
+	}
+
+	// Target the eastern zone
+	topology := &csi.Topology{
+		Segments: make(map[string]string, 0),
+	}
+	topology.Segments[LabelZoneRegion] = "k8s-region-US"
+	topology.Segments[LabelZoneFailureDomain] = "k8s-zone-US-east"
+
+	reqCreate.AccessibilityRequirements.Requisite = append(reqCreate.AccessibilityRequirements.Requisite, topology)
+
+	respCreate, err := c.CreateVolume(ctx, reqCreate)
+	if err != nil {
+		t.Fatalf("CreateVolume failed: %v", err)
+	}
+
+	volID := respCreate.Volume.VolumeId
+	volName := respCreate.Volume.VolumeContext[AttributeFirstClassDiskName]
+	t.Logf("ID: %s", volID)
+	t.Logf("%s: %s", AttributeFirstClassDiskName, volName)
+	t.Logf("%s: %s", AttributeFirstClassDiskType, respCreate.Volume.VolumeContext[AttributeFirstClassDiskType])
+	t.Logf("%s: %s", AttributeFirstClassDiskParentType, respCreate.Volume.VolumeContext[AttributeFirstClassDiskParentType])
+	t.Logf("%s: %s", AttributeFirstClassDiskParentName, respCreate.Volume.VolumeContext[AttributeFirstClassDiskParentName])
+
+	if !strings.EqualFold("test", volName) {
+		t.Errorf("[CREATE] Name of FCD does not match test != %s", volName)
+	}
+
+	//delete
+	reqDelete := &csi.DeleteVolumeRequest{
+		VolumeId: volID,
+	}
+	_, err = c.DeleteVolume(ctx, reqDelete)
+	if err != nil {
+		t.Errorf("DeleteVolume failed: %v", err)
+	}
+}

--- a/pkg/csi/service/fcd/vsphere_helper_test.go
+++ b/pkg/csi/service/fcd/vsphere_helper_test.go
@@ -41,9 +41,22 @@ func TestDoesntMeetMinMinorVersion(t *testing.T) {
 	}
 }
 
-func TestSupportedVersion(t *testing.T) {
+func TestMinSupportedVersion(t *testing.T) {
 	err := checkAPI("6.5.0")
 	if err != nil {
-		t.Errorf("This is a supported vCenter version err=%v", err)
+		t.Errorf("This is the minimum supported vCenter version err=%v", err)
+	}
+}
+func TestSupportedVersionMinor(t *testing.T) {
+	err := checkAPI("6.7.0")
+	if err != nil {
+		t.Errorf("This is a supported vCenter version (minor+) err=%v", err)
+	}
+}
+
+func TestSupportedVersionMajor(t *testing.T) {
+	err := checkAPI("7.0.0")
+	if err != nil {
+		t.Errorf("This is a supported vCenter version (major+) err=%v", err)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We need more CSI tests! Tests added:
- Complete controller go test (Create, List, Publish, Unpublish, Delete)
- Test ListVolumes boundary conditions mainly around pagination
- Test ListVoumes order
- Test for Zones support using 2 Datacenters

Additional changes found while added go tests:
- updated govmomi to latest to fix a bug in device Key/UnitNumber in the older version
- Removed some klog.V(X) to always display since they are very useful debug statements to have all the time
- Changed some klog.V(X) values as some weren't needed as often and others were
- Found a bug in GetAllDatastoreClusters in which returns an error when no DatastoreClusters exist causing the entire ListVolumes to fail
- Changed ListVolumes to be on a 0-based index instead of 1-based. This is used for the NextToken when doing pagination of volumes. 1-based was too confusing.

**Which issue this PR fixes**:
NA

**Special notes for your reviewer**:
Tested CCM and CSI on:
k8s 1.13.2 cluster with 10 worker nodes in 3 zones
vSphere 6.7u1
Deployed a test pod which targeted a particular zone using a persistent volume
Used a multiple vCenters (2 to be exact) with multiple Datacenters (3 to be exact)
`make test` passes

**Release note**:
NA
