### PR TITLE
Part 2: More go tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1232,7 +1232,6 @@
     "github.com/vmware/govmomi/vapi/tags",
     "github.com/vmware/govmomi/view",
     "github.com/vmware/govmomi/vim25",
-    "github.com/vmware/govmomi/vim25/methods",
     "github.com/vmware/govmomi/vim25/mo",
     "github.com/vmware/govmomi/vim25/soap",
     "github.com/vmware/govmomi/vim25/types",

--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"errors"
 
-	"k8s.io/klog"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 

--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/vmware/govmomi/simulator"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientv1 "k8s.io/client-go/listers/core/v1"
+	cm "k8s.io/cloud-provider-vsphere/pkg/common/connectionmanager"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+)
+
+type MyNodeManager struct {
+	NodeManager
+}
+
+func newMyNodeManager(cm *cm.ConnectionManager, lister clientv1.NodeLister) *MyNodeManager {
+	return &MyNodeManager{*newNodeManager(cm, lister)}
+}
+
+// Used to populate the networking info
+func (nm *MyNodeManager) RegisterNode(node *v1.Node) {
+	nm.NodeManager.RegisterNode(node)
+
+	myNode1 := nm.nodeNameMap[node.Name]
+	myNode2 := nm.nodeUUIDMap[ConvertK8sUUIDtoNormal(node.Status.NodeInfo.SystemUUID)]
+
+	addrs := []v1.NodeAddress{}
+	v1helper.AddToNodeAddresses(&addrs,
+		v1.NodeAddress{
+			Type:    v1.NodeExternalIP,
+			Address: "127.0.0.1",
+		}, v1.NodeAddress{
+			Type:    v1.NodeInternalIP,
+			Address: "127.0.0.1",
+		}, v1.NodeAddress{
+			Type:    v1.NodeHostName,
+			Address: node.Name,
+		},
+	)
+
+	myNode1.NodeAddresses = addrs
+	myNode2.NodeAddresses = addrs
+}
+
+func TestInstance(t *testing.T) {
+	cfg, ok := configFromEnvOrSim(true)
+	defer ok()
+
+	//context
+	ctx := context.Background()
+
+	/*
+	 * Setup
+	 */
+	connMgr := cm.NewConnectionManager(&cfg, nil)
+	nm := newMyNodeManager(connMgr, nil)
+	instances := newInstances(&nm.NodeManager)
+
+	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	name := vm.Name
+	vm.Guest.HostName = name
+	UUID := vm.Config.Uuid
+	k8sUUID := ConvertK8sUUIDtoNormal(UUID)
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{
+				SystemUUID: k8sUUID,
+			},
+		},
+	}
+
+	nm.RegisterNode(node)
+
+	providerID := ProviderPrefix + UUID
+	/*
+	 * Setup
+	 */
+
+	addrs, err := instances.NodeAddresses(ctx, types.NodeName(name))
+	if err != nil {
+		t.Errorf("NodeAddresses failed err=%v", err)
+	}
+	if len(addrs) != 3 {
+		t.Errorf("NodeAddresses mismatch should be 3 addrs count=%d", len(addrs))
+	}
+
+	addrs, err = instances.NodeAddressesByProviderID(ctx, providerID)
+	if err != nil {
+		t.Errorf("NodeAddressesByProviderID failed err=%v", err)
+	}
+	if len(addrs) != 3 {
+		t.Errorf("NodeAddressesByProviderID mismatch should be 3 addrs count=%d", len(addrs))
+	}
+
+	myUUID, err := instances.InstanceID(ctx, types.NodeName(name))
+	if err != nil {
+		t.Errorf("InstanceID failed err=%v", err)
+	}
+	if !strings.EqualFold(myUUID, UUID) {
+		t.Errorf("InstanceID mismatch %s != %s", myUUID, UUID)
+	}
+
+	exists, err := instances.InstanceExistsByProviderID(ctx, providerID)
+	if err != nil {
+		t.Errorf("InstanceExistsByProviderID failed err=%v", err)
+	}
+	if !exists {
+		t.Error("InstanceExistsByProviderID not found")
+	}
+}

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -31,16 +31,13 @@ import (
 )
 
 func TestRegUnregNode(t *testing.T) {
-	cfg, ok := configFromEnvOrSim()
+	cfg, ok := configFromEnvOrSim(true)
 	defer ok()
 
-	vsphere, err := newVSphere(cfg)
-	if err != nil {
-		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
-	}
-	vsphere.connectionManager = cm.NewConnectionManager(&cfg, nil)
+	connMgr := cm.NewConnectionManager(&cfg, nil)
+	defer connMgr.Logout()
 
-	nm := newNodeManager(vsphere.connectionManager, nil)
+	nm := newNodeManager(connMgr, nil)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name
@@ -84,23 +81,19 @@ func TestRegUnregNode(t *testing.T) {
 }
 
 func TestDiscoverNodeByName(t *testing.T) {
-	cfg, ok := configFromEnvOrSim()
+	cfg, ok := configFromEnvOrSim(true)
 	defer ok()
 
-	vsphere, err := newVSphere(cfg)
-	if err != nil {
-		t.Errorf("Failed to construct/authenticate vSphere: %s", err)
-	}
-	vsphere.connectionManager = cm.NewConnectionManager(&cfg, nil)
-	defer vsphere.connectionManager.Logout()
+	connMgr := cm.NewConnectionManager(&cfg, nil)
+	defer connMgr.Logout()
 
-	nm := newNodeManager(vsphere.connectionManager, nil)
+	nm := newNodeManager(connMgr, nil)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	vm.Guest.HostName = strings.ToLower(vm.Name) // simulator.SearchIndex.FindByDnsName matches against the guest.hostName property
 	name := vm.Name
 
-	err = nm.connectionManager.Connect(context.Background(), cfg.Global.VCenterIP)
+	err := connMgr.Connect(context.Background(), cfg.Global.VCenterIP)
 	if err != nil {
 		t.Errorf("Failed to Connect to vSphere: %s", err)
 	}
@@ -119,17 +112,13 @@ func TestDiscoverNodeByName(t *testing.T) {
 }
 
 func TestExport(t *testing.T) {
-	cfg, ok := configFromEnvOrSim()
+	cfg, ok := configFromEnvOrSim(true)
 	defer ok()
 
-	vsphere, err := newVSphere(cfg)
-	if err != nil {
-		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
-	}
-	vsphere.connectionManager = cm.NewConnectionManager(&cfg, nil)
-	defer vsphere.connectionManager.Logout()
+	connMgr := cm.NewConnectionManager(&cfg, nil)
+	defer connMgr.Logout()
 
-	nm := newNodeManager(vsphere.connectionManager, nil)
+	nm := newNodeManager(connMgr, nil)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name

--- a/pkg/cloudprovider/vsphere/util_test.go
+++ b/pkg/cloudprovider/vsphere/util_test.go
@@ -20,6 +20,26 @@ import (
 	"testing"
 )
 
+func TestUUIDFromProviderID(t *testing.T) {
+	providerID := "vsphere://423740e7-c66e-05e3-9d0b-9e1205b24d43"
+
+	UUID := GetUUIDFromProviderID(providerID)
+
+	if UUID != "423740e7-c66e-05e3-9d0b-9e1205b24d43" {
+		t.Errorf("Failed to extract UUID")
+	}
+}
+
+func TestUUIDFromUUID(t *testing.T) {
+	UUIDOrg := "423740e7-c66e-05e3-9d0b-9e1205b24d43"
+
+	UUIDNew := GetUUIDFromProviderID(UUIDOrg)
+
+	if UUIDOrg != UUIDNew {
+		t.Errorf("Failed to just return the UUID")
+	}
+}
+
 func TestUUIDConvert1(t *testing.T) {
 	k8sUUID := "56492e42-22ad-3911-6d72-59cc8f26bc90"
 

--- a/pkg/common/connectionmanager/list_test.go
+++ b/pkg/common/connectionmanager/list_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connectionmanager
+
+import (
+	"context"
+	"crypto/tls"
+	"log"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	lookup "github.com/vmware/govmomi/lookup/simulator"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/simulator/vpx"
+	sts "github.com/vmware/govmomi/sts/simulator"
+	vapi "github.com/vmware/govmomi/vapi/simulator"
+
+	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
+	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano() / int64(time.Millisecond))
+}
+
+// configFromSim starts a vcsim instance and returns config for use against the vcsim instance.
+// The vcsim instance is configured with an empty tls.Config.
+func configFromSim(multiDc bool) (vcfg.Config, func()) {
+	return configFromSimWithTLS(new(tls.Config), true, multiDc)
+}
+
+// configFromSimWithTLS starts a vcsim instance and returns config for use against the vcsim instance.
+// The vcsim instance is configured with a tls.Config. The returned client
+// config can be configured to allow/decline insecure connections.
+func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc bool) (vcfg.Config, func()) {
+	var cfg vcfg.Config
+	model := simulator.VPX()
+
+	if multiDc {
+		model.Datacenter = 2
+		model.Datastore = 1
+		model.Cluster = 1
+		model.Host = 0
+	}
+
+	err := model.Create()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	model.Service.TLS = tlsConfig
+	s := model.Service.NewServer()
+
+	// STS simulator
+	path, handler := sts.New(s.URL, vpx.Setting)
+	model.Service.ServeMux.Handle(path, handler)
+
+	// vAPI simulator
+	path, handler = vapi.New(s.URL, nil)
+	model.Service.ServeMux.Handle(path, handler)
+
+	// Lookup Service simulator
+	model.Service.RegisterSDK(lookup.New())
+
+	cfg.Global.InsecureFlag = insecureAllowed
+
+	cfg.Global.VCenterIP = s.URL.Hostname()
+	cfg.Global.VCenterPort = s.URL.Port()
+	cfg.Global.User = s.URL.User.Username()
+	cfg.Global.Password, _ = s.URL.User.Password()
+	// Configure region and zone categories
+	if multiDc {
+		cfg.Global.Datacenters = "DC0,DC1"
+	} else {
+		cfg.Global.Datacenters = vclib.TestDefaultDatacenter
+	}
+	cfg.VirtualCenter = make(map[string]*vcfg.VirtualCenterConfig)
+	cfg.VirtualCenter[s.URL.Hostname()] = &vcfg.VirtualCenterConfig{
+		User:         cfg.Global.User,
+		Password:     cfg.Global.Password,
+		VCenterPort:  cfg.Global.VCenterPort,
+		InsecureFlag: cfg.Global.InsecureFlag,
+		Datacenters:  cfg.Global.Datacenters,
+	}
+
+	// Configure region and zone categories
+	cfg.Labels.Region = "k8s-region"
+	cfg.Labels.Zone = "k8s-zone"
+
+	return cfg, func() {
+		s.Close()
+		model.Remove()
+	}
+}
+
+func configFromEnvOrSim(multiDc bool) (vcfg.Config, func()) {
+	cfg, ok := vcfg.ConfigFromEnv()
+	if ok {
+		return cfg, func() {}
+	}
+	return configFromSim(multiDc)
+}
+
+func TestListAllVcPairs(t *testing.T) {
+	config, cleanup := configFromEnvOrSim(true)
+	defer cleanup()
+
+	connMgr := NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	// context
+	ctx := context.Background()
+
+	items, err := connMgr.ListAllVCandDCPairs(ctx)
+	if err != nil {
+		t.Fatalf("ListAllVCandDCPairs err=%v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("ListAllVCandDCPairs items should be 2 but count=%d", len(items))
+	}
+
+	// item 0
+	if !strings.EqualFold(items[0].VcServer, config.Global.VCenterIP) {
+		t.Errorf("item[0].VcServer mismatch %s!=%s", items[0].VcServer, config.Global.VCenterIP)
+	}
+	if !strings.EqualFold(items[0].DataCenter.Name(), "DC0") && !strings.EqualFold(items[0].DataCenter.Name(), "DC1") {
+		t.Errorf("item[0].Datacenter.Name() name=%s should either be DC0 or DC1", items[0].DataCenter.Name())
+	}
+
+	// item 1
+	if !strings.EqualFold(items[1].VcServer, config.Global.VCenterIP) {
+		t.Errorf("item[1].VcServer mismatch %s!=%s", items[1].VcServer, config.Global.VCenterIP)
+	}
+	if !strings.EqualFold(items[1].DataCenter.Name(), "DC0") && !strings.EqualFold(items[1].DataCenter.Name(), "DC1") {
+		t.Errorf("item[1].Datacenter.Name() name=%s should either be DC0 or DC1", items[1].DataCenter.Name())
+	}
+}

--- a/pkg/common/connectionmanager/search_test.go
+++ b/pkg/common/connectionmanager/search_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connectionmanager
+
+import (
+	"context"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/vmware/govmomi/simulator"
+	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
+)
+
+func TestWhichVCandDCByNodeIdByUUID(t *testing.T) {
+	config, cleanup := configFromEnvOrSim(true)
+	defer cleanup()
+
+	connMgr := NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	// setup
+	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	name := vm.Name
+	vm.Guest.HostName = strings.ToLower(name)
+	UUID := vm.Config.Uuid
+
+	// context
+	ctx := context.Background()
+
+	info, err := connMgr.WhichVCandDCByNodeId(ctx, UUID, FindVMByUUID)
+	if err != nil {
+		t.Fatalf("WhichVCandDCByNodeId err=%v", err)
+	}
+	if info == nil {
+		t.Fatalf("WhichVCandDCByNodeId info=nil")
+	}
+
+	if !strings.EqualFold(name, info.NodeName) {
+		t.Fatalf("VM name mismatch %s=%s", name, info.NodeName)
+	}
+	if !strings.EqualFold(UUID, info.UUID) {
+		t.Fatalf("VM name mismatch %s=%s", name, info.NodeName)
+	}
+}
+
+func TestWhichVCandDCByNodeIdByName(t *testing.T) {
+	config, cleanup := configFromEnvOrSim(true)
+	defer cleanup()
+
+	connMgr := NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	// setup
+	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	name := vm.Name
+	vm.Guest.HostName = strings.ToLower(name)
+	UUID := vm.Config.Uuid
+
+	// context
+	ctx := context.Background()
+
+	info, err := connMgr.WhichVCandDCByNodeId(ctx, name, FindVMByName)
+	if err != nil {
+		t.Fatalf("WhichVCandDCByNodeId err=%v", err)
+	}
+	if info == nil {
+		t.Fatalf("WhichVCandDCByNodeId info=nil")
+	}
+
+	if !strings.EqualFold(name, info.NodeName) {
+		t.Fatalf("VM name mismatch %s=%s", name, info.NodeName)
+	}
+	if !strings.EqualFold(UUID, info.UUID) {
+		t.Fatalf("VM name mismatch %s=%s", name, info.NodeName)
+	}
+}
+
+func TestWhichVCandDCByFCDId(t *testing.T) {
+	config, cleanup := configFromEnvOrSim(true)
+	defer cleanup()
+
+	connMgr := NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	// context
+	ctx := context.Background()
+
+	/*
+	 * Setup
+	 */
+	// Get a simulator DS
+	myds := simulator.Map.Any("Datastore").(*simulator.Datastore)
+
+	items, err := connMgr.ListAllVCandDCPairs(ctx)
+	if err != nil {
+		t.Fatalf("ListAllVCandDCPairs err=%v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("ListAllVCandDCPairs items should be 2 but count=%d", len(items))
+	}
+
+	randDC := items[rand.Intn(len(items))]
+
+	datastoreName := myds.Name
+	datastoreType := vclib.TypeDatastore
+	volName := "myfcd"
+	volSizeMB := int64(1024) //1GB
+
+	err = randDC.DataCenter.CreateFirstClassDisk(ctx, datastoreName, datastoreType, volName, volSizeMB)
+	if err != nil {
+		t.Fatalf("CreateFirstClassDisk err=%v", err)
+	}
+
+	firstClassDisk, err := randDC.DataCenter.GetFirstClassDisk(
+		ctx, datastoreName, datastoreType, volName, vclib.FindFCDByName)
+	if err != nil {
+		t.Fatalf("GetFirstClassDisk err=%v", err)
+	}
+
+	fcdID := firstClassDisk.Config.Id.Id
+	/*
+	 * Setup
+	 */
+
+	// call WhichVCandDCByFCDId
+	fcdObj, err := connMgr.WhichVCandDCByFCDId(ctx, fcdID)
+	if err != nil {
+		t.Fatalf("WhichVCandDCByFCDId err=%v", err)
+	}
+	if fcdObj == nil {
+		t.Fatalf("WhichVCandDCByFCDId fcdObj=nil")
+	}
+
+	if !strings.EqualFold(fcdID, fcdObj.FCDInfo.Config.Id.Id) {
+		t.Errorf("FCD ID mismatch %s=%s", fcdID, fcdObj.FCDInfo.Config.Id.Id)
+	}
+	if datastoreType != fcdObj.FCDInfo.ParentType {
+		t.Errorf("FCD DatastoreType mismatch %v=%v", datastoreType, fcdObj.FCDInfo.ParentType)
+	}
+	if !strings.EqualFold(datastoreName, fcdObj.FCDInfo.DatastoreInfo.Info.Name) {
+		t.Errorf("FCD Datastore mismatch %s=%s", datastoreName, fcdObj.FCDInfo.DatastoreInfo.Info.Name)
+	}
+	if volSizeMB != fcdObj.FCDInfo.Config.CapacityInMB {
+		t.Errorf("FCD Size mismatch %d=%d", volSizeMB, fcdObj.FCDInfo.Config.CapacityInMB)
+	}
+}

--- a/pkg/common/connectionmanager/zones_test.go
+++ b/pkg/common/connectionmanager/zones_test.go
@@ -1,0 +1,310 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connectionmanager
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
+)
+
+func TestRemovePortFromHost(t *testing.T) {
+	str1 := removePortFromHost("127.0.0.1")
+	if !strings.EqualFold("127.0.0.1", str1) {
+		t.Errorf("removePortFromHost(127.0.0.1) failed str=%s", str1)
+	}
+	str2 := removePortFromHost("127.0.0.1:")
+	if !strings.EqualFold("127.0.0.1", str2) {
+		t.Errorf("removePortFromHost(127.0.0.1) failed str=%s", str2)
+	}
+	str3 := removePortFromHost("127.0.0.1:443")
+	if !strings.EqualFold("127.0.0.1", str3) {
+		t.Errorf("removePortFromHost(127.0.0.1) failed str=%s", str3)
+	}
+}
+
+func TestWhichVCandDCByZoneSingleDC(t *testing.T) {
+	config, cleanup := configFromEnvOrSim(false)
+	defer cleanup()
+
+	connMgr := NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	// context
+	ctx := context.Background()
+
+	zoneInfo, err := connMgr.WhichVCandDCByZone(ctx, config.Labels.Zone, config.Labels.Region, "", "")
+	if err != nil {
+		t.Fatalf("WhichVCandDCByZone failed err=%v", err)
+	}
+	if zoneInfo == nil {
+		t.Fatalf("WhichVCandDCByZone zoneInfo=nil")
+	}
+
+	if !strings.EqualFold("DC0", zoneInfo.DataCenter.Name()) {
+		t.Errorf("Datacenter mismatch DC0 != %s", zoneInfo.DataCenter.Name())
+	}
+}
+
+func TestWhichVCandDCByZoneMultiDC(t *testing.T) {
+	config, cleanup := configFromEnvOrSim(true)
+	defer cleanup()
+
+	connMgr := NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	// context
+	ctx := context.Background()
+
+	err := connMgr.Connect(ctx, config.Global.VCenterIP)
+	if err != nil {
+		t.Errorf("Failed to Connect to vSphere: %s", err)
+	}
+
+	// Get the vSphere Instance
+	vsi := connMgr.VsphereInstanceMap[config.Global.VCenterIP]
+
+	// Tag manager instance
+	restClient := rest.NewClient(vsi.Conn.Client)
+	user := url.UserPassword(vsi.Conn.Username, vsi.Conn.Password)
+	if err := restClient.Login(ctx, user); err != nil {
+		t.Fatalf("Rest login failed. err=%v", err)
+	}
+
+	m := tags.NewManager(restClient)
+
+	/*
+	 * START SETUP
+	 */
+	// Create a region category
+	regionID, err := m.CreateCategory(ctx, &tags.Category{Name: config.Labels.Region})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a region tag
+	regionID, err = m.CreateTag(ctx, &tags.Tag{CategoryID: regionID, Name: "k8s-region-US"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a zone category
+	zoneID, err := m.CreateCategory(ctx, &tags.Category{Name: config.Labels.Zone})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a zone tags
+	zoneIDwest, err := m.CreateTag(ctx, &tags.Tag{CategoryID: zoneID, Name: "k8s-zone-US-west"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	zoneIDeast, err := m.CreateTag(ctx, &tags.Tag{CategoryID: zoneID, Name: "k8s-zone-US-east"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup a multi-DC environment with zones!
+	// Setup DC0
+	dc0, err := vclib.GetDatacenter(ctx, vsi.Conn, "DC0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach tag to DC0
+	if err = m.AttachTag(ctx, regionID, dc0); err != nil {
+		t.Fatal(err)
+	}
+	if err = m.AttachTag(ctx, zoneIDwest, dc0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup DC1
+	dc1, err := vclib.GetDatacenter(ctx, vsi.Conn, "DC1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach tag to DC1
+	if err = m.AttachTag(ctx, regionID, dc1); err != nil {
+		t.Fatal(err)
+	}
+	if err = m.AttachTag(ctx, zoneIDeast, dc1); err != nil {
+		t.Fatal(err)
+	}
+	/*
+	 * END SETUP
+	 */
+
+	// Lookup DC by Zone
+	lookupRegion := "k8s-region-US"
+	lookupZone := "k8s-zone-US-east"
+
+	zoneInfo, err := connMgr.WhichVCandDCByZone(ctx, config.Labels.Zone, config.Labels.Region, lookupZone, lookupRegion)
+	if err != nil {
+		t.Fatalf("WhichVCandDCByZone failed err=%v", err)
+	}
+	if zoneInfo == nil {
+		t.Fatalf("WhichVCandDCByZone zoneInfo=nil")
+	}
+
+	if !strings.EqualFold("DC1", zoneInfo.DataCenter.Name()) {
+		t.Errorf("Datacenter mismatch DC1 != %s", zoneInfo.DataCenter.Name())
+	}
+}
+
+func TestLookupZoneByMoref(t *testing.T) {
+	config, cleanup := configFromEnvOrSim(false)
+	defer cleanup()
+
+	connMgr := NewConnectionManager(&config, nil)
+	defer connMgr.Logout()
+
+	// context
+	ctx := context.Background()
+
+	err := connMgr.Connect(ctx, config.Global.VCenterIP)
+	if err != nil {
+		t.Errorf("Failed to Connect to vSphere: %s", err)
+	}
+
+	// Get the vSphere Instance
+	vsi := connMgr.VsphereInstanceMap[config.Global.VCenterIP]
+
+	// Tag manager instance
+	restClient := rest.NewClient(vsi.Conn.Client)
+	user := url.UserPassword(vsi.Conn.Username, vsi.Conn.Password)
+	if err := restClient.Login(ctx, user); err != nil {
+		t.Fatalf("Rest login failed. err=%v", err)
+	}
+
+	m := tags.NewManager(restClient)
+
+	/*
+	 * START SETUP
+	 */
+	// Get a simulator Host
+	myHost := simulator.Map.Any("HostSystem").(*simulator.HostSystem)
+
+	// Get a simulator Cluster
+	myCluster := simulator.Map.Any("ClusterComputeResource").(*simulator.ClusterComputeResource)
+
+	// Create a region category
+	regionID, err := m.CreateCategory(ctx, &tags.Category{Name: config.Labels.Region})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a region tag
+	regionID, err = m.CreateTag(ctx, &tags.Tag{CategoryID: regionID, Name: "k8s-region-US"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a zone category
+	zoneID, err := m.CreateCategory(ctx, &tags.Category{Name: config.Labels.Zone})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a zone tags
+	zoneIDwest, err := m.CreateTag(ctx, &tags.Tag{CategoryID: zoneID, Name: "k8s-zone-US-west"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	zoneIDeast, err := m.CreateTag(ctx, &tags.Tag{CategoryID: zoneID, Name: "k8s-zone-US-east"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup a multi-DC environment with zones!
+	// Setup DC0
+	dc0, err := vclib.GetDatacenter(ctx, vsi.Conn, "DC0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach tag to DC0
+	if err = m.AttachTag(ctx, regionID, dc0); err != nil {
+		t.Fatal(err)
+	}
+	if err = m.AttachTag(ctx, zoneIDwest, dc0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach tag to HostSystem
+	if err = m.AttachTag(ctx, regionID, myHost); err != nil {
+		t.Fatal(err)
+	}
+	if err = m.AttachTag(ctx, zoneIDeast, myHost); err != nil {
+		t.Fatal(err)
+	}
+	/*
+	 * END SETUP
+	 */
+
+	// Get cluster zone found on the Datacenter object. Uses ancessor code path.
+	kv, err := connMgr.LookupZoneByMoref(ctx, dc0, myCluster.Reference(), config.Labels.Zone, config.Labels.Region, true)
+	if err != nil {
+		t.Fatalf("[CLUSTER] LookupZoneByMoref failed err=%v", err)
+	}
+
+	region := kv[RegionLabel]
+	zone := kv[ZoneLabel]
+	if !strings.EqualFold("k8s-region-US", region) {
+		t.Errorf("Region value mismatch k8s-region-US != %s", region)
+	}
+	if !strings.EqualFold("k8s-zone-US-west", zone) {
+		t.Errorf("Region value mismatch k8s-zone-US-west != %s", zone)
+	}
+
+	// Get Host zone found directly on the Host object. Overrides Datacenter. Ancessor enabled but won't use.
+	kv, err = connMgr.LookupZoneByMoref(ctx, dc0, myHost.Reference(), config.Labels.Zone, config.Labels.Region, true)
+	if err != nil {
+		t.Fatalf("[HOST] LookupZoneByMoref failed err=%v", err)
+	}
+
+	region = kv[RegionLabel]
+	zone = kv[ZoneLabel]
+	if !strings.EqualFold("k8s-region-US", region) {
+		t.Errorf("Region value mismatch k8s-region-US != %s", region)
+	}
+	if !strings.EqualFold("k8s-zone-US-east", zone) {
+		t.Errorf("Region value mismatch k8s-zone-US-east != %s", zone)
+	}
+
+	// Get Host zone direct from the Host object. Ancessor is false.
+	kv, err = connMgr.LookupZoneByMoref(ctx, dc0, myHost.Reference(), config.Labels.Zone, config.Labels.Region, false)
+	if err != nil {
+		t.Fatalf("[DIRECT HOST] LookupZoneByMoref failed err=%v", err)
+	}
+
+	region = kv[RegionLabel]
+	zone = kv[ZoneLabel]
+	if !strings.EqualFold("k8s-region-US", region) {
+		t.Errorf("Region value mismatch k8s-region-US != %s", region)
+	}
+	if !strings.EqualFold("k8s-zone-US-east", zone) {
+		t.Errorf("Region value mismatch k8s-zone-US-east != %s", zone)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Final PR for go testing. Tests added:
- Now testing the instances interface
- Now testing ConnectionManager... testing all the ways we look up or find things. Meaning we test list, search, and zone-based searches. New `_test.go` file for each category. These are used everywhere in both CCM and CSI.
- configFromEnvOrSim now supported multi-DC environment
- NodeManager now testing using multi-DC
- Improved the ListVolumes test for ordering
- Add ProviderID tests

Refactored:
- NodeManager and CCM Zones go tests don't need to initialize using newVSphere(). Was overkill and did a bunch of mostly unnecessary stuff.

**Which issue this PR fixes**:
NA

**Special notes for your reviewer**:
Since all changes were to `go tests` code only. Just made sure that `make test` passed as excepted.

**Release note**:
NA
