### PR TITLE
Fix broken cron builds that rely on fork=true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,11 +74,11 @@ jobs:
           (env(CCM) = true AND branch = master AND type =~ env(EVENT_TYPE)) OR
           (
             commit_message =~ env(COMMIT_TRIGGER_YES) AND
-            (fork = true OR sender =~ env(OWNERS))
+            (repo != 'kubernetes/cloud-provider-vsphere' OR sender =~ env(OWNERS))
           )
         ) AND NOT (
           commit_message =~ env(COMMIT_TRIGGER_NO) AND
-          (fork = true OR sender =~ env(OWNERS))
+          (repo != 'kubernetes/cloud-provider-vsphere' OR sender =~ env(OWNERS))
         )
 
       before_script:


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch fixes an issue where Travis-CI's conditional "fork" no longer is set to "true" when a build is triggered by cron.

Many thanks to @imkin and @figo for helping to discover this issue.

The underlying cause appears to be related to https://github.com/bioconda/bioconda-recipes/issues/6809. However, the original configuration was working past the point that the linked problem was discovered. It appears to be a regression in Travis-CI. An issue will be opened with their support team to alert them to the problem.

**Which issue this PR fixes**:
NA

**Special notes for your reviewer**:
NA

**Release note**:
NA