### PR TITLE
e2e: Sonobuoy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,17 +90,16 @@ jobs:
         - GCS_BUCKET=k8s-conformance-vsphere; [ "${CCM}" = "true" ] && GCS_BUCKET=k8s-conformance-cloud-provider-vsphere; export GCS_BUCKET; echo "GCS_BUCKET=${GCS_BUCKET}"
         - REPO_SLUG_SHA=$(echo $(TRAVIS_REPO_SLUG) | sha1sum | cut -c1-7); export REPO_SLUG_SHA; echo "REPO_SLUG_SHA=${REPO_SLUG_SHA}"
         - REAL_CLUSTER_NAME="${CLUSTER_NAME}-${REPO_SLUG_SHA}-${TRAVIS_BUILD_NUMBER}"; export REAL_CLUSTER_NAME; echo "REAL_CLUSTER_NAME=${REAL_CLUSTER_NAME}"
-        - export DOCKER_RUN="docker run -it --rm -v $(pwd)/data:/tf/data -v $(pwd)/key-file.json:/tf/data/key-file.json:ro -v $(pwd)/data/.terraform/plugins:/tf/.terraform/plugins --env-file vmc-info.env --env TF_VAR_wrk_count=3 --env TF_VAR_k8s_version="$K8S_VERSION" --env TF_VAR_cloud_provider="${CLOUD_PROVIDER}" --env TF_VAR_yakity_url="${SK8_URL}" "${E2E_IMAGE}" "${REAL_CLUSTER_NAME}""
-        - echo "DOCKER_RUN=${DOCKER_RUN}"
+        - export DOCKER_RUN="docker run -it --rm -v $(pwd)/data:/tf/data -v $(pwd)/key-file.json:/tf/data/key-file.json:ro -v $(pwd)/data/.terraform/plugins:/tf/.terraform/plugins --env-file vmc-info.env --env TF_VAR_wrk_count=3 --env TF_VAR_k8s_version="${K8S_VERSION}" --env TF_VAR_cloud_provider="${CLOUD_PROVIDER}" --env TF_VAR_sk8_url="${SK8_URL}" --env KUBE_CONFORMANCE_IMAGE="${KUBE_CONFORMANCE_IMAGE}" --env E2E_FOCUS='"${E2E_FOCUS}"' --env E2E_SKIP='"${E2E_SKIP}"' "${E2E_IMAGE}" "${REAL_CLUSTER_NAME}""
       script:
-        - ${DOCKER_RUN} up
-        - ${DOCKER_RUN} version
-        - ${DOCKER_RUN} test
-        - ${DOCKER_RUN} tlog
-        - ${DOCKER_RUN} tget
-        - ${DOCKER_RUN} tput "gs://${GCS_BUCKET}/head/${GCS_PATH}" data/key-file.json
+        - eval "${DOCKER_RUN} up"
+        - eval "${DOCKER_RUN} version"
+        - eval "${DOCKER_RUN} test"
+        - eval "${DOCKER_RUN} tlog"
+        - eval "${DOCKER_RUN} tget"
+        - eval "${DOCKER_RUN} tput gs://${GCS_BUCKET}/head/${GCS_PATH} data/key-file.json"
       after_script:
-        - ${DOCKER_RUN} down
+        - eval "${DOCKER_RUN} down"
 
     # Out-of-tree conformance tests (plus the initial definition above)
     - <<: *conformance-test-stage


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch updates the e2e conformance tests to use sk8's Sonobuoy refactor. Before merging the PR, the following environment variables need to be configured in the project's Travis-CI settings:

| Name | Value |
|-------|------|
| `SK8_URL` | `https://raw.githubusercontent.com/vmware/simple-k8s-test-env/v0.2.0/sk8.sh` |
| `E2E_IMAGE` | `gcr.io/kubernetes-conformance-testing/sk8e2e:v20190304-v0.2.0` |
| `KUBE_CONFORMANCE_IMAGE` | `akutz/kube-conformance:v1.13.4` |

Related to:
1. https://github.com/vmware/simple-k8s-test-env/issues/9
2. https://github.com/vmware/simple-k8s-test-env/issues/10
3. https://github.com/vmware/simple-k8s-test-env/issues/11

**Which issue this PR fixes**: NA

**Special notes for your reviewer**: Hi there. How are you today?

**Release note**: NA