### PR TITLE
CSI ginkgo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -51,6 +51,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:e6f895360ed15ead971e11a68cbcff0d6bb4b7bb23b064404934acc6010516a5"
+  name = "github.com/akutz/memconn"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e0a19f53d865bbc181e3ed1204978510b315f7e2"
+
+[[projects]]
+  branch = "master"
   digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
@@ -301,6 +309,20 @@
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
+  digest = "1:a1038ef593beb4771c8f0f9c26e8b00410acd800af5c6864651d9bf160ea1813"
+  name = "github.com/hpcloud/tail"
+  packages = [
+    ".",
+    "ratelimiter",
+    "util",
+    "watch",
+    "winfile",
+  ]
+  pruneopts = "UT"
+  revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:8eb1de8112c9924d59bf1d3e5c26f5eaa2bfc2a5fcbb92dc1c2e4546d695f277"
   name = "github.com/imdario/mergo"
   packages = ["."]
@@ -367,6 +389,54 @@
   pruneopts = "UT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
+
+[[projects]]
+  digest = "1:5f4b78246f0bcb105b1e3b2b9e22b52a57cd02f57a8078572fe27c62f4a75ff7"
+  name = "github.com/onsi/ginkgo"
+  packages = [
+    ".",
+    "config",
+    "internal/codelocation",
+    "internal/containernode",
+    "internal/failer",
+    "internal/leafnodes",
+    "internal/remote",
+    "internal/spec",
+    "internal/spec_iterator",
+    "internal/specrunner",
+    "internal/suite",
+    "internal/testingtproxy",
+    "internal/writer",
+    "reporters",
+    "reporters/stenographer",
+    "reporters/stenographer/support/go-colorable",
+    "reporters/stenographer/support/go-isatty",
+    "types",
+  ]
+  pruneopts = "UT"
+  revision = "2e1be8f7d90e9d3e3e58b0ce470f2f14d075406f"
+  version = "v1.7.0"
+
+[[projects]]
+  digest = "1:7a137fb7718928e473b7d805434ae563ec41790d3d227cdc64e8b14d1cab8a1f"
+  name = "github.com/onsi/gomega"
+  packages = [
+    ".",
+    "format",
+    "internal/assertion",
+    "internal/asyncassertion",
+    "internal/oraclematcher",
+    "internal/testingtsupport",
+    "matchers",
+    "matchers/support/goraph/bipartitegraph",
+    "matchers/support/goraph/edge",
+    "matchers/support/goraph/node",
+    "matchers/support/goraph/util",
+    "types",
+  ]
+  pruneopts = "UT"
+  revision = "65fb64232476ad9046e57c26cd0bff3d3a8dc6cd"
+  version = "v1.4.3"
 
 [[projects]]
   digest = "1:ee4d4af67d93cc7644157882329023ce9a7bcfce956a079069a9405521c7cc8d"
@@ -554,10 +624,13 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9812eb354c055268a95354e388d47021483712b842f32ebd4cbceb144cb18488"
+  digest = "1:fb920808438c9685925880da9f23de0ac148abcc718437ca47cd777fdc82f6d9"
   name = "golang.org/x/net"
   packages = [
     "context",
+    "html",
+    "html/atom",
+    "html/charset",
     "http/httpguts",
     "http2",
     "http2/hpack",
@@ -581,17 +654,29 @@
   revision = "3b58ed4ad3395d483fc92d5d14123ce2c3581fec"
 
 [[projects]]
-  digest = "1:0c56024909189aee3364b7f21a95a27459f718aa7c199a5c111c36cfffd9eaef"
+  digest = "1:bb8277a2ca2bcad6ff7f413b939375924099be908cedd1314baa21ecd08df477"
   name = "golang.org/x/text"
   packages = [
     "collate",
     "collate/build",
+    "encoding",
+    "encoding/charmap",
+    "encoding/htmlindex",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/japanese",
+    "encoding/korean",
+    "encoding/simplifiedchinese",
+    "encoding/traditionalchinese",
+    "encoding/unicode",
     "internal/colltab",
     "internal/gen",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
+    "internal/utf8internal",
     "language",
+    "runes",
     "secure/bidirule",
     "transform",
     "unicode/bidi",
@@ -659,6 +744,15 @@
   version = "v1.14.0"
 
 [[projects]]
+  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
+  name = "gopkg.in/fsnotify.v1"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  source = "https://github.com/fsnotify/fsnotify.git"
+  version = "v1.4.7"
+
+[[projects]]
   digest = "1:38cb4759428493e0b02eade2f8d2920eb55a8fb35acb45de3247f0fbeab81b78"
   name = "gopkg.in/gcfg.v1"
   packages = [
@@ -699,6 +793,14 @@
   pruneopts = "UT"
   revision = "8254d6c783765f38c8675fae4427a1fe73fbd09d"
   version = "v2.1.8"
+
+[[projects]]
+  branch = "v1"
+  digest = "1:0caa92e17bc0b65a98c63e5bc76a9e844cd5e56493f8fdbb28fad101a16254d9"
+  name = "gopkg.in/tomb.v1"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
   digest = "1:78d374b493e747afa9fbb2119687e3740a7fb8d0ebabddfef0a012593aaecbb3"
@@ -1204,8 +1306,11 @@
   analyzer-version = 1
   input-imports = [
     "github.com/akutz/gofsutil",
+    "github.com/akutz/memconn",
     "github.com/container-storage-interface/spec/lib/go/csi",
     "github.com/golang/protobuf/proto",
+    "github.com/onsi/ginkgo",
+    "github.com/onsi/gomega",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/rexray/gocsi",
     "github.com/rexray/gocsi/context",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,9 +17,9 @@ ignored = ["k8s.io/cloud-provider-vsphere"]
   name = "github.com/akutz/gofsutil"
   version = "0.1.2"
 
-[[override]]
-  branch = "master"
-  name = "github.com/golang/glog"
+[[constraint]]
+  name = "k8s.io/klog"
+  version = "0.2.0"
 
 [[override]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,6 +18,18 @@ ignored = ["k8s.io/cloud-provider-vsphere"]
   version = "0.1.2"
 
 [[constraint]]
+  name = "github.com/akutz/memconn"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/onsi/ginkgo"
+  version = "1.7.0"
+
+[[constraint]]
+  name = "github.com/onsi/gomega"
+  version = "1.4.0"
+
+[[constraint]]
   name = "k8s.io/klog"
   version = "0.2.0"
 
@@ -72,6 +84,10 @@ ignored = ["k8s.io/cloud-provider-vsphere"]
 [[override]]
   name = "k8s.io/kubernetes"
   version = "1.11.0"
+
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "https://github.com/fsnotify/fsnotify.git"
 
 [prune]
   go-tests = true

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test: unit
 check: vendor fmt vet lint
 
 unit: vendor
-	go test -tags=unit $(shell go list ./...) $(TESTARGS)
+	go test $(shell go list ./...) $(TESTARGS)
 
 fmt:
 	hack/verify-gofmt.sh

--- a/pkg/csi/testing/csi_suite_test.go
+++ b/pkg/csi/testing/csi_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCSI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CSI Suite")
+}

--- a/pkg/csi/testing/plugin_startup_test.go
+++ b/pkg/csi/testing/plugin_startup_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/akutz/memconn"
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/rexray/gocsi"
+	"google.golang.org/grpc"
+
+	"k8s.io/cloud-provider-vsphere/pkg/csi/provider"
+	"k8s.io/cloud-provider-vsphere/pkg/csi/service"
+)
+
+var _ = Describe("CSI plugin", func() {
+
+	var (
+		err     error
+		ctx     context.Context
+		stopSrv func()
+		sp      gocsi.StoragePluginProvider
+		gclient *grpc.ClientConn
+	)
+
+	BeforeEach(func() {
+		sp = provider.New()
+	})
+	AfterEach(func() {
+		gclient.Close()
+		stopSrv()
+	})
+
+	Describe("Started with memory pipe", func() {
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		When("Plugin unconfigured", func() {
+			BeforeEach(func() {
+				sp.(*gocsi.StoragePlugin).BeforeServe = nil
+			})
+			JustBeforeEach(func() {
+				gclient, stopSrv, err = getPipedClient(ctx, sp)
+				Ω(err).ShouldNot(HaveOccurred())
+			})
+
+			Context("Identity Service", func() {
+				var client csi.IdentityClient
+
+				JustBeforeEach(func() {
+					client = csi.NewIdentityClient(gclient)
+				})
+
+				Context("GetPluginInfo", func() {
+					var res *csi.GetPluginInfoResponse
+					It("should be valid", func() {
+						res, err = client.GetPluginInfo(ctx, &csi.GetPluginInfoRequest{})
+						Ω(err).ShouldNot(HaveOccurred())
+						Ω(res).ShouldNot(BeNil())
+						Ω(res.GetName()).Should(Equal(service.Name))
+					})
+				})
+				Context("GetPluginCapabilities", func() {
+					var res *csi.GetPluginCapabilitiesResponse
+					It("should have correct caps listed", func() {
+						res, err = client.GetPluginCapabilities(ctx, &csi.GetPluginCapabilitiesRequest{})
+						Ω(err).ShouldNot(HaveOccurred())
+						Ω(res).ShouldNot(BeNil())
+						caps := res.GetCapabilities()
+						Ω(caps).Should(HaveLen(2))
+						svcTypes := []csi.PluginCapability_Service_Type{
+							caps[0].GetService().Type,
+							caps[1].GetService().Type,
+						}
+						Ω(svcTypes).Should(ConsistOf(
+							csi.PluginCapability_Service_CONTROLLER_SERVICE,
+							csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS))
+					})
+				})
+				PContext("Probe", func() {
+					It("Should fail", func() {
+						_, err = client.Probe(ctx, &csi.ProbeRequest{})
+						Ω(err).Should(HaveOccurred())
+						//TODO check that the gRPC status code is FAILED_PRECONDITION
+					})
+				})
+			})
+			Context("Controller Service", func() {
+				var client csi.ControllerClient
+
+				JustBeforeEach(func() {
+					client = csi.NewControllerClient(gclient)
+				})
+
+				Context("GetCapabilities", func() {
+					var res *csi.ControllerGetCapabilitiesResponse
+					It("should be valid", func() {
+						res, err = client.ControllerGetCapabilities(ctx, &csi.ControllerGetCapabilitiesRequest{})
+						Ω(err).ShouldNot(HaveOccurred())
+						Ω(res).ShouldNot(BeNil())
+						caps := res.GetCapabilities()
+						Ω(caps).Should(HaveLen(3))
+						rpcTypes := []csi.ControllerServiceCapability_RPC_Type{
+							caps[0].GetRpc().Type,
+							caps[1].GetRpc().Type,
+							caps[2].GetRpc().Type,
+						}
+						Ω(rpcTypes).Should(ConsistOf(
+							csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
+							csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+							csi.ControllerServiceCapability_RPC_LIST_VOLUMES))
+					})
+				})
+			})
+		})
+	})
+
+})
+
+// getPipedClient serves the given SP over an in-memory pipe
+func getPipedClient(ctx context.Context, sp gocsi.StoragePluginProvider) (*grpc.ClientConn, func(), error) {
+
+	lis, err := memconn.Listen("memu", "csi-vsphere-test")
+	Ω(err).Should(BeNil())
+	go func() {
+		defer GinkgoRecover()
+		if err := sp.Serve(ctx, lis); err != nil {
+			Ω(err.Error()).Should(Equal("http: Server closed"))
+		}
+	}()
+
+	clientOpts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithDialer(func(string, time.Duration) (net.Conn, error) {
+			return memconn.Dial("memu", "csi-vsphere-test")
+		}),
+	}
+
+	// Create a client for the piped connection.
+	client, err := grpc.DialContext(ctx, "", clientOpts...)
+	Ω(err).ShouldNot(HaveOccurred())
+
+	return client, func() { sp.GracefulStop(ctx) }, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This patch adds Ginkgo tests for the CSI Plugin that can be exercised
when the plugin has not been configured (meaning, no vCenter
interaction).

These tests start an actual CSI plugin and communicate with it over
gRPC. The connection is in-memory thanks to the memconn package,
which makes testing simpler and faster.

The reference to "-tags unit" has been removed from the Makefile's
"unit" target, as no Go source files had a unit build constraint in
them. This call was ineffective.

In a separate commit, the reference to glog is removed from Gopkg.toml. This is no longer a direct dependency, and does not belong in Gopkg.toml anymore.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
`make test` passes

This is actually a first step on the way to E2E tests. This covers what we can test on a "real" CSI plugin without configuring it and deploying it on vSphere infrastructure. Next step will be a set of tests that can be run on any (Linux) node that has access to vCenter and perform the appropriate storage functionality on a single node. After that will come consuming the K8s testing framework to test functionality within K8s for a full E2E test.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
