### PR TITLE
Make Env Vars take precedence over config file

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -33,23 +33,22 @@ import (
 	"k8s.io/cloud-provider-vsphere/pkg/common/config"
 )
 
-func ParseConfig(configFile string) (config.Config, error) {
-	var cfg config.Config
+func ParseConfig(configFile string) (*config.Config, error) {
 	if len(configFile) == 0 {
-		return cfg, fmt.Errorf("Please specify vsphere cloud config file, e.g. --config vsphere.conf")
+		return nil, fmt.Errorf("Please specify vsphere cloud config file, e.g. --config vsphere.conf")
 	}
 	if _, err := os.Stat(configFile); err != nil {
-		return cfg, fmt.Errorf("Can not find config file %s, %v", configFile, err)
+		return nil, fmt.Errorf("Can not find config file %s, %v", configFile, err)
 	}
 	f, err := os.Open(configFile)
 	if err != nil {
-		return cfg, fmt.Errorf("Can not open config file %s, %v", configFile, err)
+		return nil, fmt.Errorf("Can not open config file %s, %v", configFile, err)
 	}
-	cfg, err = config.ReadConfig(f)
+	cfg, err := config.ReadConfig(f)
 	if err != nil {
-		return cfg, err
+		return nil, err
 	}
-	return cfg, err
+	return cfg, nil
 }
 
 // CheckVSphereConfig performs vSphere health check on VMs

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -47,7 +47,7 @@ func init() {
 }
 
 // Creates new Controller node interface and returns
-func newVSphere(cfg vcfg.Config, finalize ...bool) (*VSphere, error) {
+func newVSphere(cfg *vcfg.Config, finalize ...bool) (*VSphere, error) {
 	vs, err := buildVSphereFromConfig(cfg)
 	if err != nil {
 		return nil, err
@@ -123,7 +123,7 @@ func (vs *VSphere) HasClusterID() bool {
 }
 
 // Initializes vSphere from vSphere CloudProvider Configuration
-func buildVSphereFromConfig(cfg vcfg.Config) (*VSphere, error) {
+func buildVSphereFromConfig(cfg *vcfg.Config) (*VSphere, error) {
 	nm := NodeManager{
 		nodeNameMap:    make(map[string]*NodeInfo),
 		nodeUUIDMap:    make(map[string]*NodeInfo),
@@ -134,7 +134,7 @@ func buildVSphereFromConfig(cfg vcfg.Config) (*VSphere, error) {
 	var nodeMgr server.NodeManagerInterface
 	nodeMgr = &nm
 	vs := VSphere{
-		cfg:         &cfg,
+		cfg:         cfg,
 		nodeManager: &nm,
 		instances:   newInstances(&nm),
 		zones:       newZones(&nm, cfg.Labels.Zone, cfg.Labels.Region),

--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -73,7 +73,7 @@ func TestInstance(t *testing.T) {
 	/*
 	 * Setup
 	 */
-	connMgr := cm.NewConnectionManager(&cfg, nil)
+	connMgr := cm.NewConnectionManager(cfg, nil)
 	nm := newMyNodeManager(connMgr, nil)
 	instances := newInstances(&nm.NodeManager)
 

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -34,7 +34,7 @@ func TestRegUnregNode(t *testing.T) {
 	cfg, ok := configFromEnvOrSim(true)
 	defer ok()
 
-	connMgr := cm.NewConnectionManager(&cfg, nil)
+	connMgr := cm.NewConnectionManager(cfg, nil)
 	defer connMgr.Logout()
 
 	nm := newNodeManager(connMgr, nil)
@@ -84,7 +84,7 @@ func TestDiscoverNodeByName(t *testing.T) {
 	cfg, ok := configFromEnvOrSim(true)
 	defer ok()
 
-	connMgr := cm.NewConnectionManager(&cfg, nil)
+	connMgr := cm.NewConnectionManager(cfg, nil)
 	defer connMgr.Logout()
 
 	nm := newNodeManager(connMgr, nil)
@@ -115,7 +115,7 @@ func TestExport(t *testing.T) {
 	cfg, ok := configFromEnvOrSim(true)
 	defer ok()
 
-	connMgr := cm.NewConnectionManager(&cfg, nil)
+	connMgr := cm.NewConnectionManager(cfg, nil)
 	defer connMgr.Logout()
 
 	nm := newNodeManager(connMgr, nil)

--- a/pkg/cloudprovider/vsphere/zones_test.go
+++ b/pkg/cloudprovider/vsphere/zones_test.go
@@ -40,7 +40,7 @@ func TestZones(t *testing.T) {
 	defer close()
 
 	// Create configuration object
-	connMgr := cm.NewConnectionManager(&cfg, nil)
+	connMgr := cm.NewConnectionManager(cfg, nil)
 	defer connMgr.Logout()
 
 	nm := newNodeManager(connMgr, nil)

--- a/pkg/common/connectionmanager/list_test.go
+++ b/pkg/common/connectionmanager/list_test.go
@@ -41,15 +41,15 @@ func init() {
 
 // configFromSim starts a vcsim instance and returns config for use against the vcsim instance.
 // The vcsim instance is configured with an empty tls.Config.
-func configFromSim(multiDc bool) (vcfg.Config, func()) {
+func configFromSim(multiDc bool) (*vcfg.Config, func()) {
 	return configFromSimWithTLS(new(tls.Config), true, multiDc)
 }
 
 // configFromSimWithTLS starts a vcsim instance and returns config for use against the vcsim instance.
 // The vcsim instance is configured with a tls.Config. The returned client
 // config can be configured to allow/decline insecure connections.
-func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc bool) (vcfg.Config, func()) {
-	var cfg vcfg.Config
+func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc bool) (*vcfg.Config, func()) {
+	cfg := &vcfg.Config{}
 	model := simulator.VPX()
 
 	if multiDc {
@@ -109,19 +109,19 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc b
 	}
 }
 
-func configFromEnvOrSim(multiDc bool) (vcfg.Config, func()) {
-	cfg, ok := vcfg.ConfigFromEnv()
-	if ok {
-		return cfg, func() {}
+func configFromEnvOrSim(multiDc bool) (*vcfg.Config, func()) {
+	cfg := &vcfg.Config{}
+	if err := vcfg.ConfigFromEnv(cfg); err != nil {
+		return configFromSim(multiDc)
 	}
-	return configFromSim(multiDc)
+	return cfg, func() {}
 }
 
 func TestListAllVcPairs(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(true)
 	defer cleanup()
 
-	connMgr := NewConnectionManager(&config, nil)
+	connMgr := NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	// context

--- a/pkg/common/connectionmanager/search_test.go
+++ b/pkg/common/connectionmanager/search_test.go
@@ -30,7 +30,7 @@ func TestWhichVCandDCByNodeIdByUUID(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(true)
 	defer cleanup()
 
-	connMgr := NewConnectionManager(&config, nil)
+	connMgr := NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	// setup
@@ -62,7 +62,7 @@ func TestWhichVCandDCByNodeIdByName(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(true)
 	defer cleanup()
 
-	connMgr := NewConnectionManager(&config, nil)
+	connMgr := NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	// setup
@@ -94,7 +94,7 @@ func TestWhichVCandDCByFCDId(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(true)
 	defer cleanup()
 
-	connMgr := NewConnectionManager(&config, nil)
+	connMgr := NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	// context

--- a/pkg/common/connectionmanager/zones_test.go
+++ b/pkg/common/connectionmanager/zones_test.go
@@ -47,7 +47,7 @@ func TestWhichVCandDCByZoneSingleDC(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(false)
 	defer cleanup()
 
-	connMgr := NewConnectionManager(&config, nil)
+	connMgr := NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	// context
@@ -70,7 +70,7 @@ func TestWhichVCandDCByZoneMultiDC(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(true)
 	defer cleanup()
 
-	connMgr := NewConnectionManager(&config, nil)
+	connMgr := NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	// context
@@ -177,7 +177,7 @@ func TestLookupZoneByMoref(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(false)
 	defer cleanup()
 
-	connMgr := NewConnectionManager(&config, nil)
+	connMgr := NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	// context

--- a/pkg/csi/service/fcd/controller_test.go
+++ b/pkg/csi/service/fcd/controller_test.go
@@ -41,15 +41,15 @@ import (
 
 // configFromSim starts a vcsim instance and returns config for use against the vcsim instance.
 // The vcsim instance is configured with an empty tls.Config.
-func configFromSim(multiDc bool) (vcfg.Config, func()) {
+func configFromSim(multiDc bool) (*vcfg.Config, func()) {
 	return configFromSimWithTLS(new(tls.Config), true, multiDc)
 }
 
 // configFromSimWithTLS starts a vcsim instance and returns config for use against the vcsim instance.
 // The vcsim instance is configured with a tls.Config. The returned client
 // config can be configured to allow/decline insecure connections.
-func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc bool) (vcfg.Config, func()) {
-	var cfg vcfg.Config
+func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc bool) (*vcfg.Config, func()) {
+	cfg := &vcfg.Config{}
 	model := simulator.VPX()
 
 	if multiDc {
@@ -111,23 +111,23 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc b
 	}
 }
 
-func configFromEnvOrSim(multiDc bool) (vcfg.Config, func()) {
-	cfg, ok := vcfg.ConfigFromEnv()
-	if ok {
-		return cfg, func() {}
+func configFromEnvOrSim(multiDc bool) (*vcfg.Config, func()) {
+	cfg := &vcfg.Config{}
+	if err := vcfg.ConfigFromEnv(cfg); err != nil {
+		return configFromSim(multiDc)
 	}
-	return configFromSim(multiDc)
+	return cfg, func() {}
 }
 
 func TestCompleteControllerFlow(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(false)
 	defer cleanup()
 
-	connMgr := cm.NewConnectionManager(&config, nil)
+	connMgr := cm.NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	c := &controller{
-		cfg:     &config,
+		cfg:     config,
 		connMgr: connMgr,
 	}
 
@@ -233,11 +233,11 @@ func TestListBoundaries(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(false)
 	defer cleanup()
 
-	connMgr := cm.NewConnectionManager(&config, nil)
+	connMgr := cm.NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	c := &controller{
-		cfg:     &config,
+		cfg:     config,
 		connMgr: connMgr,
 	}
 
@@ -373,11 +373,11 @@ func TestListOrder(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(false)
 	defer cleanup()
 
-	connMgr := cm.NewConnectionManager(&config, nil)
+	connMgr := cm.NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	c := &controller{
-		cfg:     &config,
+		cfg:     config,
 		connMgr: connMgr,
 	}
 
@@ -506,11 +506,11 @@ func TestZoneSupport(t *testing.T) {
 	config, cleanup := configFromEnvOrSim(true)
 	defer cleanup()
 
-	connMgr := cm.NewConnectionManager(&config, nil)
+	connMgr := cm.NewConnectionManager(config, nil)
 	defer connMgr.Logout()
 
 	c := &controller{
-		cfg:     &config,
+		cfg:     config,
 		connMgr: connMgr,
 	}
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The way that the config file was parsed and loaded previously was done
in a way that when reading a vSphere.conf file, env vars were checked
first, all errors from that were ignored, then values were loaded from
file and the config was validated.

Env vars should take precedence. This patch changes it so that when
reading a config file, that file is loaded, any valid env vars overwrite
the values from the file, and then the whole composite config is
validated.

It was also true (in the case of CSI) that a vsphere.conf file was
always required. This makes future testing difficult, as for basic
cases, it should be possible to configure the CSI plugin via Env vars
only. This patch makes that possible.

It was previously possible that if you did use Env Var only for config,
that an invalid config was returned without error. This patch fixes that
as well.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
