### PR TITLE
Image for building the binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,9 @@
+/cluster
+/docs
+/hack
+/manifests
+/test
+
 /Dockerfile*
 /image-*.d
 /image-*.tar

--- a/hack/images/golang/Dockerfile
+++ b/hack/images/golang/Dockerfile
@@ -1,0 +1,14 @@
+# Use a dedicated stage to download the project's dependencies.
+FROM golang:{{GO_VERSION}} as builder
+WORKDIR /build
+COPY go.mod go.sum /build/
+COPY cmd /build/cmd/
+COPY pkg /build/pkg/
+RUN go mod download && go mod verify
+
+FROM golang:{{GO_VERSION}}
+LABEL "maintainer" "Andrew Kutz <akutz@vmware.com>"
+
+# Copy the Go module cache from the builder.
+COPY --from=builder /go/pkg/mod \
+                    /go/pkg/mod/

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -43,8 +43,14 @@ GO_VERSION="$(grep '^go:' <".travis.yml" | sed 's/^\(go:[[:space:]]\{0,\}\"\{0,1
 TERM_FLAGS="-i"
 echo "${-}" | grep -q i && TERM_FLAGS="${TERM_FLAGS}t"
 
+IMAGE="gcr.io/cloud-provider-vsphere/golang-${GO_VERSION}:latest"
+if ! docker pull "${IMAGE}"; then
+  IMAGE="golang:${GO_VERSION}"
+  docker pull "${IMAGE}"
+fi
+
 # shellcheck disable=2086
 docker run --rm ${TERM_FLAGS} ${DOCKER_OPTS} \
   -v "$(pwd)":/build:z \
   -w /build \
-  golang:"${GO_VERSION}" make "${@}"
+  "${IMAGE}" make "${@}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch introduces an image that already has a Go module cache produced from a recent execution of "make deps" against the "master" branch of this repository. This speeds up builds exponentially when executing "hack/make.sh" since only delta changes are downloaded for dependencies. For example:

```shell
$ hack/make.sh build
latest: Pulling from cloud-provider-vsphere/golang-1.12
Digest: sha256:8ab7713835daaf7f0e141f355f6f87d40c1fb8f78f46a7a1e7eb056dc069cae9
Status: Image is up to date for gcr.io/cloud-provider-vsphere/golang-1.12:latest
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "main.version=7612a0af"' -o vsphere-cloud-controller-manager.linux_amd64 cmd/vsphere-cloud-controller-manager/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static" -w -s -X "k8s.io/cloud-provider-vsphere/pkg/csi/service.version=7612a0af"' -o vsphere-csi.linux_amd64 cmd/vsphere-csi/main.go
```

If a variant of `cloud-provider-vsphere/golang-1.12` isn't available for the requested Golang version, then the default `golang` image is used at the requested version.

**Which issue this PR fixes**: NA

**Special notes for your reviewer**: NA

**Release note**: NA