### PR TITLE
Add env var to disable CSI K8s client

### DIFF
--- a/cmd/vsphere-csi/main.go
+++ b/cmd/vsphere-csi/main.go
@@ -39,4 +39,15 @@ const usage = `    X_CSI_VSPHERE_APINAME
         Specifies the name of the API to use when talking to vCenter
 
 				The default value is "FCD" (First Class Disk)
+
+    X_CSI_VSPHERE_CLOUD_CONFIG
+        Specifies the path to the vsphere.conf file
+
+        The default falue is "/etc/cloud/vsphere.conf"
+
+    X_CSI_DISABLE_K8S_CLIENT
+        Boolean flag that disables the Kubernetes API client to retrieve
+        secrets.
+
+        The default value is "false"
 `

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -67,7 +67,7 @@ func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) 
 	if err == nil {
 		klog.V(1).Info("Kubernetes Client Init Succeeded")
 
-		vs.informMgr = k8s.NewInformer(&client)
+		vs.informMgr = k8s.NewInformer(client)
 
 		connMgr := cm.NewConnectionManager(vs.cfg, vs.informMgr.GetSecretListener())
 		vs.connectionManager = connMgr

--- a/pkg/common/kubernetes/informers.go
+++ b/pkg/common/kubernetes/informers.go
@@ -31,11 +31,11 @@ func noResyncPeriodFunc() time.Duration {
 }
 
 // NewInformer creates a newk8s client based on a service account
-func NewInformer(client *clientset.Interface) *InformerManager {
+func NewInformer(client clientset.Interface) *InformerManager {
 	return &InformerManager{
 		client:          client,
 		stopCh:          signals.SetupSignalHandler(),
-		informerFactory: informers.NewSharedInformerFactory(*client, noResyncPeriodFunc()),
+		informerFactory: informers.NewSharedInformerFactory(client, noResyncPeriodFunc()),
 	}
 }
 

--- a/pkg/common/kubernetes/types.go
+++ b/pkg/common/kubernetes/types.go
@@ -27,7 +27,7 @@ import (
 // to well-defined information in the Kubernetes API server.
 type InformerManager struct {
 	// k8s client
-	client *clientset.Interface
+	client clientset.Interface
 	// main shared informer factory
 	informerFactory informers.SharedInformerFactory
 	// main signal

--- a/pkg/csi/service/service.go
+++ b/pkg/csi/service/service.go
@@ -46,7 +46,7 @@ const (
 
 var (
 	api     = defaultAPI
-	cfgPath = DefaultCloudConfigPath
+	cfgPath = vTypes.DefaultCloudConfigPath
 )
 
 // Service is a CSI SP and idempotency.Provider.
@@ -69,7 +69,7 @@ func New() Service {
 
 func (s *service) GetController() csi.ControllerServer {
 	// check which API to use
-	api = os.Getenv(EnvAPI)
+	api = os.Getenv(vTypes.EnvAPI)
 	if api == "" {
 		api = defaultAPI
 	}
@@ -114,9 +114,9 @@ func (s *service) BeforeServe(
 			return fmt.Errorf("Invalid API: %s", api)
 		}
 
-		cfgPath = csictx.Getenv(ctx, EnvCloudConfig)
+		cfgPath = csictx.Getenv(ctx, vTypes.EnvCloudConfig)
 		if cfgPath == "" {
-			cfgPath = DefaultCloudConfigPath
+			cfgPath = vTypes.DefaultCloudConfigPath
 		}
 
 		var cfg *vcfg.Config
@@ -125,7 +125,9 @@ func (s *service) BeforeServe(
 		if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
 			// config from Env var only
 			cfg = &vcfg.Config{}
-			vcfg.FromEnv(cfg)
+			if err := vcfg.FromEnv(cfg); err != nil {
+				return err
+			}
 		} else {
 			config, err := os.Open(cfgPath)
 			if err != nil {
@@ -143,7 +145,6 @@ func (s *service) BeforeServe(
 			log.WithError(err).Error("Failed to init controller")
 			return err
 		}
-
 	}
 
 	return nil

--- a/pkg/csi/types/envvars.go
+++ b/pkg/csi/types/envvars.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package service
+package types
 
 const (
 	// DefaultCloudConfigPath is /etc/cloud/vsphere.conf
@@ -27,4 +27,8 @@ const (
 
 	// EnvCloudConfig contains the path to the vSphere Cloud Config
 	EnvCloudConfig = "X_CSI_VSPHERE_CLOUD_CONFIG"
+
+	// EnvK8s is a boolean flag to indicate whether or not the CSI plugin should
+	// use a Kubernetes API client to get secrets
+	EnvDisableK8sClient = "X_CSI_DISABLE_K8S_CLIENT"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR will make it possible (may not be all that's needed) to run the [CSI-Sanity test suite](https://github.com/kubernetes-csi/csi-test) against our CSI plugin outside of a K8s pod.

CSI plugins are intended to be CO agnostic. The current CSI plugin was
always initializing a K8s client and informer, which would cause plugin
initialization to fail if it was not running within a K8s pod.

This patch adds a new env var, X_CSI_DISABLE_K8S_CLIENT which can be set to
"true" (or any other truthy value) to disable said initialization.

This patch also changes some methods around the K8s client and informer
to no longer use a pointer to a Go interface, as Go interfaces are
already pointers.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
`pkg/csi/envvars.go` was moved to `pkg/csi/types/envvars.go` to avoid circular imports.

The struct `pkg/csi/service/fcd/controller.controller` no longs holds a reference to the Kubernetes clientset or the informer, as these were never used again outside of the `Init` function.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
