### PR TITLE
Only report IPs bound to vNICs

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"net"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	clientv1 "k8s.io/client-go/listers/core/v1"
 	pb "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/proto"
 	"k8s.io/klog"
@@ -145,6 +145,10 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 
 	addrs := []v1.NodeAddress{}
 	for _, v := range oVM.Guest.Net {
+		if v.DeviceConfigId == -1 {
+			klog.V(4).Info("Skipping device because not a vNIC")
+			continue
+		}
 		for _, ip := range v.IpAddress {
 			if net.ParseIP(ip).To4() != nil {
 				v1helper.AddToNodeAddresses(&addrs,


### PR DESCRIPTION
**What this PR does / why we need it**:
We only report the IP address bound to the vNIC. As shown below in testing...

```
[vonthd@k8smaster csi]$ kubectl describe node k8sworker1.local
Name:               k8sworker1.local
Roles:              <none>
Labels:             beta.kubernetes.io/arch=amd64
                    beta.kubernetes.io/instance-type=vsphere-vm
                    beta.kubernetes.io/os=linux
                    failure-domain.beta.kubernetes.io/region=k8s-region-eu
                    failure-domain.beta.kubernetes.io/zone=k8s-region-eu-all
                    kubernetes.io/hostname=k8sworker1.local
...
Addresses:
  ExternalIP:  10.160.137.75
  InternalIP:  10.160.137.75
  Hostname:    k8sworker1.local
```

**Which issue this PR fixes**: https://github.com/kubernetes/cloud-provider-vsphere/issues/138

**Special notes for your reviewer**:
NA

**Release note**:
NA
