### PR TITLE
ci: Update the version of sk8e2e to fix CI bug

### DIFF
--- a/hack/images/ci/Dockerfile
+++ b/hack/images/ci/Dockerfile
@@ -7,7 +7,7 @@ ARG GOLANG_IMAGE=golang:1.12
 
 # The image from which the Terraform project used to turn up a K8s cluster is
 # copied, as well as several programs.
-ARG SK8E2E_IMAGE=gcr.io/kubernetes-conformance-testing/sk8e2e:v0.2.1-8-g2f2a8de
+ARG SK8E2E_IMAGE=gcr.io/kubernetes-conformance-testing/sk8e2e:v0.2.1-9-geb10f99
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch updates the version of sk8e2e used in the CI image to fix an issue when running conformance tests on Prow. The underlying issue is described at vmware/simple-k8s-test-env@eb10f99.

The CI image for this commit is already built and published at `gcr.io/cloud-provider-vsphere/ci:f2a0d372`.

**Which issue this PR fixes**: NA

**Special notes for your reviewer**: NA

**Release note**: NA