### PR TITLE
use string data for example vSphere secret manifest

### DIFF
--- a/manifests/controller-manager/vccm-secret.yaml
+++ b/manifests/controller-manager/vccm-secret.yaml
@@ -3,6 +3,6 @@ kind: Secret
 metadata:
   name: vccm
   namespace: kube-system
-data:
-  1.2.3.4.username: "Replace with output from `echo -n YOUR_VCENTER_USERNAME | base64`"
-  1.2.3.4.password: "Replace with output from `echo -n YOUR_VCENTER_PASSWORD | base64`"
+stringData:
+  1.2.3.4.username: "<YOUR_VCENTER_USERNAME>"
+  1.2.3.4.password: "<YOUR_VCENTER_PASSWORD>"


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use stringData for secret manifest, easier to install since you don't have to take the extra step of base64 encoding your secret values.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
