### PR TITLE
Fix logging for vendored packages

### DIFF
--- a/cmd/vsphere-cloud-controller-manager/main.go
+++ b/cmd/vsphere-cloud-controller-manager/main.go
@@ -52,6 +52,9 @@ func init() {
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
+	goflag.Set("logtostderr", "true")
+	goflag.Set("stderrthreshold", "INFO")
+	goflag.Set("alsologtostderr", "true")
 	goflag.CommandLine.Parse([]string{})
 	s, err := options.NewCloudControllerManagerOptions()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This does effectively the same thing that the vSphere CSI plugin already does for logging when klog and glog are intermixed. This is described on the klog github page.

**Which issue this PR fixes**: NA

**Special notes for your reviewer**:
None

**Release note**:
No behavioral changes