### PR TITLE
redirect to cloud-provider-vsphere.sigs.k8s.io in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,19 +6,19 @@
 # Netlify redirects
 [[redirects]]
     from = "https://kubernetes-sigs-cloud-provider-vsphere.netlify.com/*"
-    to = "https://vsphere.sigs.k8s.io/:splat"
+    to = "https://cloud-provider-vsphere.sigs.k8s.io/:splat"
     status = 301
     force = true
 
 # HTTP -> HTTPS
 [[redirects]]
-    from = "http://vsphere.sigs.k8s.io/*"
-    to = "https://vsphere.sigs.k8s.io/:splat"
+    from = "http://cloud-provider-vsphere.sigs.k8s.io/*"
+    to = "https://cloud-provider-vsphere.sigs.k8s.io/:splat"
     status = 301
     force = true
 
 [[redirects]]
     from = "http://kubernetes-sigs-cloud-provider-vsphere.netlify.com/*"
-    to = "http://vsphere.sigs.k8s.io/:splat"
+    to = "http://cloud-provider-vsphere.sigs.k8s.io/:splat"
     status = 301
     force = true


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What this PR does / why we need it**:
As per https://github.com/kubernetes/k8s.io/pull/277#discussion_r292415768 the netlify redirects need to be consistent with repo names, so changing `vsphere.sigs.k8s.io` to `cloud-provider-vsphere.sigs.k8s.io`. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
