### PR TITLE
add order-only pre-req for deploy, as it's beeing skipped when recursing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ dist: dist-ccm
 ################################################################################
 # The deploy target is for use by Prow.
 .PHONY: deploy
-deploy:
+deploy: | $(DOCKER_SOCK)
 	$(MAKE) check
 	$(MAKE) build-bins
 	$(MAKE) unit-test


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What this PR does / why we need it**: this explicits the order-only pre-requirement as it is being skipped while recursing using `$(MAKE)`

**Which issue this PR fixes** : fixes #

**Special notes for your reviewer**:
/assign @akutz 
**Release note**:

```release-note
NONE
```
