### PR TITLE
bump sk8e2e to pickup fixes on ELB timeouts

### DIFF
--- a/hack/images/ci/Dockerfile
+++ b/hack/images/ci/Dockerfile
@@ -7,7 +7,7 @@ ARG GOLANG_IMAGE=golang:1.12
 
 # The image from which the Terraform project used to turn up a K8s cluster is
 # copied, as well as several programs.
-ARG SK8E2E_IMAGE=gcr.io/kubernetes-conformance-testing/sk8e2e:v0.2.1-13-g7a0afda
+ARG SK8E2E_IMAGE=gcr.io/kubernetes-conformance-testing/sk8e2e:v0.2.1-21-g7acbf48
 
 ################################################################################
 ##                            GO MOD CACHE STAGE                              ##


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: bumps sk8e2e version to pick up fixes that deflake some of our prow jobs

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**:

/assign @akutz @frapposelli 
/hold

didn't trigger a re-build, will do after approval/lgtm

**Release note**:

```release-note
NONE
```
