### PR TITLE
Implement Lookup VM by IP

### DIFF
--- a/pkg/cloudprovider/vsphere/util.go
+++ b/pkg/cloudprovider/vsphere/util.go
@@ -19,12 +19,17 @@ package vsphere
 import (
 	"fmt"
 	"strings"
+
+	"k8s.io/klog"
 )
 
 const (
 	// ProviderPrefix is the Kubernetes cloud provider prefix for this
 	// cloud provider.
 	ProviderPrefix = "vsphere://"
+
+	// MinUUIDLen is the min length for a valid UUID
+	MinUUIDLen int = 36
 )
 
 // GetUUIDFromProviderID returns a UUID from the supplied cloud provider ID.
@@ -40,6 +45,10 @@ func GetUUIDFromProviderID(providerID string) string {
 // K8s:    56492e42-22ad-3911-6d72-59cc8f26bc90
 // VMware: 422e4956-ad22-1139-6d72-59cc8f26bc90
 func ConvertK8sUUIDtoNormal(k8sUUID string) string {
+	if len(k8sUUID) < MinUUIDLen {
+		klog.Errorf("The UUID length is invalid. Returning UUID=%s as is.", k8sUUID)
+		return k8sUUID
+	}
 	uuid := fmt.Sprintf("%s%s%s%s-%s%s-%s%s-%s-%s",
 		k8sUUID[6:8], k8sUUID[4:6], k8sUUID[2:4], k8sUUID[0:2],
 		k8sUUID[11:13], k8sUUID[9:11],

--- a/pkg/common/connectionmanager/connectionmanager.go
+++ b/pkg/common/connectionmanager/connectionmanager.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"sync"
 
-	"k8s.io/client-go/listers/core/v1"
+	v1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog"
 
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
@@ -35,9 +35,10 @@ type FindVM int
 const (
 	// FindVMByUUID finds VMs with the provided UUID.
 	FindVMByUUID FindVM = iota // 0
-
 	// FindVMByName finds VMs with the provided name.
 	FindVMByName // 1
+	// FindVMByIP finds VMs with the provided IP adress.
+	FindVMByIP // 2
 
 	// PoolSize is the number of goroutines used in parallel to find a VM.
 	PoolSize int = 8


### PR DESCRIPTION
**What this PR does / why we need it**:
This addresses the issue reported below. It allows for the capability for the VMName to be overridden from the FQDN/hostname to the IP address of the node. Implements FindVMByIP.

This also addresses a bug a crash issue when the ProviderID cannot be found or when the ProviderID is malformed.

**Which issue this PR fixes**: https://github.com/kubernetes/cloud-provider-vsphere/issues/202

**Special notes for your reviewer**:
Tested on 1.14.1 with `--hostname-override=<ip address>` on the node.
Using vSphere 6.7u2 (but that version shouldn't matter).

**Release note**:
NA