### PR TITLE
Fix UUID/ProviderID to only use lower case based on VC and k8s matching/lookup

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -103,13 +103,13 @@ func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, 
 	if searchBy == cm.FindVMByName {
 		vmDI, err := nm.connectionManager.WhichVCandDCByNodeID(ctx, nodeID, cm.FindVM(searchBy))
 		if err == nil {
-			klog.Infof("Discovered VM using FQDN or short-hand name")
+			klog.Info("Discovered VM using FQDN or short-hand name")
 			return vmDI, err
 		}
 
 		vmDI, err = nm.connectionManager.WhichVCandDCByNodeID(ctx, nodeID, cm.FindVMByIP)
 		if err == nil {
-			klog.Infof("Discovered VM using IP address")
+			klog.Info("Discovered VM using IP address")
 			return vmDI, err
 		}
 
@@ -120,7 +120,7 @@ func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, 
 	// Search by UUID
 	vmDI, err := nm.connectionManager.WhichVCandDCByNodeID(ctx, nodeID, cm.FindVM(searchBy))
 	if err == nil {
-		klog.Infof("Discovered VM using normal UUID format")
+		klog.Info("Discovered VM using normal UUID format")
 		return vmDI, err
 	}
 
@@ -130,7 +130,7 @@ func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, 
 	reverseUUID := ConvertK8sUUIDtoNormal(nodeID)
 	vmDI, err = nm.connectionManager.WhichVCandDCByNodeID(ctx, reverseUUID, cm.FindVM(searchBy))
 	if err == nil {
-		klog.Infof("Discovered VM using reverse UUID format")
+		klog.Info("Discovered VM using reverse UUID format")
 		return vmDI, err
 	}
 

--- a/pkg/cloudprovider/vsphere/util.go
+++ b/pkg/cloudprovider/vsphere/util.go
@@ -34,7 +34,8 @@ const (
 
 // GetUUIDFromProviderID returns a UUID from the supplied cloud provider ID.
 func GetUUIDFromProviderID(providerID string) string {
-	return strings.TrimPrefix(providerID, ProviderPrefix)
+	withoutPrefix := strings.TrimPrefix(providerID, ProviderPrefix)
+	return strings.ToLower(strings.TrimSpace(withoutPrefix))
 }
 
 // ConvertK8sUUIDtoNormal reformats UUID to match VMware's format:
@@ -55,5 +56,5 @@ func ConvertK8sUUIDtoNormal(k8sUUID string) string {
 		k8sUUID[16:18], k8sUUID[14:16],
 		k8sUUID[19:23],
 		k8sUUID[24:36])
-	return strings.ToLower(uuid)
+	return strings.ToLower(strings.TrimSpace(uuid))
 }

--- a/pkg/cloudprovider/vsphere/util_test.go
+++ b/pkg/cloudprovider/vsphere/util_test.go
@@ -17,8 +17,30 @@ limitations under the License.
 package vsphere
 
 import (
+	"strings"
 	"testing"
 )
+
+func TestInvalidProviderID(t *testing.T) {
+	providerID := ""
+
+	UUID := GetUUIDFromProviderID(providerID)
+
+	if UUID != "" {
+		t.Errorf("Should return an empty string")
+	}
+}
+
+func TestUpperUUIDFromProviderID(t *testing.T) {
+	tmpUUID := strings.ToUpper("423740e7-c66e-05e3-9d0b-9e1205b24d43")
+	providerID := ProviderPrefix + tmpUUID
+
+	UUID := GetUUIDFromProviderID(providerID)
+
+	if UUID != "423740e7-c66e-05e3-9d0b-9e1205b24d43" {
+		t.Errorf("Failed to extract UUID")
+	}
+}
 
 func TestUUIDFromProviderID(t *testing.T) {
 	providerID := "vsphere://423740e7-c66e-05e3-9d0b-9e1205b24d43"
@@ -40,7 +62,17 @@ func TestUUIDFromUUID(t *testing.T) {
 	}
 }
 
-func TestUUIDConvert1(t *testing.T) {
+func TestUUIDConvertInvalid(t *testing.T) {
+	k8sUUID := ""
+
+	biosUUID := ConvertK8sUUIDtoNormal(k8sUUID)
+
+	if biosUUID != "" {
+		t.Errorf("Should return empty string")
+	}
+}
+
+func TestUUIDConvert(t *testing.T) {
 	k8sUUID := "56492e42-22ad-3911-6d72-59cc8f26bc90"
 
 	biosUUID := ConvertK8sUUIDtoNormal(k8sUUID)
@@ -50,8 +82,8 @@ func TestUUIDConvert1(t *testing.T) {
 	}
 }
 
-func TestUUIDConvert2(t *testing.T) {
-	k8sUUID := "422e4956-ad22-1139-6d72-59cc8f26bc90"
+func TestUpperUUIDConvert(t *testing.T) {
+	k8sUUID := strings.ToUpper("422e4956-ad22-1139-6d72-59cc8f26bc90")
 
 	biosUUID := ConvertK8sUUIDtoNormal(k8sUUID)
 

--- a/pkg/common/connectionmanager/search.go
+++ b/pkg/common/connectionmanager/search.go
@@ -65,7 +65,7 @@ func (cm *ConnectionManager) WhichVCandDCByNodeID(ctx context.Context, nodeID st
 	switch searchBy {
 	case FindVMByUUID:
 		klog.V(3).Info("WhichVCandDCByNodeID by UUID")
-		myNodeID = strings.ToLower(nodeID)
+		myNodeID = strings.TrimSpace(strings.ToLower(nodeID))
 	case FindVMByIP:
 		klog.V(3).Info("WhichVCandDCByNodeID by IP")
 	default:
@@ -202,12 +202,14 @@ func (cm *ConnectionManager) WhichVCandDCByNodeID(ctx context.Context, nodeID st
 					hostName = myNodeID
 				}
 
+				UUID := strings.ToLower(strings.TrimSpace(oVM.Summary.Config.Uuid))
+
 				klog.V(2).Infof("Found node %s as vm=%+v in vc=%s and datacenter=%s",
 					nodeID, vm, res.vc, res.datacenter.Name())
-				klog.V(2).Info("Hostname: ", hostName, " UUID: ", oVM.Summary.Config.Uuid)
+				klog.V(2).Infof("Hostname: %s, UUID: %s", hostName, UUID)
 
 				vmInfo = &VMDiscoveryInfo{DataCenter: res.datacenter, VM: vm, VcServer: res.vc,
-					UUID: oVM.Summary.Config.Uuid, NodeName: hostName}
+					UUID: UUID, NodeName: hostName}
 				setVMFound(true)
 				break
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes an issue where a user-defined vSphere ProviderID `--provider-id=` is of mixed case (lower/upper). The internal workings of the cloud provider interface discovers the ProviderID in lower case and the internal lookup fails if with at least 1 UpperCase character when user-provider.

Additional changes:
- Added negative go tests for cloud provider Instance interface
- Purposely made provided UUID ToUpper in certain go tests to validate this fix
- Fixed Infof -> Info in certain locations

**Which issue this PR fixes**: https://github.com/kubernetes/cloud-provider-vsphere/issues/204

**Special notes for your reviewer**:
Tested on vSphere 6.7u2

**Release note**:
Does not affect user documentation or behavior