### PR TITLE
Add InstanceShutdownByProviderID implementation

### DIFF
--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -132,6 +132,15 @@ func TestInstance(t *testing.T) {
 	if !exists {
 		t.Error("InstanceExistsByProviderID not found")
 	}
+
+	ishut, err := instances.InstanceShutdownByProviderID(ctx, providerID)
+	if err != nil {
+		t.Errorf("InstanceShutdownByProviderID failed err=%v", err)
+	}
+	if ishut {
+		t.Error("InstanceShutdownByProviderID is shutdown")
+	}
+
 }
 
 func TestInvalidInstance(t *testing.T) {


### PR DESCRIPTION
This PR adds a quick and naive implementation of InstanceShutdownByProviderID, used to track when a node is shutdown and safe to detach storage from

Fixes: #207

/cc: @dvonthenen @andrewsykim