### PR TITLE
Refactor WhichVCandDCByZone Lookup starting w/ Host using Ancestors()

### DIFF
--- a/pkg/cloudprovider/vsphere/zones.go
+++ b/pkg/cloudprovider/vsphere/zones.go
@@ -70,7 +70,7 @@ func (z *zones) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 	klog.V(4).Infof("Host owning VM is %s", oHost.Summary.Config.Name)
 
 	zoneResult, err := z.nodeManager.connectionManager.LookupZoneByMoref(
-		ctx, node.dataCenter, vmHost.Reference(), z.zone, z.region, true)
+		ctx, node.dataCenter, vmHost.Reference(), z.zone, z.region)
 	if err != nil {
 		klog.Errorf("Failed to get host system properties. err: %+v", err)
 		return zone, err
@@ -111,7 +111,7 @@ func (z *zones) GetZoneByNodeName(ctx context.Context, nodeName k8stypes.NodeNam
 	klog.V(4).Infof("Host owning VM is %s", oHost.Summary.Config.Name)
 
 	zoneResult, err := z.nodeManager.connectionManager.LookupZoneByMoref(
-		ctx, node.dataCenter, vmHost.Reference(), z.zone, z.region, true)
+		ctx, node.dataCenter, vmHost.Reference(), z.zone, z.region)
 	if err != nil {
 		klog.Errorf("Failed to get host system properties. err: %+v", err)
 		return zone, err
@@ -151,7 +151,7 @@ func (z *zones) GetZoneByProviderID(ctx context.Context, providerID string) (clo
 	klog.V(4).Infof("Host owning VM is %s", oHost.Summary.Config.Name)
 
 	zoneResult, err := z.nodeManager.connectionManager.LookupZoneByMoref(
-		ctx, node.dataCenter, vmHost.Reference(), z.zone, z.region, true)
+		ctx, node.dataCenter, vmHost.Reference(), z.zone, z.region)
 	if err != nil {
 		klog.Errorf("Failed to get host system properties. err: %+v", err)
 		return zone, err

--- a/pkg/common/connectionmanager/zones_test.go
+++ b/pkg/common/connectionmanager/zones_test.go
@@ -206,9 +206,6 @@ func TestLookupZoneByMoref(t *testing.T) {
 	// Get a simulator Host
 	myHost := simulator.Map.Any("HostSystem").(*simulator.HostSystem)
 
-	// Get a simulator Cluster
-	myCluster := simulator.Map.Any("ClusterComputeResource").(*simulator.ClusterComputeResource)
-
 	// Create a region category
 	regionID, err := m.CreateCategory(ctx, &tags.Category{Name: config.Labels.Region})
 	if err != nil {
@@ -237,7 +234,7 @@ func TestLookupZoneByMoref(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Setup a multi-DC environment with zones!
+	// Setup a single-DC environment with zones!
 	// Setup DC0
 	dc0, err := vclib.GetDatacenter(ctx, vsi.Conn, "DC0")
 	if err != nil {
@@ -263,44 +260,14 @@ func TestLookupZoneByMoref(t *testing.T) {
 	 * END SETUP
 	 */
 
-	// Get cluster zone found on the Datacenter object. Uses ancessor code path.
-	kv, err := connMgr.LookupZoneByMoref(ctx, dc0, myCluster.Reference(), config.Labels.Zone, config.Labels.Region, true)
-	if err != nil {
-		t.Fatalf("[CLUSTER] LookupZoneByMoref failed err=%v", err)
-	}
-
-	region := kv[RegionLabel]
-	zone := kv[ZoneLabel]
-	if !strings.EqualFold("k8s-region-US", region) {
-		t.Errorf("Region value mismatch k8s-region-US != %s", region)
-	}
-	if !strings.EqualFold("k8s-zone-US-west", zone) {
-		t.Errorf("Region value mismatch k8s-zone-US-west != %s", zone)
-	}
-
 	// Get Host zone found directly on the Host object. Overrides Datacenter. Ancessor enabled but won't use.
-	kv, err = connMgr.LookupZoneByMoref(ctx, dc0, myHost.Reference(), config.Labels.Zone, config.Labels.Region, true)
+	kv, err := connMgr.LookupZoneByMoref(ctx, dc0, myHost.Reference(), config.Labels.Zone, config.Labels.Region)
 	if err != nil {
 		t.Fatalf("[HOST] LookupZoneByMoref failed err=%v", err)
 	}
 
-	region = kv[RegionLabel]
-	zone = kv[ZoneLabel]
-	if !strings.EqualFold("k8s-region-US", region) {
-		t.Errorf("Region value mismatch k8s-region-US != %s", region)
-	}
-	if !strings.EqualFold("k8s-zone-US-east", zone) {
-		t.Errorf("Region value mismatch k8s-zone-US-east != %s", zone)
-	}
-
-	// Get Host zone direct from the Host object. Ancessor is false.
-	kv, err = connMgr.LookupZoneByMoref(ctx, dc0, myHost.Reference(), config.Labels.Zone, config.Labels.Region, false)
-	if err != nil {
-		t.Fatalf("[DIRECT HOST] LookupZoneByMoref failed err=%v", err)
-	}
-
-	region = kv[RegionLabel]
-	zone = kv[ZoneLabel]
+	region := kv[RegionLabel]
+	zone := kv[ZoneLabel]
 	if !strings.EqualFold("k8s-region-US", region) {
 		t.Errorf("Region value mismatch k8s-region-US != %s", region)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR refactors the existing implementation to effectively remove the warning of performing the zone/region labels at the host/ESX level. Previously, zones/regions started it is Ancestors() search with clusters -> folders -> datacenters as it was thought that searching per host was expensive. There are a number of places where we already gather properties, etc per host and this also matches the implementation currently in-tree. This will also enable the **future** support of fault domains in vSAN. There was also a bug on the host label lookup which has now been fixed.

Old behavior:
1. Look for zones starting with clusters -> folders -> datacenters
2. If can't find the zone, print warning
3. Look at each host to get zones anyways

New streamlined behavior:
1. Look for zones starting with host -> clusters -> folders -> datacenters

```
I0709 15:45:03.692207       1 zones.go:128] zones.GetZoneByProviderID() called with vsphere://42278c9d-79fb-f2af-b060-d7f167fa261c
I0709 15:45:03.699515       1 zones.go:151] Host owning VM is 10.160.155.27
I0709 15:45:03.897993       1 zones.go:339] Name: host-21, Type: HostSystem
I0709 15:45:03.974402       1 zones.go:339] Name: domain-c7, Type: ClusterComputeResource
I0709 15:45:04.019047       1 zones.go:339] Name: group-h4, Type: Folder
I0709 15:45:04.075159       1 zones.go:339] Name: datacenter-2, Type: Datacenter
I0709 15:45:04.125783       1 zones.go:358] Found k8s-zone tag (k8s-region-eu-all) attached to HostSystem:host-21
I0709 15:45:04.130746       1 zones.go:358] Found k8s-region tag (k8s-region-eu) attached to HostSystem:host-21
```

**Which issue this PR fixes**:
NA

**Special notes for your reviewer**:
The internal behavior of the WhichVCandDCByZone is actually unchanged. It's a refactor to basically remove code.

Verified on k8s 1.14.1
vSphere 6.7u2

**Release note**:
Since this code also affects CSI, we will need to have a patch release in order for CSI to absorb this PR.