### PR TITLE
Fix repo owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
 approvers:
-- abrarshivani
-- baludontu
-- divyenpatel
-- imkin
-- kerneltime
-- luomiao
-- frapposelli
-- dougm
-- dvonthenen
+  - sig-cloud-provider-leads
+  - cloud-provider-vsphere-maintainers
+
+reviewers:
+  - cloud-provider-vsphere-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,17 @@
+# See the OWNERS docs: https://git.k8s.io/community/docs/devel/owners.md
+
+aliases:
+  sig-cloud-provider-leads:
+    - andrewsykim
+    - hogepodge
+    - jagosan
+  cloud-provider-vsphere-maintainers:
+    - abrarshivani
+    - andrewsykim
+    - baludontu
+    - divyenpatel
+    - dougm
+    - frapposelli
+    - imkin
+    - sandeeppissay
+    - dvonthenen


### PR DESCRIPTION
This PR fixes the repo OWNERS file, aligning with the current standard (OWNERS_ALIASES and OWNERS) used by other projects, it also removes @kerneltime and @luomiao that are no longer involved with the project