### PR TITLE
Update the version string used in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,15 +64,19 @@ deps:
 ##                                VERSIONS                                    ##
 ################################################################################
 # Ensure the version is injected into the binaries via a linker flag.
-export VERSION ?= $(shell git describe --exact-match 2>/dev/null || git describe --match=$$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+export VERSION ?= $(shell git describe --always --dirty)
 
 # Load the image registry include.
 include hack/make/login-to-image-registry.mk
 
 # Define the images.
 IMAGE_CCM := $(REGISTRY)/vsphere-cloud-controller-manager
-.PHONY: print-ccm-image
 
+.PHONY: version print-ccm-image
+
+version:
+	@echo $(VERSION)
+	
 # Printing the image versions are defined early so Go modules aren't forced.
 print-ccm-image:
 	@echo $(IMAGE_CCM):$(VERSION)
@@ -350,13 +354,6 @@ push-ci-image:
 
 print-ci-image:
 	@$(MAKE) --no-print-directory -C hack/images/ci print
-
-################################################################################
-##                               PRINT VERISON                                ##
-################################################################################
-.PHONY: version
-version:
-	@echo $(VERSION)
 
 ################################################################################
 ##                                TODO(akutz)                                 ##

--- a/hack/images/ci/Makefile
+++ b/hack/images/ci/Makefile
@@ -2,7 +2,7 @@ all: build
 
 include ../../../hack/make/login-to-image-registry.mk
 
-VERSION ?= $(shell git describe --exact-match 2>/dev/null || git describe --match=$$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+VERSION ?= $(shell git describe --always --dirty)
 IMAGE := $(REGISTRY)/ci
 IMAGE_D := $(VERSION).d
 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -6,7 +6,7 @@ include ../../hack/make/docker.mk
 PROJECT_ROOT ?= $(abspath ../..)
 
 CLUSTER_NAME := ccm-integration-test
-VERSION ?= $(shell git describe --exact-match 2> /dev/null || git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
+VERSION ?= $(shell git describe --always --dirty)
 CCM_IMAGE := gcr.io/cloud-provider-vsphere/vsphere-cloud-controller-manager:$(VERSION)
 
 KIND_CONFIG := kind-config.yaml


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This patch updates how the version is parsed from the git repo to be
much simpler, and the same as what we will want across CSI, CAPV, and
CPI.

This will mostly be visible for images built via post-submit and tagged
as latest. This will have a meaningful version number in them now,
instead of just an 8-char git hash.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
