### PR TITLE
Introduce new release tooling and structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,20 +66,10 @@ deps:
 # Ensure the version is injected into the binaries via a linker flag.
 export VERSION ?= $(shell git describe --always --dirty)
 
-# Load the image registry include.
-include hack/make/login-to-image-registry.mk
-
-# Define the images.
-IMAGE_CCM := $(REGISTRY)/vsphere-cloud-controller-manager
-
 .PHONY: version print-ccm-image
 
 version:
 	@echo $(VERSION)
-
-# Printing the image versions are defined early so Go modules aren't forced.
-print-ccm-image:
-	@echo $(IMAGE_CCM):$(VERSION)
 
 ################################################################################
 ##                              BUILD BINARIES                                ##
@@ -140,10 +130,8 @@ deploy: | $(DOCKER_SOCK)
 	$(MAKE) check
 	$(MAKE) build-bins
 	$(MAKE) unit-test
-	$(MAKE) build-images
 	$(MAKE) integration-test
-	$(MAKE) push-bins
-	$(MAKE) push-images
+	$(MAKE) release-push
 
 ################################################################################
 ##                                 CLEAN                                      ##
@@ -151,7 +139,8 @@ deploy: | $(DOCKER_SOCK)
 .PHONY: clean
 clean:
 	@rm -f Dockerfile*
-	@rm -f $(CCM_BIN) cloud-provider-vsphere-*.tar.gz cloud-provider-vsphere-*.zip \
+	@rm -f $(CCM_BIN) $(CCM_BIN).sha256 \
+	  cloud-provider-vsphere-*.tar.gz cloud-provider-vsphere-*.zip \
 		image-*.tar image-*.d
 	GO111MODULE=off go clean -i -x . ./cmd/$(CCM_BIN_NAME)
 
@@ -294,42 +283,18 @@ shellcheck:
 	hack/check-shell.sh
 
 ################################################################################
-##                                 BUILD IMAGES                               ##
+##                                 BUILD IMAGES AND BINARIES                  ##
 ################################################################################
-IMAGE_CCM_D := image-ccm-$(VERSION).d
-build-ccm-image ccm-image: $(IMAGE_CCM_D)
-$(IMAGE_CCM): $(IMAGE_CCM_D)
-ifneq ($(GOOS),linux)
-$(IMAGE_CCM_D):
-	$(error Please set GOOS=linux for building $@)
-else
-$(IMAGE_CCM_D): $(CCM_BIN) | $(DOCKER_SOCK)
-	cp -f $< cluster/images/controller-manager/vsphere-cloud-controller-manager
-	docker build -t $(IMAGE_CCM):$(VERSION) cluster/images/controller-manager
-	docker tag $(IMAGE_CCM):$(VERSION) $(IMAGE_CCM):latest
-	@rm -f cluster/images/controller-manager/vsphere-cloud-controller-manager && touch $@
-endif
-
-build-images images: build-ccm-image
+.PHONY: release
+release: | $(DOCKER_SOCK)
+	hack/release.sh
 
 ################################################################################
-##                                  PUSH IMAGES                               ##
+##                                  PUSH IMAGES AND BINARIES                  ##
 ################################################################################
-.PHONY: push-$(IMAGE_CCM) upload-$(IMAGE_CCM)
-push-ccm-image upload-ccm-image: upload-$(IMAGE_CCM)
-push-$(IMAGE_CCM) upload-$(IMAGE_CCM): $(IMAGE_CCM_D) login-to-image-registry | $(DOCKER_SOCK)
-	docker push $(IMAGE_CCM):$(VERSION)
-	docker push $(IMAGE_CCM):latest
-
-.PHONY: push-images upload-images
-push-images upload-images: upload-ccm-image
-
-################################################################################
-##                                  PUSH BINS                                 ##
-################################################################################
-.PHONY: push-bins
-push-bins: build-bins
-	gsutil cp $(CCM_BIN) gs://artifacts.cloud-provider-vsphere.appspot.com/binaries/$(VERSION)/
+.PHONY: release-push
+release-push: | $(DOCKER_SOCK)
+	hack/release.sh -p -l
 
 ################################################################################
 ##                                  CI IMAGE                                  ##
@@ -342,11 +307,3 @@ push-ci-image:
 
 print-ci-image:
 	@$(MAKE) --no-print-directory -C hack/images/ci print
-
-################################################################################
-##                                TODO(akutz)                                 ##
-################################################################################
-TODO := docs godoc releasenotes translation
-.PHONY: $(TODO)
-$(TODO):
-	@echo "$@ not yet implemented"

--- a/cluster/images/controller-manager/Dockerfile
+++ b/cluster/images/controller-manager/Dockerfile
@@ -10,8 +10,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM photon:2.0
+################################################################################
+##                               BUILD ARGS                                   ##
+################################################################################
+# This build arg allows the specification of a custom Golang image.
+ARG GOLANG_IMAGE=golang:1.12.6
 
-ADD vsphere-cloud-controller-manager /bin/
+# The distroless image on which the CPI manager image is built.
+#
+# Please do not use "latest". Explicit tags should be used to provide
+# deterministic builds. This image doesn't have semantic version tags, but
+# the fully-qualified image can be obtained by entering
+# "gcr.io/distroless/static:latest" in a browser and then copying the
+# fully-qualified image from the web page.
+ARG DISTROLESS_IMAGE=gcr.io/distroless/static@sha256:9b60270ec0991bc4f14bda475e8cae75594d8197d0ae58576ace84694aa75d7a
 
-CMD ["/bin/vsphere-cloud-controller-manager"]
+################################################################################
+##                              BUILD STAGE                                   ##
+################################################################################
+# Build the manager as a statically compiled binary so it has no dependencies
+# libc, muscl, etc.
+FROM ${GOLANG_IMAGE} as builder
+
+# This build arg is the version to embed in the CPI binary
+ARG VERSION=unknown
+
+# This build arg controls the GOPROXY setting
+ARG GOPROXY
+
+WORKDIR /build
+COPY go.mod go.sum ./
+COPY pkg/    pkg/
+COPY cmd/    cmd/
+ENV CGO_ENABLED=0
+ENV GOPROXY ${GOPROXY:-}
+RUN go build -a -ldflags='-w -s -extldflags=static -X main.version=${VERSION}' -o vsphere-cloud-controller-manager ./cmd/vsphere-cloud-controller-manager
+
+################################################################################
+##                               MAIN STAGE                                   ##
+################################################################################
+# Copy the manager into the distroless image.
+FROM ${DISTROLESS_IMAGE}
+LABEL maintainer="Travis Rhoden <trhoden@vmware.com>"
+COPY --from=builder /build/vsphere-cloud-controller-manager /bin/vsphere-cloud-controller-manager
+ENTRYPOINT [ "/bin/vsphere-cloud-controller-manager" ]

--- a/hack/match-release-tag.sh
+++ b/hack/match-release-tag.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+usage() {
+  cat <<EOF
+usage: ${0} [TAG]
+  Verifies the provided tag is a release tag.
+
+TAG
+  If no tag is provided then "git describe --dirty" is used to obtain the tag.
+
+FLAGS
+  -h    prints this help screen
+  -x    run the examples
+EOF
+}
+
+while getopts ':hx' opt; do
+  case "${opt}" in
+  h)
+    usage 1>&2; exit 1
+    ;;
+  x)
+    EXAMPLES=1
+    ;;
+  \?)
+    { echo "invalid option: -${OPTARG}"; usage; } 1>&2; exit 1
+    ;;
+  :)
+    echo "option -${OPTARG} requires an argument" 1>&2; exit 1
+    ;;
+  esac
+done
+shift $((OPTIND-1))
+
+# The regular expression matches the following strings:
+#   * v1.0.0-alpha.0
+#   * v1.0.0-beta.0
+#   * v1.0.0-rc.0
+#   * v1.0.0
+# Any occurence of a digit in the above examples may be multiple digits.
+REGEX='^[[:space:]]{0,}v[[:digit:]]{1,}\.[[:digit:]]{1,}\.[[:digit:]]{1,}(-(alpha|beta|rc)\.[[:digit:]]{1,}){0,1}[[:space:]]{0,}$'
+
+# Match the tag against the regular expression for a release tag.
+match() {
+  if [[ ${1} =~ ${REGEX} ]]; then
+    echo "yay: ${1}"
+  else
+    exit_code="${?}"
+    echo "nay: ${1}"
+    return "${exit_code}"
+  fi
+}
+
+# Run examples to illustrate valid and invalid values.
+examples() {
+  local semvers=" \
+    v1.0.0-alpha.0 \
+    v1.0.0-beta.0 \
+    v1.0.0-rc.0 \
+    v1.0.0 \
+    v10.0.0 \
+    v1.10.0 \
+    v1.0.10 \
+    v10.0.0-alpha.10 \
+    v1.10.0-beta.10 \
+    v1.0.10-rc.10 \
+    1.0.0 \
+    v1.0.0+rc.0 \
+    v10a.0.0 \
+    1.1.0-alpha.1 \
+    v1.0.0-alpha.0a"
+  set +o errexit
+  for v in ${semvers}; do match "${v}"; done
+  return 0
+}
+
+main() {
+  # Get the tag from the remaining arguments or from "git describe --dirty"
+  [ "${#}" -eq "0" ] || tag="${1}"
+  [ -n "${tag-}" ] || tag="$(git describe --dirty)"
+
+  # Match the tag against the regular expression for a release tag.
+  match "${tag}" 1>&2
+}
+
+{ [ "${EXAMPLES-}" ] && examples; } || main "${@-}"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used build new container images of the CAPV manager and
+# clusterctl. When invoked without arguments, the default behavior is to build
+# new ci images
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# BASE_REPO is the root path of the image repository
+readonly BASE_IMAGE_REPO=gcr.io/cloud-provider-vsphere
+
+# Release images
+readonly CPI_IMAGE_RELEASE=${BASE_IMAGE_REPO}/cpi/release/manager
+
+# PR images
+readonly CPI_IMAGE_PR=${BASE_IMAGE_REPO}/cpi/pr/manager
+
+# CI images
+readonly CPI_IMAGE_CI=${BASE_IMAGE_REPO}/cpi/ci/manager
+
+AUTH=
+PUSH=
+LATEST=
+CPI_IMAGE_NAME=
+VERSION=$(git describe --dirty --always 2>/dev/null)
+GCR_KEY_FILE="${GCR_KEY_FILE:-}"
+GOPROXY="${GOPROXY:-}"
+BUILD_RELEASE_TYPE="${BUILD_RELEASE_TYPE:-}"
+
+# If BUILD_RELEASE_TYPE is not set then check to see if this is a PR
+# or release build. This may still be overridden below with the "-t" flag.
+if [ -z "${BUILD_RELEASE_TYPE}" ]; then
+  if hack/match-release-tag.sh >/dev/null 2>&1; then
+    BUILD_RELEASE_TYPE=release
+  else
+    BUILD_RELEASE_TYPE=ci
+  fi
+fi
+
+USAGE="
+usage: ${0} [FLAGS]
+  Builds and optionally pushes new images for vSphere CPI manager
+
+  Honored environment variables:
+  GCR_KEY_FILE
+  GOPROXY
+  BUILD_RELEASE_TYPE
+
+FLAGS
+  -h    show this help and exit
+  -k    path to GCR key file. Used to login to registry if specified
+        (defaults to: ${GCR_KEY_FILE})
+  -l    tag the images as \"latest\" in addition to their version
+        when used with -p, both tags will be pushed
+  -p    push the images to the public container registry
+  -t    the build/release type (defaults to: ${BUILD_RELEASE_TYPE})
+        one of [ci,pr,release]
+"
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+function error() {
+  local exit_code="${?}"
+  echo "${@}" 1>&2
+  return "${exit_code}"
+}
+
+function fatal() {
+  error "${@}" || exit 1
+}
+
+function build_images() {
+  case "${BUILD_RELEASE_TYPE}" in
+    ci)
+      # A non-PR, non-release build. This is usually a build off of master
+      CPI_IMAGE_NAME=${CPI_IMAGE_CI}
+      ;;
+    pr)
+      # A PR build
+      CPI_IMAGE_NAME=${CPI_IMAGE_PR}
+      ;;
+    release)
+      # On an annotated tag
+      CPI_IMAGE_NAME=${CPI_IMAGE_RELEASE}
+      ;;
+  esac
+
+  echo "building ${CPI_IMAGE_NAME}:${VERSION}"
+  echo "GOPROXY=${GOPROXY}"
+  docker build \
+    -f cluster/images/controller-manager/Dockerfile \
+    -t "${CPI_IMAGE_NAME}:${VERSION}" \
+    --build-arg "VERSION=${VERSION}" \
+    --build-arg "GOPROXY=${GOPROXY}" \
+    .
+  if [ "${LATEST}" ]; then
+    echo "tagging image ${CPI_IMAGE_NAME}:${VERSION} as latest"
+    docker tag "${CPI_IMAGE_NAME}:${VERSION} ${CPI_IMAGE_NAME}:latest"
+  fi
+}
+
+function logout() {
+  if [ "${AUTH}" ]; then
+    gcloud auth revoke
+  fi
+}
+
+function login() {
+  # If GCR_KEY_FILE is set, use that service account to login
+  if [ "${GCR_KEY_FILE}" ]; then
+    trap logout EXIT
+    gcloud auth configure-docker --quiet || fatal "unable to add docker auth helper"
+    gcloud auth activate-service-account --key-file "${GCR_KEY_FILE}" || fatal "unable to login"
+    docker login -u _json_key --password-stdin https://gcr.io <"${GCR_KEY_FILE}" || fatal "unable to login"
+    AUTH=1
+  fi
+}
+
+function push_images() {
+  [ "${CPI_IMAGE_NAME}" ] || fatal "CPI_IMAGE_NAME not set"
+
+  login
+
+  echo "pushing ${CPI_IMAGE_NAME}:${VERSION}"
+  docker push "${CPI_IMAGE_NAME}":"${VERSION}"
+  if [ "${LATEST}" ]; then
+    echo "also pushing ${CPI_IMAGE_NAME}:${VERSION} as latest"
+    docker push "${CPI_IMAGE_NAME}":latest
+  fi
+}
+
+function build_ccm_bin() {
+  echo "building ccm binary"
+  GOOS=linux GOARCH=amd64 make build-bins
+}
+
+function sha_sum() {
+  { sha256sum "${1}" || shasum -a 256 "${1}"; } 2>/dev/null > "${1}.sha256"
+}
+
+function push_ccm_bin() {
+  local bucket="vsphere-cpi-${BUILD_RELEASE_TYPE}"
+
+  sha_sum ".build/bin/vsphere-cloud-controller-manager.linux_amd64"
+  echo "copying ccm version ${VERSION} to ${bucket}"
+  gsutil cp "build/bin/vsphere-cloud-controller-manager.linux_amd64" "gs://${bucket}/${VERSION}/bin/linux/amd64/vsphere-cloud-controller-manager"
+  gsutil cp "build/bin/vsphere-cloud-controller-manager.linux_amd64.sha256" "gs://${bucket}/${VERSION}/bin/linux/amd64/vsphere-cloud-controller-manager.sha256"
+}
+
+# Start of main script
+while getopts ":hk:lpt:" opt; do
+  case ${opt} in
+    h)
+      error "${USAGE}" && exit 1
+      ;;
+    k)
+      GCR_KEY_FILE="${OPTARG}"
+      ;;
+    l)
+      LATEST=1
+      ;;
+    p)
+      PUSH=1
+      ;;
+    t)
+      BUILD_RELEASE_TYPE="${OPTARG}"
+      ;;
+    \?)
+      error "invalid option: -${OPTARG} ${USAGE}" && exit 1
+      ;;
+    :)
+      error "option -${OPTARG} requires an argument" && exit 1
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+# Verify the GCR_KEY_FILE exists if defined
+if [ "${GCR_KEY_FILE}" ]; then
+  [ -e "${GCR_KEY_FILE}" ] || fatal "key file ${GCR_KEY_FILE} does not exist"
+fi
+
+# Validate build/release type.
+case "${BUILD_RELEASE_TYPE}" in
+  ci|pr|release)
+    # do nothing
+    ;;
+  *)
+    fatal "invalid BUILD_RELEASE_TYPE: ${BUILD_RELEASE_TYPE}"
+    ;;
+esac
+
+# make sure that Docker is available
+docker ps >/dev/null 2>&1 || fatal "Docker not available"
+
+# build container images
+build_images
+
+# build CCM binary
+build_ccm_bin
+
+# Optionally push artifacts
+if [ "${PUSH}" ]; then
+  push_images
+  push_ccm_bin
+fi

--- a/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
@@ -36,9 +36,8 @@ spec:
       serviceAccountName: cloud-controller-manager
       containers:
         - name: vsphere-cloud-controller-manager
-          image: gcr.io/cloud-provider-vsphere/vsphere-cloud-controller-manager:latest
+          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:latest
           args:
-            - /bin/vsphere-cloud-controller-manager
             - --v=2
             - --cloud-provider=vsphere
             - --cloud-config=/etc/cloud/vsphere.conf

--- a/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml
@@ -18,9 +18,8 @@ metadata:
 spec:
   containers:
     - name: vsphere-cloud-controller-manager
-      image: gcr.io/cloud-provider-vsphere/vsphere-cloud-controller-manager:latest
+      image: gcr.io/cloud-provider-vsphere/cpi/release/manager:latest
       args:
-        - /bin/vsphere-cloud-controller-manager
         - --v=2
         - --cloud-config=/etc/cloud/vsphere.conf
         - --cloud-provider=vsphere

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -7,7 +7,7 @@ PROJECT_ROOT ?= $(abspath ../..)
 
 CLUSTER_NAME := ccm-integration-test
 VERSION ?= $(shell git describe --always --dirty)
-CCM_IMAGE := gcr.io/cloud-provider-vsphere/vsphere-cloud-controller-manager:$(VERSION)
+CCM_IMAGE := gcr.io/cloud-provider-vsphere/cpi/pr/manager:$(VERSION)
 
 KIND_CONFIG := kind-config.yaml
 .PHONY: $(KIND_CONFIG)
@@ -53,7 +53,7 @@ deploy-ccm:
 	kubectl -n kube-system create -f secrets.yaml && \
 	kubectl -n kube-system apply -f ../../manifests/controller-manager/cloud-controller-manager-roles.yaml && \
 	kubectl -n kube-system apply -f ../../manifests/controller-manager/cloud-controller-manager-role-bindings.yaml && \
-	sed 's~gcr.io/cloud-provider-vsphere/vsphere-cloud-controller-manager:latest~$(CCM_IMAGE)~g' <../../manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml | kubectl -n kube-system apply -f -
+	sed 's~gcr.io/cloud-provider-vsphere/cpi/release/manager:latest~$(CCM_IMAGE)~g' <../../manifests/controller-manager/vsphere-cloud-controller-manager-pod.yaml | kubectl -n kube-system apply -f -
 
 delete-ccm:
 	kubectl -n kube-system delete configmaps cloud-config && \
@@ -70,7 +70,7 @@ log-ccm:
 	kubectl -n kube-system logs vsphere-cloud-controller-manager
 
 build-ccm-image:
-	GOOS=linux $(MAKE) -C ../.. build-ccm-image
+	../../hack/release.sh -t pr
 
 load-ccm-image: | $(DOCKER_SOCK)
 	kind load docker-image --name "$(CLUSTER_NAME)" $(CCM_IMAGE)


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This patch adds a hack/release.sh script that can be used both locally
and in CI for generating and pushing images and binaries to GCR and GCS.
The Makefile is modified to make use of this script, and the integration
test is modified to use the new images.

The location of the images and binaries moves with this change, mainly
splitting the latest builds from master into one channel versus a
release channel that only contains tagged releases. Doc updates and
manifest changes need to come in after this as well.

The CPI container image is also now based on distroless.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Okay, this is  a big one. This change would bring CPI in-line with both CAPV and CSI, as far as how releases are done. Major changes to note...

Tagged images would now now live at:
`gcr.io/cloud-provider-vsphere/cpi/release`. So, for example, if we release v0.3.1, the image would be at `gcr.io/cloud-provider-vsphere/cpi/release/manager:v0.3.1`.

Images that are built from master after each merge will live at `gcr.io/cloud-provider-vsphere/cpi/ci`, and those built for testing during PRs would live at `gcr.io/cloud-provider-vsphere/cpi/pr`. This allows us to clean up old images (like for PRs) w/o worrying about if someone else is using them. The PR images should never be used other than for the PR itself.

This should also fix the error that's happening right now when pushing the binaries. Since we added the step to push the CCM binary to GCS using `gsutil`, the push has [been failing](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-cloud-provider-vsphere-deploy/1154396491809296384) with errors like:
```
gsutil cp .build/bin/vsphere-cloud-controller-manager.linux_amd64 gs://artifacts.cloud-provider-vsphere.appspot.com/binaries/675f0b47/
Copying file://.build/bin/vsphere-cloud-controller-manager.linux_amd64 [Content-Type=application/octet-stream]...
/ [0 files][    0.0 B/ 52.3 MiB]                                                
ResumableUploadAbortException: 403 Insufficient Permission
```
This is because no `gcloud auth` command was done. We logged into gcr via Docker, but not GCS. I probably need to create the GCS buckets still and apply the appropriate lifecycle to them, just like we did with CAPV.

Once this is merged in, we can added a new post-submit to Prow that pushes tagged releases for us automatically. The existing post-submit that runs post merge to master should still work, as it uses the same make target: `make deploy`.

/assign @frapposelli 
/assign @yastij 
/assign @dvonthenen 

/hold

I'm putting the hold on here because even if this looks good to others, I really want the buy-in from Fabio that these changes are okay.

Also, I expect it's going to take me a couple iterations here to get the integration (and maybe conformance?) tests to pass.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
