### PR TITLE
Use bash for conformance.sh script

### DIFF
--- a/hack/images/ci/conformance.sh
+++ b/hack/images/ci/conformance.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2018 The Kubernetes Authors.
 #
@@ -19,7 +19,7 @@
 
 set -o nounset
 set -o errexit
-! /bin/sh -c 'set -o pipefail' >/dev/null 2>&1 || set -o pipefail
+set -o pipefail
 
 # Ensure the Docker socket is bind mounted into the container.
 DOCKER_SOCK="${DOCKER_SOCK:-/var/run/docker.sock}"


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Shellcheck was unhappy with tryingt to conditionally enable pipefail.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This should fix the error seen [here](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-cloud-provider-vsphere-deploy/1156646439502221312).
I'm not sure why this only showed up in the post-submit.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
