### PR TITLE
Add token auth support for tags client

### DIFF
--- a/pkg/cloudprovider/vsphere/zones_test.go
+++ b/pkg/cloudprovider/vsphere/zones_test.go
@@ -39,6 +39,10 @@ func TestZones(t *testing.T) {
 	cfg, close := configFromEnvOrSim(false)
 	defer close()
 
+	// Configure for SAML token auth
+	cfg.Global.User = localhostCert
+	cfg.Global.Password = localhostKey
+
 	// Create configuration object
 	connMgr := cm.NewConnectionManager(cfg, nil)
 	defer connMgr.Logout()

--- a/pkg/common/vclib/connection.go
+++ b/pkg/common/vclib/connection.go
@@ -84,6 +84,43 @@ func (connection *VSphereConnection) Connect(ctx context.Context) error {
 	return nil
 }
 
+// Signer returns an sts.Signer for use with SAML token auth if connection is configured for such.
+// Returns nil if username/password auth is configured for the connection.
+func (connection *VSphereConnection) Signer(ctx context.Context, client *vim25.Client) (*sts.Signer, error) {
+	// TODO: Add separate fields for certificate and private-key.
+	// For now we can leave the config structs and validation as-is and
+	// decide to use LoginByToken if the username value is PEM encoded.
+	b, _ := pem.Decode([]byte(connection.Username))
+	if b == nil {
+		return nil, nil
+	}
+
+	cert, err := tls.X509KeyPair([]byte(connection.Username), []byte(connection.Password))
+	if err != nil {
+		klog.Errorf("Failed to load X509 key pair. err: %+v", err)
+		return nil, err
+	}
+
+	tokens, err := sts.NewClient(ctx, client)
+	if err != nil {
+		klog.Errorf("Failed to create STS client. err: %+v", err)
+		return nil, err
+	}
+
+	req := sts.TokenRequest{
+		Certificate: &cert,
+		Delegatable: true,
+	}
+
+	signer, err := tokens.Issue(ctx, req)
+	if err != nil {
+		klog.Errorf("Failed to issue SAML token. err: %+v", err)
+		return nil, err
+	}
+
+	return signer, nil
+}
+
 // login calls SessionManager.LoginByToken if certificate and private key are configured,
 // otherwise calls SessionManager.Login with user and password.
 func (connection *VSphereConnection) login(ctx context.Context, client *vim25.Client) error {
@@ -91,38 +128,17 @@ func (connection *VSphereConnection) login(ctx context.Context, client *vim25.Cl
 	connection.credentialsLock.Lock()
 	defer connection.credentialsLock.Unlock()
 
-	// TODO: Add separate fields for certificate and private-key.
-	// For now we can leave the config structs and validation as-is and
-	// decide to use LoginByToken if the username value is PEM encoded.
-	b, _ := pem.Decode([]byte(connection.Username))
-	if b == nil {
-		klog.V(3).Infof("SessionManager.Login with username '%s'", connection.Username)
+	signer, err := connection.Signer(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	if signer == nil {
+		klog.V(3).Infof("SessionManager.Login with username %q", connection.Username)
 		return m.Login(ctx, neturl.UserPassword(connection.Username, connection.Password))
 	}
 
-	klog.V(3).Infof("SessionManager.LoginByToken with certificate '%s'", connection.Username)
-
-	cert, err := tls.X509KeyPair([]byte(connection.Username), []byte(connection.Password))
-	if err != nil {
-		klog.Errorf("Failed to load X509 key pair. err: %+v", err)
-		return err
-	}
-
-	tokens, err := sts.NewClient(ctx, client)
-	if err != nil {
-		klog.Errorf("Failed to create STS client. err: %+v", err)
-		return err
-	}
-
-	req := sts.TokenRequest{
-		Certificate: &cert,
-	}
-
-	signer, err := tokens.Issue(ctx, req)
-	if err != nil {
-		klog.Errorf("Failed to issue SAML token. err: %+v", err)
-		return err
-	}
+	klog.V(3).Infof("SessionManager.LoginByToken with certificate %q", connection.Username)
 
 	header := soap.Header{Security: signer}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Ported fix from the in-tree provider: kubernetes/kubernetes#77360

**Which issue this PR fixes**

Fixes #200

**Special notes for your reviewer**:

In-tree PRs:
kubernetes/kubernetes#75515
kubernetes/kubernetes#78137
kubernetes/kubernetes#78876

**Release note**:

```release-note
Support SAML token auth when using Zones
```
