### PR TITLE
IPv6 Support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/btree v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/pkg/errors v0.8.0
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3

--- a/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
+++ b/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml
@@ -1,6 +1,23 @@
 apiVersion: v1
 items:
 - apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: servicecatalog.k8s.io:apiserver-authentication-reader
+    namespace: kube-system
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: extension-apiserver-authentication-reader
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+  - apiGroup: ""
+    kind: User
+    name: cloud-controller-manager
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: system:cloud-controller-manager

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	pb "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/proto"
+	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
 	cm "k8s.io/cloud-provider-vsphere/pkg/common/connectionmanager"
 )
 
@@ -153,4 +154,28 @@ func TestExport(t *testing.T) {
 	}
 
 	nm.UnregisterNode(node)
+}
+
+func TestReturnIPsFromSpecificFamily(t *testing.T) {
+	ipFamilies := []string{
+		"10.161.34.192",
+		"fd01:0:101:2609:bdd2:ee20:7bd7:5836",
+		"fe80::98b5:4834:27a8:c58d",
+	}
+
+	ips := returnIPsFromSpecificFamily(vcfg.IPv6Family, ipFamilies)
+	size := len(ips)
+	if size != 1 {
+		t.Errorf("Should only return single IPv6 address. expected: 1, actual: %d", size)
+	} else if !strings.EqualFold(ips[0], "fd01:0:101:2609:bdd2:ee20:7bd7:5836") {
+		t.Errorf("IPv6 does not match. expected: fd01:0:101:2609:bdd2:ee20:7bd7:5836, actual: %s", ips[0])
+	}
+
+	ips = returnIPsFromSpecificFamily(vcfg.IPv4Family, ipFamilies)
+	size = len(ips)
+	if size != 1 {
+		t.Errorf("Should only return single IPv4 address. expected: 1, actual: %d", size)
+	} else if !strings.EqualFold(ips[0], "10.161.34.192") {
+		t.Errorf("IPv6 does not match. expected: 10.161.34.192, actual: %s", ips[0])
+	}
 }

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -78,3 +78,57 @@ func TestBlankEnvFails(t *testing.T) {
 		t.Fatalf("Env only config should fail if env not set")
 	}
 }
+
+func TestIPFamilies(t *testing.T) {
+	input := "ipv6"
+	ipFamilies, err := validateIPFamily(input)
+	if err != nil {
+		t.Errorf("Valid ipv6 but yielded err: %s", err)
+	}
+	size := len(ipFamilies)
+	if size != 1 {
+		t.Errorf("Invalid family list expected: 1, actual: %d", size)
+	}
+
+	input = "ipv4"
+	ipFamilies, err = validateIPFamily(input)
+	if err != nil {
+		t.Errorf("Valid ipv4 but yielded err: %s", err)
+	}
+	size = len(ipFamilies)
+	if size != 1 {
+		t.Errorf("Invalid family list expected: 1, actual: %d", size)
+	}
+
+	input = "ipv4, "
+	ipFamilies, err = validateIPFamily(input)
+	if err != nil {
+		t.Errorf("Valid ipv4, but yielded err: %s", err)
+	}
+	size = len(ipFamilies)
+	if size != 1 {
+		t.Errorf("Invalid family list expected: 1, actual: %d", size)
+	}
+
+	input = "ipv6,ipv4"
+	ipFamilies, err = validateIPFamily(input)
+	if err != nil {
+		t.Errorf("Valid ipv6/ipv4 but yielded err: %s", err)
+	}
+	size = len(ipFamilies)
+	if size != 2 {
+		t.Errorf("Invalid family list expected: 2, actual: %d", size)
+	}
+
+	input = "ipv7"
+	_, err = validateIPFamily(input)
+	if err == nil {
+		t.Errorf("Invalid ipv7 but successful")
+	}
+
+	input = "ipv4,ipv7"
+	_, err = validateIPFamily(input)
+	if err == nil {
+		t.Errorf("Invalid ipv4,ipv7 but successful")
+	}
+}

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -57,6 +57,11 @@ type Config struct {
 		// Configurable vSphere CCM API port
 		// Default: 43001
 		APIBinding string `gcfg:"api-binding"`
+		// IP Family enables the ability to support IPv4 or IPv6
+		// Supported values are:
+		// ipv4 - IPv4 addresses only (Default)
+		// ipv6 - IPv6 addresses only
+		IPFamily string `gcfg:"ip-family"`
 	}
 
 	// Virtual Center configurations
@@ -89,4 +94,11 @@ type VirtualCenterConfig struct {
 	CAFile string `gcfg:"ca-file"`
 	// Thumbprint of the VCenter's certificate thumbprint
 	Thumbprint string `gcfg:"thumbprint"`
+	// IP Family enables the ability to support IPv4 or IPv6
+	// Supported values are:
+	// ipv4 - IPv4 addresses only (Default)
+	// ipv6 - IPv6 addresses only
+	IPFamily string `gcfg:"ip-family"`
+	// IPFamilyPriority the list/priority of IP versions
+	IPFamilyPriority []string
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for IPv6 environments. This PR allows you to specify either Globally or per-VC the IP Family for the discovered VM. For more details on what that configuration looks like, please see the `Special notes` section below to see what the vsphere.conf looks like.

The supported values for `ip-family` are:
- ipv4 - This is the default if nothing is specified. Only use ipv4 addresses
- ipv6 - Only use ipv6 addresses

Side note: In testing this functionality, apparently some recent changes (I am guessing this PR https://github.com/kubernetes/cloud-provider-vsphere/pull/228) broke the ability for the CPI to grab the creds from the k8s secret. Unless the role binding is added to the YAML, the CPI would error with the following:
```
Unable to get configmap/extension-apiserver-authentication in kube-system.  Usually fixed by 'kubectl create rolebinding -n kube-system ROLE_NAME --role=extension-apiserver-authentication-reader --serviceaccount=YOUR_NS:YOUR_SA'
Error: configmaps "extension-apiserver-authentication" not found
```

**Which issue this PR fixes**: https://github.com/kubernetes/cloud-provider-vsphere/issues/209

**Special notes for your reviewer**:
Tested the following combinations... all test cases work as expected. `go test` walks through the expected behavior when doing the selection on which IP family to use.

Case 1: Didn't specify anything in terms of IP Family. (aka Default behavior is ipv4)

Case 2: Explicitly specifying ipv4 only
```
[Global]
ip-family=ipv4
```

Case 3: Specifying ipv6 addresses only
```
[Global]
ip-family=ipv6
```

Case 4: Making sure ipv6 addresses are used and that the ip-family set in `Global` doesn't override what's specified for each VC
```
[Global]
ip-family=ipv4

[VirtualCenter "vc1"]
ip-family=ipv6

[VirtualCenter "vc2"]
ip-family=ipv6
```

**Release note**:
The default (ipv4) behavior remains unchanged. This PR has zero impact to CSI.