### PR TITLE
docs: fix link to CSI page

### DIFF
--- a/docs/book/SUMMARY.md
+++ b/docs/book/SUMMARY.md
@@ -8,7 +8,7 @@
   * [Overview of the CSI](concepts/csi_overview.md)
 * [Glossary](glossary.md)
 * [Cloud Provider Interface (CPI)](cloud_provider_interface.md)
-* [Container Storage Interface (CSI)](cloud_provider_interface.md)
+* [Container Storage Interface (CSI)](container_storage_interface.md)
 * [Cloud Config Spec](cloud_config.md)
 
 ## Tutorials


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixes an incorrect link to the CSI page in the vSphere docs. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
