### PR TITLE
Fix import syntax in cloudprovidervsphere.pb.go

### DIFF
--- a/pkg/cloudprovider/vsphere/proto/cloudprovidervsphere.pb.go
+++ b/pkg/cloudprovider/vsphere/proto/cloudprovidervsphere.pb.go
@@ -8,9 +8,6 @@ import (
 	math "math"
 
 	proto "github.com/golang/protobuf/proto"
-)
-
-import (
 	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Starting on 8/16, the `make fmt` target has been returning [an error](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-cloud-provider-vsphere-deploy/1162441111394848768) in the post-submit deploy step.

I'm not sure why this is only being caught in the post-submit and not the pre-submit, but sure enough the file is formatted funny with two different import sections. Since this is a generated file, I figured tried to regenerate teh `pb.go` file with `protoc` but that generated so many differences it didn't look right. So I'm just fixing this explicitly.

At some point, we need to visit generating the protobuf file again with the version we have in the `go.mod` file -- they are definitely differences.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
w/o this fix, the post-submit deploy step was always failing. Except, with the new release tooling, this would actually succeed. We now assume that anything that makes it to `master` is okay to build, and we don't run the linting scripts as a pre-requisite. This should still get fixed, though.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @frapposelli 
/hold
^ I'd like to see this get merged after https://github.com/kubernetes/test-infra/pull/13983, as it will be a good test to see that the post-submit deploy is working.