### PR TITLE
Fix tagging of latest in hack/release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -113,7 +113,7 @@ function build_images() {
     .
   if [ "${LATEST}" ]; then
     echo "tagging image ${CPI_IMAGE_NAME}:${VERSION} as latest"
-    docker tag "${CPI_IMAGE_NAME}:${VERSION} ${CPI_IMAGE_NAME}:latest"
+    docker tag "${CPI_IMAGE_NAME}:${VERSION}" "${CPI_IMAGE_NAME}:latest"
   fi
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The two args to `docker tag` need to be in separate quotes, otherwise
they are seen as one single arg.

This fixes the error seen [here](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-cloud-provider-vsphere-deploy/1163880859799916544#0:build-log.txt%3A599)

I had thought I was making a simplification over what I had done in CAPV and CSI, but turns out it just broke the script. Doh :/

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @frapposelli 
/assign @dvonthenen 
