### PR TITLE
Refactor using single SharedInformer

### DIFF
--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -66,7 +66,7 @@ func (vs *VSphere) Initialize(clientBuilder cloudprovider.ControllerClientBuilde
 	if err == nil {
 		klog.V(1).Info("Kubernetes Client Init Succeeded")
 
-		vs.informMgr = k8s.NewInformer(client)
+		vs.informMgr = k8s.NewInformer(client, true)
 
 		connMgr := cm.NewConnectionManager(vs.cfg, vs.informMgr, client)
 		vs.connectionManager = connMgr

--- a/pkg/common/connectionmanager/connectionmanager.go
+++ b/pkg/common/connectionmanager/connectionmanager.go
@@ -117,7 +117,7 @@ func (connMgr *ConnectionManager) createManagersPerTenant(secretName string, sec
 	var informMgr *k8s.InformerManager
 	var lister listerv1.SecretLister
 	if client != nil && secretsDirectory == "" {
-		informMgr = k8s.NewInformer(client)
+		informMgr = k8s.NewInformer(client, true)
 		lister = informMgr.GetSecretLister()
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This was some fallout from creating listers for multiple secrets for VC creds. This refactors NewInformer so that only a single SharedInformer is created. In English, we only have a single watcher for all secrets.

**Which issue this PR fixes** : fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/243

**Special notes for your reviewer**:
Tested on k8s 1.14.1 on vsphere 6.7u2 using multiple secrets.

**Release note**:
NA