### PR TITLE
Controller manifest update to point to apps/v1 to replace deprecated extensions/v1beta1

### DIFF
--- a/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
+++ b/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cloud-controller-manager
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: vsphere-cloud-controller-manager


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update to the controller manifest vsphere-cloud-controller-manager-ds.yaml to enable support for Kubernetes 1.16 as the the daemonset controller api 'extensions/v1beta1' is now deprecated

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #252

**Special notes for your reviewer**:
the apps/v1 API has been supported since Kubernetes 1.9 for DaemonSets so backwards compatible

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
As per the 1.16 release notes the api tree 'extensions/v1beta1' has been deprecated. The replacement is fully backwards supported through to 1.9 as detailed in  https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/