### PR TITLE
Update Go docker images to 1.12.10

### DIFF
--- a/cluster/images/controller-manager/Dockerfile
+++ b/cluster/images/controller-manager/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.12.6
+ARG GOLANG_IMAGE=golang:1.12.10
 
 # The distroless image on which the CPI manager image is built.
 #

--- a/hack/images/ci/Dockerfile
+++ b/hack/images/ci/Dockerfile
@@ -3,7 +3,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.12
+ARG GOLANG_IMAGE=golang:1.12.10
 
 # The image from which the Terraform project used to turn up a K8s cluster is
 # copied, as well as several programs.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We are using an old (with security issues) version of Go for our builds.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Thoughts for pinning versions exactly: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/74#issuecomment-538433556
And some other interesting thoughts on issues with our current "CI" image: https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/76#issue-324835621

However, the "CI" image does a lot more in the CPI project than it does CSI (e.g. conformance), so that's another topic.

/assign @frapposelli 
/assign @andrewsykim 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
