### PR TITLE
remove ServiceAccount in cloud config

### DIFF
--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -35,6 +35,8 @@ const (
 	// ProviderName is the name of the cloud provider registered with
 	// Kubernetes.
 	ProviderName string = "vsphere"
+	// ClientName is the user agent passed into the controller client builder.
+	ClientName string = "vsphere-cloud-controller-manager"
 )
 
 func init() {
@@ -62,7 +64,7 @@ func newVSphere(cfg *vcfg.Config, finalize ...bool) (*VSphere, error) {
 
 // Initialize initializes the cloud provider.
 func (vs *VSphere) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
-	client, err := clientBuilder.Client(vs.cfg.Global.ServiceAccount)
+	client, err := clientBuilder.Client(ClientName)
 	if err == nil {
 		klog.V(1).Info("Kubernetes Client Init Succeeded")
 

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -88,9 +88,6 @@ func (cfg *Config) FromEnv() error {
 	if v := os.Getenv("VSPHERE_SECRET_NAMESPACE"); v != "" {
 		cfg.Global.SecretNamespace = v
 	}
-	if v := os.Getenv("VSPHERE_SERVICE_ACCOUNT"); v != "" {
-		cfg.Global.ServiceAccount = v
-	}
 
 	if v := os.Getenv("VSPHERE_ROUNDTRIP_COUNT"); v != "" {
 		tmp, err := strconv.ParseUint(v, 10, 32)
@@ -317,9 +314,6 @@ func (cfg *Config) validateConfig() error {
 	//Fix default global values
 	if cfg.Global.RoundTripperCount == 0 {
 		cfg.Global.RoundTripperCount = DefaultRoundTripperCount
-	}
-	if cfg.Global.ServiceAccount == "" {
-		cfg.Global.ServiceAccount = DefaultK8sServiceAccount
 	}
 	if cfg.Global.VCenterPort == "" {
 		cfg.Global.VCenterPort = DefaultVCenterPort

--- a/pkg/common/config/consts_and_errors.go
+++ b/pkg/common/config/consts_and_errors.go
@@ -29,10 +29,6 @@ const (
 	// exposing the API service.
 	DefaultAPIBinding string = ":43001"
 
-	// DefaultK8sServiceAccount is the default name of the Kubernetes
-	// service account.
-	DefaultK8sServiceAccount string = "cloud-controller-manager"
-
 	// DefaultVCenterPort is the default port used to access vCenter.
 	DefaultVCenterPort string = "443"
 

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -43,9 +43,6 @@ type Config struct {
 		SecretName string `gcfg:"secret-name"`
 		// Secret Namespace where secret will be present that has vCenter credentials.
 		SecretNamespace string `gcfg:"secret-namespace"`
-		// The kubernetes service account used to launch the cloud controller manager.
-		// Default: cloud-controller-manager
-		ServiceAccount string `gcfg:"service-account"`
 		// Secret directory in the event that:
 		// 1) we don't want to use the k8s API to listen for changes to secrets
 		// 2) we are not in a k8s env, namely DC/OS, since CSI is CO agnostic


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Removes ServiceAccount in cloud config which we were using as the client's user agent. The user agent can just be a well-known constant and shouldn't be configurable. The name "ServiceAccount" also implies that changing this field changes the Kubernetes service account the controller manager uses which can be confusing. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
Fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/259 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Removes ServiceAccount in cloud config
```
