### PR TITLE
Locate InternalIP and ExternalIP by vSphere Network name

### DIFF
--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -45,13 +45,18 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return newVSphere(cfg, true)
+
+		cpiConfig, err := ReadCPIConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		return newVSphere(cfg, cpiConfig, true)
 	})
 }
 
 // Creates new Controller node interface and returns
-func newVSphere(cfg *vcfg.Config, finalize ...bool) (*VSphere, error) {
-	vs, err := buildVSphereFromConfig(cfg)
+func newVSphere(cfg *vcfg.Config, cpiCfg *CPIConfig, finalize ...bool) (*VSphere, error) {
+	vs, err := buildVSphereFromConfig(cfg, cpiCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +149,7 @@ func (vs *VSphere) HasClusterID() bool {
 }
 
 // Initializes vSphere from vSphere CloudProvider Configuration
-func buildVSphereFromConfig(cfg *vcfg.Config) (*VSphere, error) {
+func buildVSphereFromConfig(cfg *vcfg.Config, cpiCfg *CPIConfig) (*VSphere, error) {
 	nm := &NodeManager{
 		nodeNameMap:    make(map[string]*NodeInfo),
 		nodeUUIDMap:    make(map[string]*NodeInfo),
@@ -154,6 +159,7 @@ func buildVSphereFromConfig(cfg *vcfg.Config) (*VSphere, error) {
 
 	vs := VSphere{
 		cfg:         cfg,
+		cpiCfg:      cpiCfg,
 		nodeManager: nm,
 		instances:   newInstances(nm),
 		zones:       newZones(nm, cfg.Labels.Zone, cfg.Labels.Region),

--- a/pkg/cloudprovider/vsphere/config.go
+++ b/pkg/cloudprovider/vsphere/config.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019New The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/gcfg.v1"
+)
+
+// CPIConfig is used to read and store information (related only to the CPI) from the cloud configuration file
+type CPIConfig struct {
+	Nodes struct {
+		// IP address on VirtualMachine's network interfaces included in the fields' CIDRs
+		// that will be used in respective status.addresses fields.
+		InternalNetworkSubnetCIDR string `gcfg:"internal-network-subnet-cidr"`
+		ExternalNetworkSubnetCIDR string `gcfg:"external-network-subnet-cidr"`
+	}
+}
+
+// FromEnv initializes the provided configuratoin object with values
+// obtained from environment variables. If an environment variable is set
+// for a property that's already initialized, the environment variable's value
+// takes precedence.
+func (cfg *CPIConfig) FromEnv() {
+	if v := os.Getenv("VSPHERE_NODES_INTERNAL_NETWORK_SUBNET_CIDR"); v != "" {
+		cfg.Nodes.InternalNetworkSubnetCIDR = v
+	}
+
+	if v := os.Getenv("VSPHERE_NODES_EXTERNAL_NETWORK_SUBNET_CIDR"); v != "" {
+		cfg.Nodes.ExternalNetworkSubnetCIDR = v
+	}
+}
+
+// ReadCPIConfig parses vSphere cloud config file and stores it into CPIConfig.
+// Environment variables are also checked
+func ReadCPIConfig(config io.Reader) (*CPIConfig, error) {
+	if config == nil {
+		return nil, fmt.Errorf("no vSphere cloud provider config file given")
+	}
+
+	cfg := &CPIConfig{}
+
+	if err := gcfg.FatalOnly(gcfg.ReadInto(cfg, config)); err != nil {
+		return nil, err
+	}
+
+	// Env Vars should override config file entries if present
+	cfg.FromEnv()
+
+	return cfg, nil
+}

--- a/pkg/cloudprovider/vsphere/config_test.go
+++ b/pkg/cloudprovider/vsphere/config_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const basicConfig = `
+[Nodes]
+internal-network-subnet-cidr = 192.0.2.0/24
+external-network-subnet-cidr = 198.51.100.0/24
+`
+
+func TestReadConfigGlobal(t *testing.T) {
+	_, err := ReadCPIConfig(nil)
+	if err == nil {
+		t.Errorf("Should fail when no config is provided: %s", err)
+	}
+
+	cfg, err := ReadCPIConfig(strings.NewReader(basicConfig))
+	if err != nil {
+		t.Fatalf("Should succeed when a valid config is provided: %s", err)
+	}
+
+	if cfg.Nodes.InternalNetworkSubnetCIDR != "192.0.2.0/24" {
+		t.Errorf("incorrect vcenter ip: %s", cfg.Nodes.InternalNetworkSubnetCIDR)
+	}
+
+	if cfg.Nodes.ExternalNetworkSubnetCIDR != "198.51.100.0/24" {
+		t.Errorf("incorrect datacenter: %s", cfg.Nodes.ExternalNetworkSubnetCIDR)
+	}
+}
+
+func TestEnvOverridesFile(t *testing.T) {
+	subnet := "203.0.113.0/24"
+	os.Setenv("VSPHERE_NODES_INTERNAL_NETWORK_SUBNET_CIDR", subnet)
+	defer os.Unsetenv("VSPHERE_NODES_INTERNAL_NETWORK_SUBNET_CIDR")
+
+	cfg, err := ReadCPIConfig(strings.NewReader(basicConfig))
+	if err != nil {
+		t.Fatalf("Should succeed when a valid config is provided: %s", err)
+	}
+
+	if cfg.Nodes.InternalNetworkSubnetCIDR != subnet {
+		t.Errorf("expected subnet: \"%s\", got: \"%s\"", subnet, cfg.Nodes.InternalNetworkSubnetCIDR)
+	}
+}

--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -37,6 +37,7 @@ type GRPCServer interface {
 // VSphere is an implementation of cloud provider Interface for VSphere.
 type VSphere struct {
 	cfg               *vcfg.Config
+	cpiCfg            *CPIConfig
 	connectionManager *cm.ConnectionManager
 	nodeManager       *NodeManager
 	informMgr         *k8s.InformerManager
@@ -83,6 +84,9 @@ type NodeManager struct {
 	connectionManager *cm.ConnectionManager
 	// NodeLister to track Node properties
 	nodeLister clientv1.NodeLister
+
+	// Reference to CPI-specific configuration
+	cpiCfg *CPIConfig
 
 	// Mutexes
 	nodeInfoLock    sync.RWMutex

--- a/pkg/cloudprovider/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/vsphere/vsphere_test.go
@@ -142,11 +142,12 @@ func configFromEnvOrSim(multiDc bool) (*vcfg.Config, func()) {
 
 func TestNewVSphere(t *testing.T) {
 	cfg := &vcfg.Config{}
+	cpiCfg := &CPIConfig{}
 	if err := cfg.FromEnv(); err != nil {
 		t.Skipf("No config found in environment")
 	}
 
-	_, err := newVSphere(cfg)
+	_, err := newVSphere(cfg, cpiCfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
 	}
@@ -155,9 +156,10 @@ func TestNewVSphere(t *testing.T) {
 func TestVSphereLogin(t *testing.T) {
 	cfg, cleanup := configFromEnvOrSim(false)
 	defer cleanup()
+	cpiCfg := &CPIConfig{}
 
 	// Create vSphere configuration object
-	vs, err := newVSphere(cfg)
+	vs, err := newVSphere(cfg, cpiCfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
 	}
@@ -184,13 +186,14 @@ func TestVSphereLogin(t *testing.T) {
 func TestVSphereLoginByToken(t *testing.T) {
 	cfg, cleanup := configFromSim(false)
 	defer cleanup()
+	cpiCfg := &CPIConfig{}
 
 	// Configure for SAML token auth
 	cfg.Global.User = localhostCert
 	cfg.Global.Password = localhostKey
 
 	// Create vSphere configuration object
-	vs, err := newVSphere(cfg)
+	vs, err := newVSphere(cfg, cpiCfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
 	}
@@ -490,7 +493,7 @@ func TestSecretVSphereConfig(t *testing.T) {
 				t.Fatalf("readConfig: unexpected error returned: %v", err)
 			}
 		}
-		vs, err = buildVSphereFromConfig(cfg)
+		vs, err = buildVSphereFromConfig(cfg, &CPIConfig{})
 		if err != nil { // testcase.expectedError {
 			t.Fatalf("buildVSphereFromConfig: Should succeed when a valid config is provided: %v", err)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Currently, vsphere CCM will iterate over physical vNICs and setup first IP address on each as both *InternalIP* and  . This behavior is undesirable, if we are aware of vSphere Network names.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/270