### PR TITLE
Always ensure KIND is present for integration test

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -22,7 +22,10 @@ else
 export KUBECONFIG := $(KUBECONFIG_ORIG)
 endif
 
-cluster-up: $(KIND_CONFIG) | $(DOCKER_SOCK)
+kind:
+	./install_kind.sh
+
+cluster-up: $(KIND_CONFIG) kind | $(DOCKER_SOCK)
 	kind create cluster --config "$(KIND_CONFIG)" --name "$(CLUSTER_NAME)"
 ifeq (true,$(DOCKER_SOCK_FROM_HOST))
 	ipv4=$$(docker exec "$(CLUSTER_NAME)-control-plane" ip route get dev eth0 1 | awk '{print $$NF;exit}') && \

--- a/test/integration/install_kind.sh
+++ b/test/integration/install_kind.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KIND_VERSION="v0.5.1"
+KIND_PATH="/usr/local/bin/kind"
+
+# Check if KIND already exists
+if ! [[ -x "${KIND_PATH}" ]]; then
+  wget "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64" \
+    --no-verbose -O "${KIND_PATH}"
+  chmod +x "${KIND_PATH}"
+fi

--- a/test/kind/kind-config.yaml
+++ b/test/kind/kind-config.yaml
@@ -1,5 +1,5 @@
-kind: Config
-apiVersion: kind.sigs.k8s.io/v1alpha2
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:
 - role: control-plane
   extraMounts:


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This (in conjunction with a test-infra PR) will fix the failing integration tests.

This patch adds a step in the integration test Makefile to explicitly
install KIND if it is not present. The default KIND version is now
v0.5.1, which requires changes to the kind config to use the v1alpha3
API.

Part of the movitivation behind this is to be able to run the
integration test in the kubekins-e2e image rather than a custom "CI"
image created from this project.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
/hold
^ until https://github.com/kubernetes/test-infra/pull/15171 is merged

/assign @dvonthenen 