### PR TITLE
Remove unused node maps and informers

### DIFF
--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -20,10 +20,8 @@ import (
 	"io"
 	"runtime"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
-
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog"
 
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/server"
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
@@ -78,8 +76,6 @@ func (vs *VSphere) Initialize(clientBuilder cloudprovider.ControllerClientBuilde
 		connMgr := cm.NewConnectionManager(vs.cfg, vs.informMgr, client)
 		vs.connectionManager = connMgr
 		vs.nodeManager.connectionManager = connMgr
-
-		vs.informMgr.AddNodeListener(vs.nodeAdded, vs.nodeDeleted, nil)
 
 		vs.informMgr.Listen()
 
@@ -170,26 +166,4 @@ func buildVSphereFromConfig(cfg *vcfg.Config, cpiCfg *CPIConfig) (*VSphere, erro
 
 func logout(vs *VSphere) {
 	vs.connectionManager.Logout()
-}
-
-// Notification handler when node is added into k8s cluster.
-func (vs *VSphere) nodeAdded(obj interface{}) {
-	node, ok := obj.(*v1.Node)
-	if node == nil || !ok {
-		klog.Warningf("nodeAdded: unrecognized object %+v", obj)
-		return
-	}
-
-	vs.nodeManager.RegisterNode(node)
-}
-
-// Notification handler when node is removed from k8s cluster.
-func (vs *VSphere) nodeDeleted(obj interface{}) {
-	node, ok := obj.(*v1.Node)
-	if node == nil || !ok {
-		klog.Warningf("nodeDeleted: unrecognized object %+v", obj)
-		return
-	}
-
-	vs.nodeManager.UnregisterNode(node)
 }

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -147,10 +147,9 @@ func (vs *VSphere) HasClusterID() bool {
 // Initializes vSphere from vSphere CloudProvider Configuration
 func buildVSphereFromConfig(cfg *vcfg.Config, cpiCfg *CPIConfig) (*VSphere, error) {
 	nm := &NodeManager{
-		nodeNameMap:    make(map[string]*NodeInfo),
-		nodeUUIDMap:    make(map[string]*NodeInfo),
-		nodeRegUUIDMap: make(map[string]*v1.Node),
-		vcList:         make(map[string]*VCenterInfo),
+		nodeNameMap: make(map[string]*NodeInfo),
+		nodeUUIDMap: make(map[string]*NodeInfo),
+		vcList:      make(map[string]*VCenterInfo),
 	}
 
 	vs := VSphere{

--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -42,7 +42,8 @@ func newMyNodeManager(cm *cm.ConnectionManager, lister clientv1.NodeLister) *MyN
 
 // Used to populate the networking info
 func (nm *MyNodeManager) RegisterNode(node *v1.Node) {
-	nm.NodeManager.RegisterNode(node)
+	uuid := ConvertK8sUUIDtoNormal(node.Status.NodeInfo.SystemUUID)
+	nm.NodeManager.DiscoverNode(uuid, cm.FindVMByUUID)
 
 	myNode1 := nm.nodeNameMap[node.Name]
 	myNode2 := nm.nodeUUIDMap[ConvertK8sUUIDtoNormal(node.Status.NodeInfo.SystemUUID)]

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -58,20 +58,6 @@ func newNodeManager(cm *cm.ConnectionManager, lister clientv1.NodeLister) *NodeM
 	}
 }
 
-// RegisterNode is the handler for when a node is added to a K8s cluster.
-func (nm *NodeManager) RegisterNode(node *v1.Node) {
-	klog.V(4).Info("RegisterNode ENTER: ", node.Name)
-	uuid := ConvertK8sUUIDtoNormal(node.Status.NodeInfo.SystemUUID)
-	nm.DiscoverNode(uuid, cm.FindVMByUUID)
-	klog.V(4).Info("RegisterNode LEAVE: ", node.Name)
-}
-
-// UnregisterNode is the handler for when a node is removed from a K8s cluster.
-func (nm *NodeManager) UnregisterNode(node *v1.Node) {
-	klog.V(4).Info("UnregisterNode ENTER: ", node.Name)
-	klog.V(4).Info("UnregisterNode LEAVE: ", node.Name)
-}
-
 func (nm *NodeManager) addNodeInfo(node *NodeInfo) {
 	nm.nodeInfoLock.Lock()
 	klog.V(4).Info("addNodeInfo NodeName: ", node.NodeName, ", UUID: ", node.UUID)

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -52,7 +52,6 @@ func newNodeManager(cm *cm.ConnectionManager, lister clientv1.NodeLister) *NodeM
 	return &NodeManager{
 		nodeNameMap:       make(map[string]*NodeInfo),
 		nodeUUIDMap:       make(map[string]*NodeInfo),
-		nodeRegUUIDMap:    make(map[string]*v1.Node),
 		vcList:            make(map[string]*VCenterInfo),
 		connectionManager: cm,
 		nodeLister:        lister,

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -64,15 +64,12 @@ func (nm *NodeManager) RegisterNode(node *v1.Node) {
 	klog.V(4).Info("RegisterNode ENTER: ", node.Name)
 	uuid := ConvertK8sUUIDtoNormal(node.Status.NodeInfo.SystemUUID)
 	nm.DiscoverNode(uuid, cm.FindVMByUUID)
-	nm.addNode(uuid, node)
 	klog.V(4).Info("RegisterNode LEAVE: ", node.Name)
 }
 
 // UnregisterNode is the handler for when a node is removed from a K8s cluster.
 func (nm *NodeManager) UnregisterNode(node *v1.Node) {
 	klog.V(4).Info("UnregisterNode ENTER: ", node.Name)
-	uuid := ConvertK8sUUIDtoNormal(node.Status.NodeInfo.SystemUUID)
-	nm.removeNode(uuid, node)
 	klog.V(4).Info("UnregisterNode LEAVE: ", node.Name)
 }
 
@@ -83,20 +80,6 @@ func (nm *NodeManager) addNodeInfo(node *NodeInfo) {
 	nm.nodeUUIDMap[node.UUID] = node
 	nm.AddNodeInfoToVCList(node.vcServer, node.dataCenter.Name(), node)
 	nm.nodeInfoLock.Unlock()
-}
-
-func (nm *NodeManager) addNode(uuid string, node *v1.Node) {
-	nm.nodeRegInfoLock.Lock()
-	klog.V(4).Info("addNode NodeName: ", node.GetName(), ", UID: ", uuid)
-	nm.nodeRegUUIDMap[uuid] = node
-	nm.nodeRegInfoLock.Unlock()
-}
-
-func (nm *NodeManager) removeNode(uuid string, node *v1.Node) {
-	nm.nodeRegInfoLock.Lock()
-	klog.V(4).Info("removeNode NodeName: ", node.GetName(), ", UID: ", uuid)
-	delete(nm.nodeRegUUIDMap, uuid)
-	nm.nodeRegInfoLock.Unlock()
 }
 
 func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, searchBy cm.FindVM) (*cm.VMDiscoveryInfo, error) {

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -64,9 +64,6 @@ func TestRegUnregNode(t *testing.T) {
 	if len(nm.nodeUUIDMap) != 1 {
 		t.Errorf("Failed: nodeUUIDMap should be a length of  1")
 	}
-	if len(nm.nodeRegUUIDMap) != 1 {
-		t.Errorf("Failed: nodeRegUUIDMap should be a length of  1")
-	}
 
 	nm.UnregisterNode(node)
 
@@ -75,9 +72,6 @@ func TestRegUnregNode(t *testing.T) {
 	}
 	if len(nm.nodeUUIDMap) != 1 {
 		t.Errorf("Failed: nodeUUIDMap should be a length of  1")
-	}
-	if len(nm.nodeRegUUIDMap) != 0 {
-		t.Errorf("Failed: nodeRegUUIDMap should be a length of 0")
 	}
 }
 

--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -78,8 +78,6 @@ type NodeManager struct {
 	nodeUUIDMap map[string]*NodeInfo
 	// Maps VC -> DC -> VM
 	vcList map[string]*VCenterInfo
-	// Maps UUID to node info.
-	nodeRegUUIDMap map[string]*v1.Node
 	// ConnectionManager
 	connectionManager *cm.ConnectionManager
 	// NodeLister to track Node properties
@@ -89,8 +87,7 @@ type NodeManager struct {
 	cpiCfg *CPIConfig
 
 	// Mutexes
-	nodeInfoLock    sync.RWMutex
-	nodeRegInfoLock sync.RWMutex
+	nodeInfoLock sync.RWMutex
 }
 
 type instances struct {

--- a/pkg/cloudprovider/vsphere/zones_test.go
+++ b/pkg/cloudprovider/vsphere/zones_test.go
@@ -86,9 +86,6 @@ func TestZones(t *testing.T) {
 	if len(nm.nodeUUIDMap) != 1 {
 		t.Fatalf("Failed: nodeUUIDMap should be a length of  1")
 	}
-	if len(nm.nodeRegUUIDMap) != 1 {
-		t.Fatalf("Failed: nodeRegUUIDMap should be a length of  1")
-	}
 
 	// Get vclib DC
 	dc, err := vclib.GetDatacenter(ctx, vsi.Conn, mydc.Name)

--- a/pkg/cloudprovider/vsphere/zones_test.go
+++ b/pkg/cloudprovider/vsphere/zones_test.go
@@ -18,9 +18,6 @@ import (
 	"net/url"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vapi/rest"
@@ -59,26 +56,13 @@ func TestZones(t *testing.T) {
 
 	// Get a simulator VM
 	myvm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
-	name := myvm.Name
 	UUID := myvm.Config.Uuid
 	k8sUUID := ConvertK8sUUIDtoNormal(UUID)
 
 	// Get a simulator DC
 	mydc := simulator.Map.Any("Datacenter").(*simulator.Datacenter)
 
-	// Add the node to the NodeManager
-	node := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Status: v1.NodeStatus{
-			NodeInfo: v1.NodeSystemInfo{
-				SystemUUID: k8sUUID,
-			},
-		},
-	}
-
-	nm.RegisterNode(node)
+	nm.DiscoverNode(k8sUUID, cm.FindVMByUUID)
 
 	if len(nm.nodeNameMap) != 1 {
 		t.Fatalf("Failed: nodeNameMap should be a length of 1")

--- a/pkg/common/kubernetes/informers.go
+++ b/pkg/common/kubernetes/informers.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	listerv1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/sample-controller/pkg/signals"
 )
 
@@ -64,19 +63,6 @@ func (im *InformerManager) GetSecretLister() listerv1.SecretLister {
 	}
 
 	return im.secretInformer.Lister()
-}
-
-// AddNodeListener hooks up add, update, delete callbacks
-func (im *InformerManager) AddNodeListener(add, remove func(obj interface{}), update func(oldObj, newObj interface{})) {
-	if im.nodeInformer == nil {
-		im.nodeInformer = im.informerFactory.Core().V1().Nodes().Informer()
-	}
-
-	im.nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    add,
-		UpdateFunc: update,
-		DeleteFunc: remove,
-	})
 }
 
 // Listen starts the Informers. Based on client-go informer package, if the Lister has

--- a/pkg/common/kubernetes/types.go
+++ b/pkg/common/kubernetes/types.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/client-go/informers"
 	v1 "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 )
 
 // InformerManager is a service that notifies subscribers about changes
@@ -35,7 +34,4 @@ type InformerManager struct {
 
 	// secret informer
 	secretInformer v1.SecretInformer
-
-	// node informer
-	nodeInformer cache.SharedInformer
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Removes node informer which updates a node UUID map that is no longer used. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
