### PR TITLE
Report Active Nodes Only

### DIFF
--- a/pkg/cloudprovider/vsphere/proto/cloudprovidervsphere.pb.go
+++ b/pkg/cloudprovider/vsphere/proto/cloudprovidervsphere.pb.go
@@ -4,72 +4,24 @@
 package cloudprovidervsphere
 
 import (
+	context "context"
 	fmt "fmt"
-	math "math"
 
 	proto "github.com/golang/protobuf/proto"
-
-	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = fmt.Errorf
-var _ = math.Inf
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
-
-type ListNodesRequest struct {
-	Vcenter              string   `protobuf:"bytes,1,opt,name=vcenter,proto3" json:"vcenter,omitempty"`
-	Datacenter           string   `protobuf:"bytes,2,opt,name=datacenter,proto3" json:"datacenter,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *ListNodesRequest) Reset()         { *m = ListNodesRequest{} }
-func (m *ListNodesRequest) String() string { return proto.CompactTextString(m) }
-func (*ListNodesRequest) ProtoMessage()    {}
-func (*ListNodesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b637d4c33cef7514, []int{0}
-}
-
-func (m *ListNodesRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListNodesRequest.Unmarshal(m, b)
-}
-func (m *ListNodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListNodesRequest.Marshal(b, m, deterministic)
-}
-func (m *ListNodesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListNodesRequest.Merge(m, src)
-}
-func (m *ListNodesRequest) XXX_Size() int {
-	return xxx_messageInfo_ListNodesRequest.Size(m)
-}
-func (m *ListNodesRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListNodesRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ListNodesRequest proto.InternalMessageInfo
-
-func (m *ListNodesRequest) GetVcenter() string {
-	if m != nil {
-		return m.Vcenter
-	}
-	return ""
-}
-
-func (m *ListNodesRequest) GetDatacenter() string {
-	if m != nil {
-		return m.Datacenter
-	}
-	return ""
-}
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type Node struct {
 	Vcenter              string   `protobuf:"bytes,1,opt,name=vcenter,proto3" json:"vcenter,omitempty"`
@@ -87,7 +39,7 @@ func (m *Node) Reset()         { *m = Node{} }
 func (m *Node) String() string { return proto.CompactTextString(m) }
 func (*Node) ProtoMessage()    {}
 func (*Node) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b637d4c33cef7514, []int{1}
+	return fileDescriptor_b637d4c33cef7514, []int{0}
 }
 
 func (m *Node) XXX_Unmarshal(b []byte) error {
@@ -150,6 +102,139 @@ func (m *Node) GetUuid() string {
 	return ""
 }
 
+type GetNodeRequest struct {
+	Uuid                 string   `protobuf:"bytes,1,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetNodeRequest) Reset()         { *m = GetNodeRequest{} }
+func (m *GetNodeRequest) String() string { return proto.CompactTextString(m) }
+func (*GetNodeRequest) ProtoMessage()    {}
+func (*GetNodeRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b637d4c33cef7514, []int{1}
+}
+
+func (m *GetNodeRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetNodeRequest.Unmarshal(m, b)
+}
+func (m *GetNodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetNodeRequest.Marshal(b, m, deterministic)
+}
+func (m *GetNodeRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetNodeRequest.Merge(m, src)
+}
+func (m *GetNodeRequest) XXX_Size() int {
+	return xxx_messageInfo_GetNodeRequest.Size(m)
+}
+func (m *GetNodeRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetNodeRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetNodeRequest proto.InternalMessageInfo
+
+func (m *GetNodeRequest) GetUuid() string {
+	if m != nil {
+		return m.Uuid
+	}
+	return ""
+}
+
+type GetNodeReply struct {
+	Node                 *Node    `protobuf:"bytes,1,opt,name=node,proto3" json:"node,omitempty"`
+	Error                string   `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetNodeReply) Reset()         { *m = GetNodeReply{} }
+func (m *GetNodeReply) String() string { return proto.CompactTextString(m) }
+func (*GetNodeReply) ProtoMessage()    {}
+func (*GetNodeReply) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b637d4c33cef7514, []int{2}
+}
+
+func (m *GetNodeReply) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetNodeReply.Unmarshal(m, b)
+}
+func (m *GetNodeReply) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetNodeReply.Marshal(b, m, deterministic)
+}
+func (m *GetNodeReply) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetNodeReply.Merge(m, src)
+}
+func (m *GetNodeReply) XXX_Size() int {
+	return xxx_messageInfo_GetNodeReply.Size(m)
+}
+func (m *GetNodeReply) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetNodeReply.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetNodeReply proto.InternalMessageInfo
+
+func (m *GetNodeReply) GetNode() *Node {
+	if m != nil {
+		return m.Node
+	}
+	return nil
+}
+
+func (m *GetNodeReply) GetError() string {
+	if m != nil {
+		return m.Error
+	}
+	return ""
+}
+
+type ListNodesRequest struct {
+	Vcenter              string   `protobuf:"bytes,1,opt,name=vcenter,proto3" json:"vcenter,omitempty"`
+	Datacenter           string   `protobuf:"bytes,2,opt,name=datacenter,proto3" json:"datacenter,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ListNodesRequest) Reset()         { *m = ListNodesRequest{} }
+func (m *ListNodesRequest) String() string { return proto.CompactTextString(m) }
+func (*ListNodesRequest) ProtoMessage()    {}
+func (*ListNodesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b637d4c33cef7514, []int{3}
+}
+
+func (m *ListNodesRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListNodesRequest.Unmarshal(m, b)
+}
+func (m *ListNodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListNodesRequest.Marshal(b, m, deterministic)
+}
+func (m *ListNodesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListNodesRequest.Merge(m, src)
+}
+func (m *ListNodesRequest) XXX_Size() int {
+	return xxx_messageInfo_ListNodesRequest.Size(m)
+}
+func (m *ListNodesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListNodesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ListNodesRequest proto.InternalMessageInfo
+
+func (m *ListNodesRequest) GetVcenter() string {
+	if m != nil {
+		return m.Vcenter
+	}
+	return ""
+}
+
+func (m *ListNodesRequest) GetDatacenter() string {
+	if m != nil {
+		return m.Datacenter
+	}
+	return ""
+}
+
 type ListNodesReply struct {
 	Nodes                []*Node  `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes,omitempty"`
 	Error                string   `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
@@ -162,7 +247,7 @@ func (m *ListNodesReply) Reset()         { *m = ListNodesReply{} }
 func (m *ListNodesReply) String() string { return proto.CompactTextString(m) }
 func (*ListNodesReply) ProtoMessage()    {}
 func (*ListNodesReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b637d4c33cef7514, []int{2}
+	return fileDescriptor_b637d4c33cef7514, []int{4}
 }
 
 func (m *ListNodesReply) XXX_Unmarshal(b []byte) error {
@@ -207,7 +292,7 @@ func (m *VersionRequest) Reset()         { *m = VersionRequest{} }
 func (m *VersionRequest) String() string { return proto.CompactTextString(m) }
 func (*VersionRequest) ProtoMessage()    {}
 func (*VersionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b637d4c33cef7514, []int{3}
+	return fileDescriptor_b637d4c33cef7514, []int{5}
 }
 
 func (m *VersionRequest) XXX_Unmarshal(b []byte) error {
@@ -239,7 +324,7 @@ func (m *VersionReply) Reset()         { *m = VersionReply{} }
 func (m *VersionReply) String() string { return proto.CompactTextString(m) }
 func (*VersionReply) ProtoMessage()    {}
 func (*VersionReply) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b637d4c33cef7514, []int{4}
+	return fileDescriptor_b637d4c33cef7514, []int{6}
 }
 
 func (m *VersionReply) XXX_Unmarshal(b []byte) error {
@@ -268,11 +353,43 @@ func (m *VersionReply) GetVersion() string {
 }
 
 func init() {
-	proto.RegisterType((*ListNodesRequest)(nil), "cloudprovidervsphere.ListNodesRequest")
 	proto.RegisterType((*Node)(nil), "cloudprovidervsphere.Node")
+	proto.RegisterType((*GetNodeRequest)(nil), "cloudprovidervsphere.GetNodeRequest")
+	proto.RegisterType((*GetNodeReply)(nil), "cloudprovidervsphere.GetNodeReply")
+	proto.RegisterType((*ListNodesRequest)(nil), "cloudprovidervsphere.ListNodesRequest")
 	proto.RegisterType((*ListNodesReply)(nil), "cloudprovidervsphere.ListNodesReply")
 	proto.RegisterType((*VersionRequest)(nil), "cloudprovidervsphere.VersionRequest")
 	proto.RegisterType((*VersionReply)(nil), "cloudprovidervsphere.VersionReply")
+}
+
+func init() { proto.RegisterFile("cloudprovidervsphere.proto", fileDescriptor_b637d4c33cef7514) }
+
+var fileDescriptor_b637d4c33cef7514 = []byte{
+	// 375 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x53, 0x4d, 0x6b, 0xea, 0x40,
+	0x14, 0x35, 0x1a, 0xf5, 0xe5, 0x3e, 0x11, 0x19, 0x5c, 0x0c, 0xe1, 0xf1, 0x08, 0x83, 0x3c, 0x5c,
+	0x85, 0x87, 0xdd, 0x75, 0x69, 0x17, 0x6e, 0xa4, 0x88, 0xb4, 0x22, 0x74, 0x95, 0x3a, 0x17, 0x1a,
+	0xd0, 0x4c, 0x3a, 0x93, 0xa4, 0xf8, 0x77, 0x4a, 0x7f, 0x68, 0x99, 0x99, 0x98, 0xc6, 0x12, 0x11,
+	0xba, 0xbb, 0x1f, 0xe7, 0x9e, 0x73, 0xe6, 0x84, 0x80, 0xbf, 0xdb, 0x8b, 0x9c, 0xa7, 0x52, 0x14,
+	0x31, 0x47, 0x59, 0xa8, 0xf4, 0x05, 0x25, 0x86, 0xa9, 0x14, 0x99, 0x20, 0xe3, 0xa6, 0x1d, 0x7b,
+	0x77, 0xc0, 0xbd, 0x17, 0x1c, 0x09, 0x85, 0x7e, 0xb1, 0xc3, 0x24, 0x43, 0x49, 0x9d, 0xc0, 0x99,
+	0x7a, 0xeb, 0x53, 0x4b, 0xfe, 0x02, 0xf0, 0x28, 0x8b, 0xca, 0x65, 0xdb, 0x2c, 0x6b, 0x13, 0x42,
+	0xc0, 0x4d, 0xa2, 0x03, 0xd2, 0x8e, 0xd9, 0x98, 0x9a, 0xf8, 0xf0, 0x8b, 0x27, 0x4a, 0x97, 0x8a,
+	0xba, 0x41, 0x67, 0xea, 0xad, 0xab, 0x9e, 0xfc, 0x01, 0x2f, 0xe2, 0x5c, 0xa2, 0x52, 0xa8, 0x68,
+	0xd7, 0x2c, 0xbf, 0x06, 0x9a, 0x2d, 0xcf, 0x63, 0x4e, 0x7b, 0x96, 0x4d, 0xd7, 0x6c, 0x02, 0xc3,
+	0x05, 0x66, 0xda, 0xe6, 0x1a, 0x5f, 0x73, 0x54, 0x59, 0x85, 0x72, 0x6a, 0xa8, 0x07, 0x18, 0x54,
+	0xa8, 0x74, 0x7f, 0x24, 0x21, 0xb8, 0x89, 0xe0, 0x68, 0x30, 0xbf, 0x67, 0x7e, 0xd8, 0x98, 0x8d,
+	0x81, 0x1b, 0x1c, 0x19, 0x43, 0x17, 0xa5, 0x14, 0xa7, 0x27, 0xda, 0x86, 0x2d, 0x61, 0xb4, 0x8c,
+	0x95, 0xa1, 0x55, 0x27, 0xf5, 0x1f, 0x67, 0xc5, 0xb6, 0x30, 0xac, 0xb1, 0x69, 0x97, 0xff, 0xa1,
+	0xab, 0xd5, 0x15, 0x75, 0x82, 0xce, 0x15, 0x9b, 0x16, 0x78, 0xc1, 0xe7, 0x08, 0x86, 0x1b, 0x94,
+	0x2a, 0x16, 0x49, 0xe9, 0x92, 0x4d, 0x61, 0x50, 0x4d, 0xb4, 0x92, 0x76, 0x6d, 0xfb, 0xca, 0xb5,
+	0x6d, 0x67, 0x1f, 0x6d, 0x18, 0xdf, 0x69, 0xd9, 0x55, 0x29, 0xbb, 0xb1, 0xb2, 0xe4, 0x11, 0xfa,
+	0x65, 0xa4, 0x64, 0xd2, 0x6c, 0xec, 0xfc, 0xbb, 0xf8, 0xec, 0x0a, 0x2a, 0xdd, 0x1f, 0x59, 0x8b,
+	0x3c, 0x81, 0x57, 0xa5, 0x40, 0xfe, 0x35, 0x9f, 0x7c, 0x0f, 0xdd, 0x9f, 0x5c, 0xc5, 0x59, 0xf2,
+	0x2d, 0xc0, 0x02, 0xb3, 0xf2, 0xe5, 0x97, 0x6c, 0x9f, 0x47, 0x75, 0xc9, 0x76, 0x3d, 0x3e, 0xd6,
+	0x9a, 0xdf, 0x42, 0xb0, 0x13, 0x87, 0xb0, 0x38, 0xbc, 0x45, 0x12, 0xcf, 0x2f, 0xc2, 0xf2, 0x64,
+	0xde, 0x98, 0xe3, 0xca, 0x79, 0xee, 0x99, 0x9f, 0xf0, 0xe6, 0x33, 0x00, 0x00, 0xff, 0xff, 0x4d,
+	0x6a, 0x77, 0xb3, 0xa2, 0x03, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -287,6 +404,7 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type CloudProviderVsphereClient interface {
+	GetNode(ctx context.Context, in *GetNodeRequest, opts ...grpc.CallOption) (*GetNodeReply, error)
 	ListNodes(ctx context.Context, in *ListNodesRequest, opts ...grpc.CallOption) (*ListNodesReply, error)
 	GetVersion(ctx context.Context, in *VersionRequest, opts ...grpc.CallOption) (*VersionReply, error)
 }
@@ -297,6 +415,15 @@ type cloudProviderVsphereClient struct {
 
 func NewCloudProviderVsphereClient(cc *grpc.ClientConn) CloudProviderVsphereClient {
 	return &cloudProviderVsphereClient{cc}
+}
+
+func (c *cloudProviderVsphereClient) GetNode(ctx context.Context, in *GetNodeRequest, opts ...grpc.CallOption) (*GetNodeReply, error) {
+	out := new(GetNodeReply)
+	err := c.cc.Invoke(ctx, "/cloudprovidervsphere.CloudProviderVsphere/GetNode", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *cloudProviderVsphereClient) ListNodes(ctx context.Context, in *ListNodesRequest, opts ...grpc.CallOption) (*ListNodesReply, error) {
@@ -319,12 +446,45 @@ func (c *cloudProviderVsphereClient) GetVersion(ctx context.Context, in *Version
 
 // CloudProviderVsphereServer is the server API for CloudProviderVsphere service.
 type CloudProviderVsphereServer interface {
+	GetNode(context.Context, *GetNodeRequest) (*GetNodeReply, error)
 	ListNodes(context.Context, *ListNodesRequest) (*ListNodesReply, error)
 	GetVersion(context.Context, *VersionRequest) (*VersionReply, error)
 }
 
+// UnimplementedCloudProviderVsphereServer can be embedded to have forward compatible implementations.
+type UnimplementedCloudProviderVsphereServer struct {
+}
+
+func (*UnimplementedCloudProviderVsphereServer) GetNode(ctx context.Context, req *GetNodeRequest) (*GetNodeReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetNode not implemented")
+}
+func (*UnimplementedCloudProviderVsphereServer) ListNodes(ctx context.Context, req *ListNodesRequest) (*ListNodesReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListNodes not implemented")
+}
+func (*UnimplementedCloudProviderVsphereServer) GetVersion(ctx context.Context, req *VersionRequest) (*VersionReply, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetVersion not implemented")
+}
+
 func RegisterCloudProviderVsphereServer(s *grpc.Server, srv CloudProviderVsphereServer) {
 	s.RegisterService(&_CloudProviderVsphere_serviceDesc, srv)
+}
+
+func _CloudProviderVsphere_GetNode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetNodeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(CloudProviderVsphereServer).GetNode(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cloudprovidervsphere.CloudProviderVsphere/GetNode",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(CloudProviderVsphereServer).GetNode(ctx, req.(*GetNodeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _CloudProviderVsphere_ListNodes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -368,6 +528,10 @@ var _CloudProviderVsphere_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*CloudProviderVsphereServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
+			MethodName: "GetNode",
+			Handler:    _CloudProviderVsphere_GetNode_Handler,
+		},
+		{
 			MethodName: "ListNodes",
 			Handler:    _CloudProviderVsphere_ListNodes_Handler,
 		},
@@ -378,31 +542,4 @@ var _CloudProviderVsphere_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "cloudprovidervsphere.proto",
-}
-
-func init() { proto.RegisterFile("cloudprovidervsphere.proto", fileDescriptor_b637d4c33cef7514) }
-
-var fileDescriptor_b637d4c33cef7514 = []byte{
-	// 330 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x52, 0x4d, 0x4b, 0xc3, 0x40,
-	0x10, 0x35, 0xf6, 0x43, 0x33, 0x4a, 0x29, 0x43, 0x0f, 0x4b, 0x10, 0x09, 0x8b, 0x48, 0x4e, 0x41,
-	0xea, 0xcd, 0x63, 0x3d, 0x78, 0x29, 0x52, 0x72, 0x28, 0x05, 0x4f, 0xb1, 0x3b, 0x60, 0xa0, 0xc9,
-	0xc6, 0xdd, 0x24, 0xd2, 0xbf, 0xe3, 0xff, 0xf1, 0x3f, 0xc9, 0x66, 0xd3, 0xd8, 0x4a, 0xa4, 0xe0,
-	0x6d, 0xde, 0xbc, 0x99, 0x37, 0x33, 0x6f, 0x17, 0xbc, 0xf5, 0x46, 0x96, 0x22, 0x57, 0xb2, 0x4a,
-	0x04, 0xa9, 0x4a, 0xe7, 0x6f, 0xa4, 0x28, 0xcc, 0x95, 0x2c, 0x24, 0x4e, 0xba, 0x38, 0x3e, 0x87,
-	0xf1, 0x3c, 0xd1, 0xc5, 0xb3, 0x14, 0xa4, 0x23, 0x7a, 0x2f, 0x49, 0x17, 0xc8, 0xe0, 0xac, 0x5a,
-	0x53, 0x56, 0x90, 0x62, 0x8e, 0xef, 0x04, 0x6e, 0xb4, 0x83, 0x78, 0x0d, 0x20, 0xe2, 0x22, 0x6e,
-	0xc8, 0xd3, 0x9a, 0xdc, 0xcb, 0xf0, 0x4f, 0x07, 0xfa, 0x46, 0xea, 0xff, 0x12, 0x88, 0xd0, 0xcf,
-	0xe2, 0x94, 0x58, 0xaf, 0x66, 0xea, 0x18, 0x3d, 0x38, 0x17, 0x99, 0x36, 0xa1, 0x66, 0x7d, 0xbf,
-	0x17, 0xb8, 0x51, 0x8b, 0xf1, 0x0a, 0xdc, 0x58, 0x08, 0x45, 0x5a, 0x93, 0x66, 0x83, 0x9a, 0xfc,
-	0x49, 0x18, 0xb5, 0xb2, 0x4c, 0x04, 0x1b, 0x5a, 0x35, 0x13, 0xf3, 0x15, 0x8c, 0xf6, 0x4e, 0xce,
-	0x37, 0x5b, 0xbc, 0x83, 0x41, 0x66, 0x10, 0x73, 0xfc, 0x5e, 0x70, 0x31, 0xf5, 0xc2, 0x4e, 0x1b,
-	0x4d, 0x43, 0x64, 0x0b, 0x71, 0x02, 0x03, 0x52, 0x4a, 0xee, 0x0e, 0xb0, 0x80, 0x8f, 0x61, 0xb4,
-	0x24, 0xa5, 0x13, 0x99, 0x35, 0x56, 0xf2, 0x00, 0x2e, 0xdb, 0x8c, 0x99, 0x64, 0x7c, 0xb1, 0xb8,
-	0xf5, 0xc5, 0xc2, 0xe9, 0x97, 0x03, 0x93, 0x47, 0x33, 0x76, 0xd1, 0x8c, 0x5d, 0xda, 0xb1, 0xf8,
-	0x02, 0x6e, 0xbb, 0x2e, 0xde, 0x76, 0xaf, 0xf6, 0xfb, 0x09, 0xbd, 0x9b, 0xa3, 0x75, 0xf9, 0x66,
-	0xcb, 0x4f, 0x70, 0x05, 0xf0, 0x44, 0x45, 0xb3, 0x22, 0xfe, 0xd1, 0x75, 0x78, 0x93, 0xc7, 0x8f,
-	0x54, 0xd5, 0xca, 0xb3, 0x07, 0xf0, 0xd7, 0x32, 0x0d, 0xab, 0xf4, 0x23, 0x56, 0x74, 0xd8, 0x11,
-	0x36, 0x2d, 0xb3, 0xce, 0x83, 0x17, 0xce, 0xeb, 0xb0, 0xfe, 0xb1, 0xf7, 0xdf, 0x01, 0x00, 0x00,
-	0xff, 0xff, 0xf0, 0x70, 0xf0, 0x60, 0xcf, 0x02, 0x00, 0x00,
 }

--- a/pkg/cloudprovider/vsphere/proto/cloudprovidervsphere.proto
+++ b/pkg/cloudprovider/vsphere/proto/cloudprovidervsphere.proto
@@ -24,13 +24,9 @@ package cloudprovidervsphere;
 
 // The service definition.
 service CloudProviderVsphere {
+  rpc GetNode (GetNodeRequest) returns (GetNodeReply) {}
   rpc ListNodes (ListNodesRequest) returns (ListNodesReply) {}
   rpc GetVersion (VersionRequest) returns (VersionReply) {}
-}
-
-message ListNodesRequest {
-  string vcenter = 1;
-  string datacenter = 2;
 }
 
 message Node {
@@ -42,15 +38,29 @@ message Node {
 	string uuid = 6;
 }
 
+message GetNodeRequest {
+  string uuid = 1;
+}
+  
+message GetNodeReply {
+  Node node = 1;
+  string error = 2;
+}
+
+message ListNodesRequest {
+  string vcenter = 1;
+  string datacenter = 2;
+}
+
 message ListNodesReply {
-	repeated Node nodes = 1;
-	string error = 2;
+  repeated Node nodes = 1;
+  string error = 2;
 }
 
 message VersionRequest {
 }
 
 message VersionReply {
-	string version = 1;
+  string version = 1;
 }
   

--- a/pkg/cloudprovider/vsphere/server/server.go
+++ b/pkg/cloudprovider/vsphere/server/server.go
@@ -43,6 +43,7 @@ const (
 // NodeManagerInterface describes types that can export a list of Kubernetes
 // nodes into the supplied slice address.
 type NodeManagerInterface interface {
+	GetNode(UUID string, node *pb.Node) error
 	ExportNodes(vcenter string, datacenter string, nodeList *[]*pb.Node) error
 }
 
@@ -68,6 +69,18 @@ func NewServer(binding string, nodeMgr NodeManagerInterface) GRPCServer {
 	pb.RegisterCloudProviderVsphereServer(s, myServer)
 	reflection.Register(s)
 	return myServer
+}
+
+// GetNode implements CloudProviderVsphere interface
+func (s *server) GetNode(ctx context.Context, request *pb.GetNodeRequest) (*pb.GetNodeReply, error) {
+	reply := &pb.GetNodeReply{
+		Node: &pb.Node{},
+	}
+	err := s.nodeMgr.GetNode(request.Uuid, reply.Node)
+	if err != nil {
+		reply.Error = err.Error()
+	}
+	return reply, nil
 }
 
 // ListNodes implements CloudProviderVsphere interface


### PR DESCRIPTION
**What this PR does / why we need it**:
This addresses an issue with the ListNodes functionality in the CPI. The CPI should only report back currently active nodes registered to the CPI. This was discovered when attempting to clean out dead code in this PR https://github.com/kubernetes/cloud-provider-vsphere/pull/278

Also added in this PR is functionality to `GetNode` which just returns information about a particular node based on the node's UUID.

**Which issue this PR fixes**:
NA

**Special notes for your reviewer**:
`go test` added to exercise the functionality

**Release note**:
NA