### PR TITLE
Allow Internal/External status.Address Filtering by VM Network Name

### DIFF
--- a/pkg/cloudprovider/vsphere/config.go
+++ b/pkg/cloudprovider/vsphere/config.go
@@ -31,14 +31,6 @@ type CPIConfig struct {
 		// that will be used in respective status.addresses fields.
 		InternalNetworkSubnetCIDR string `gcfg:"internal-network-subnet-cidr"`
 		ExternalNetworkSubnetCIDR string `gcfg:"external-network-subnet-cidr"`
-		// IP address on VirtualMachine's VM Network names that will be used in respective
-		// status.addresses fields. Note that in this configuration there must only be a
-		// single IP address bound to a given vNIC when associated with these
-		// VM Network names.
-		// NOTE: when InternalNetworkSubnetCIDR and ExternalNetworkSubnetCIDR are set,
-		// these values take presedence over InternalVMNetworkName and ExternalVMNetworkName
-		InternalVMNetworkName string `gcfg:"internal-vm-network-name"`
-		ExternalVMNetworkName string `gcfg:"external-vm-network-name"`
 	}
 }
 
@@ -50,26 +42,9 @@ func (cfg *CPIConfig) FromEnv() {
 	if v := os.Getenv("VSPHERE_NODES_INTERNAL_NETWORK_SUBNET_CIDR"); v != "" {
 		cfg.Nodes.InternalNetworkSubnetCIDR = v
 	}
+
 	if v := os.Getenv("VSPHERE_NODES_EXTERNAL_NETWORK_SUBNET_CIDR"); v != "" {
 		cfg.Nodes.ExternalNetworkSubnetCIDR = v
-	}
-
-	if v := os.Getenv("VSPHERE_NODES_INTERNAL_VM_NETWORK_NAME"); v != "" {
-		cfg.Nodes.InternalVMNetworkName = v
-	}
-	if v := os.Getenv("VSPHERE_NODES_EXTERNAL_VM_NETWORK_NAME"); v != "" {
-		cfg.Nodes.ExternalVMNetworkName = v
-	}
-
-	cfg.validateConfig()
-}
-
-func (cfg *CPIConfig) validateConfig() {
-	if cfg.Nodes.InternalNetworkSubnetCIDR != "" {
-		cfg.Nodes.InternalVMNetworkName = ""
-	}
-	if cfg.Nodes.ExternalNetworkSubnetCIDR != "" {
-		cfg.Nodes.ExternalVMNetworkName = ""
 	}
 }
 

--- a/pkg/cloudprovider/vsphere/config.go
+++ b/pkg/cloudprovider/vsphere/config.go
@@ -31,6 +31,14 @@ type CPIConfig struct {
 		// that will be used in respective status.addresses fields.
 		InternalNetworkSubnetCIDR string `gcfg:"internal-network-subnet-cidr"`
 		ExternalNetworkSubnetCIDR string `gcfg:"external-network-subnet-cidr"`
+		// IP address on VirtualMachine's VM Network names that will be used in respective
+		// status.addresses fields. Note that in this configuration there must only be a
+		// single IP address bound to a given vNIC when associated with these
+		// VM Network names.
+		// NOTE: when InternalNetworkSubnetCIDR and ExternalNetworkSubnetCIDR are set,
+		// these values take presedence over InternalVMNetworkName and ExternalVMNetworkName
+		InternalVMNetworkName string `gcfg:"internal-vm-network-name"`
+		ExternalVMNetworkName string `gcfg:"external-vm-network-name"`
 	}
 }
 
@@ -42,9 +50,26 @@ func (cfg *CPIConfig) FromEnv() {
 	if v := os.Getenv("VSPHERE_NODES_INTERNAL_NETWORK_SUBNET_CIDR"); v != "" {
 		cfg.Nodes.InternalNetworkSubnetCIDR = v
 	}
-
 	if v := os.Getenv("VSPHERE_NODES_EXTERNAL_NETWORK_SUBNET_CIDR"); v != "" {
 		cfg.Nodes.ExternalNetworkSubnetCIDR = v
+	}
+
+	if v := os.Getenv("VSPHERE_NODES_INTERNAL_VM_NETWORK_NAME"); v != "" {
+		cfg.Nodes.InternalVMNetworkName = v
+	}
+	if v := os.Getenv("VSPHERE_NODES_EXTERNAL_VM_NETWORK_NAME"); v != "" {
+		cfg.Nodes.ExternalVMNetworkName = v
+	}
+
+	cfg.validateConfig()
+}
+
+func (cfg *CPIConfig) validateConfig() {
+	if cfg.Nodes.InternalNetworkSubnetCIDR != "" {
+		cfg.Nodes.InternalVMNetworkName = ""
+	}
+	if cfg.Nodes.ExternalNetworkSubnetCIDR != "" {
+		cfg.Nodes.ExternalVMNetworkName = ""
 	}
 }
 

--- a/pkg/cloudprovider/vsphere/config_test.go
+++ b/pkg/cloudprovider/vsphere/config_test.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2019 The Kubernetes Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,48 +14,76 @@ limitations under the License.
 package vsphere
 
 import (
-	"os"
 	"strings"
 	"testing"
 )
 
-const basicConfig = `
+const subnetCidrConfig = `
+[Global]
+server = 0.0.0.0
+port = 443
+user = user
+password = password
+insecure-flag = true
+datacenters = us-west
+ca-file = /some/path/to/a/ca.pem
+
 [Nodes]
-internal-network-subnet-cidr = 192.0.2.0/24
-external-network-subnet-cidr = 198.51.100.0/24
+internal-network-subnet-cidr = "192.0.2.0/24"
+external-network-subnet-cidr = "198.51.100.0/24"
 `
 
-func TestReadConfigGlobal(t *testing.T) {
+const networkNameConfig = `
+[Global]
+server = 0.0.0.0
+port = 443
+user = user
+password = password
+insecure-flag = true
+datacenters = us-west
+ca-file = /some/path/to/a/ca.pem
+
+[Nodes]
+internal-vm-network-name = "Internal K8s Traffic"
+external-vm-network-name = "External/Outbound Traffic"
+`
+
+func TestReadConfigSubnetCidr(t *testing.T) {
 	_, err := ReadCPIConfig(nil)
 	if err == nil {
 		t.Errorf("Should fail when no config is provided: %s", err)
 	}
 
-	cfg, err := ReadCPIConfig(strings.NewReader(basicConfig))
+	cfg, err := ReadCPIConfig(strings.NewReader(subnetCidrConfig))
 	if err != nil {
 		t.Fatalf("Should succeed when a valid config is provided: %s", err)
 	}
 
 	if cfg.Nodes.InternalNetworkSubnetCIDR != "192.0.2.0/24" {
-		t.Errorf("incorrect vcenter ip: %s", cfg.Nodes.InternalNetworkSubnetCIDR)
+		t.Errorf("incorrect internal network subnet cidr: %s", cfg.Nodes.InternalNetworkSubnetCIDR)
 	}
 
 	if cfg.Nodes.ExternalNetworkSubnetCIDR != "198.51.100.0/24" {
-		t.Errorf("incorrect datacenter: %s", cfg.Nodes.ExternalNetworkSubnetCIDR)
+		t.Errorf("incorrect external network subnet cidr: %s", cfg.Nodes.ExternalNetworkSubnetCIDR)
 	}
 }
 
-func TestEnvOverridesFile(t *testing.T) {
-	subnet := "203.0.113.0/24"
-	os.Setenv("VSPHERE_NODES_INTERNAL_NETWORK_SUBNET_CIDR", subnet)
-	defer os.Unsetenv("VSPHERE_NODES_INTERNAL_NETWORK_SUBNET_CIDR")
+func TestReadConfigNetworkName(t *testing.T) {
+	_, err := ReadCPIConfig(nil)
+	if err == nil {
+		t.Errorf("Should fail when no config is provided: %s", err)
+	}
 
-	cfg, err := ReadCPIConfig(strings.NewReader(basicConfig))
+	cfg, err := ReadCPIConfig(strings.NewReader(networkNameConfig))
 	if err != nil {
 		t.Fatalf("Should succeed when a valid config is provided: %s", err)
 	}
 
-	if cfg.Nodes.InternalNetworkSubnetCIDR != subnet {
-		t.Errorf("expected subnet: \"%s\", got: \"%s\"", subnet, cfg.Nodes.InternalNetworkSubnetCIDR)
+	if cfg.Nodes.InternalVMNetworkName != "Internal K8s Traffic" {
+		t.Errorf("incorrect internal vm network name: %s", cfg.Nodes.InternalVMNetworkName)
+	}
+
+	if cfg.Nodes.ExternalVMNetworkName != "External/Outbound Traffic" {
+		t.Errorf("incorrect internal vm network name: %s", cfg.Nodes.ExternalVMNetworkName)
 	}
 }

--- a/pkg/cloudprovider/vsphere/config_test.go
+++ b/pkg/cloudprovider/vsphere/config_test.go
@@ -17,84 +17,48 @@ limitations under the License.
 package vsphere
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
 
-const subnetCidrConfig = `
+const basicConfig = `
 [Nodes]
-internal-network-subnet-cidr = "192.0.2.0/24"
-external-network-subnet-cidr = "198.51.100.0/24"
+internal-network-subnet-cidr = 192.0.2.0/24
+external-network-subnet-cidr = 198.51.100.0/24
 `
 
-const networkNameConfig = `
-[Nodes]
-internal-vm-network-name = "Internal K8s Traffic"
-external-vm-network-name = "External/Outbound Traffic"
-`
-
-const overrideConfig = `
-[Nodes]
-internal-network-subnet-cidr = "192.0.2.0/24"
-internal-vm-network-name = "Internal K8s Traffic"
-external-vm-network-name = "External/Outbound Traffic"
-`
-
-func TestReadConfigSubnetCidr(t *testing.T) {
+func TestReadConfigGlobal(t *testing.T) {
 	_, err := ReadCPIConfig(nil)
 	if err == nil {
 		t.Errorf("Should fail when no config is provided: %s", err)
 	}
 
-	cfg, err := ReadCPIConfig(strings.NewReader(subnetCidrConfig))
+	cfg, err := ReadCPIConfig(strings.NewReader(basicConfig))
 	if err != nil {
 		t.Fatalf("Should succeed when a valid config is provided: %s", err)
 	}
 
 	if cfg.Nodes.InternalNetworkSubnetCIDR != "192.0.2.0/24" {
-		t.Errorf("incorrect internal network subnet cidr: %s", cfg.Nodes.InternalNetworkSubnetCIDR)
+		t.Errorf("incorrect vcenter ip: %s", cfg.Nodes.InternalNetworkSubnetCIDR)
 	}
 
 	if cfg.Nodes.ExternalNetworkSubnetCIDR != "198.51.100.0/24" {
-		t.Errorf("incorrect external network subnet cidr: %s", cfg.Nodes.ExternalNetworkSubnetCIDR)
-	}
-}
-
-func TestReadConfigNetworkName(t *testing.T) {
-	_, err := ReadCPIConfig(nil)
-	if err == nil {
-		t.Errorf("Should fail when no config is provided: %s", err)
-	}
-
-	cfg, err := ReadCPIConfig(strings.NewReader(networkNameConfig))
-	if err != nil {
-		t.Fatalf("Should succeed when a valid config is provided: %s", err)
-	}
-
-	if cfg.Nodes.InternalVMNetworkName != "Internal K8s Traffic" {
-		t.Errorf("incorrect internal vm network name: %s", cfg.Nodes.InternalVMNetworkName)
-	}
-
-	if cfg.Nodes.ExternalVMNetworkName != "External/Outbound Traffic" {
-		t.Errorf("incorrect internal vm network name: %s", cfg.Nodes.ExternalVMNetworkName)
+		t.Errorf("incorrect datacenter: %s", cfg.Nodes.ExternalNetworkSubnetCIDR)
 	}
 }
 
 func TestEnvOverridesFile(t *testing.T) {
-	cfg, err := ReadCPIConfig(strings.NewReader(overrideConfig))
+	subnet := "203.0.113.0/24"
+	os.Setenv("VSPHERE_NODES_INTERNAL_NETWORK_SUBNET_CIDR", subnet)
+	defer os.Unsetenv("VSPHERE_NODES_INTERNAL_NETWORK_SUBNET_CIDR")
+
+	cfg, err := ReadCPIConfig(strings.NewReader(basicConfig))
 	if err != nil {
 		t.Fatalf("Should succeed when a valid config is provided: %s", err)
 	}
 
-	if cfg.Nodes.InternalNetworkSubnetCIDR != "192.0.2.0/24" {
-		t.Errorf("expected subnet: \"192.0.2.0/24\", got: \"%s\"", cfg.Nodes.InternalNetworkSubnetCIDR)
-	}
-
-	if cfg.Nodes.InternalVMNetworkName != "" {
-		t.Errorf("expected vm network name should be empty, got: \"%s\"", cfg.Nodes.InternalVMNetworkName)
-	}
-
-	if cfg.Nodes.ExternalVMNetworkName != "External/Outbound Traffic" {
-		t.Errorf("expected vm network name should be \"External/Outbound Traffic\", got: \"%s\"", cfg.Nodes.ExternalVMNetworkName)
+	if cfg.Nodes.InternalNetworkSubnetCIDR != subnet {
+		t.Errorf("expected subnet: \"%s\", got: \"%s\"", subnet, cfg.Nodes.InternalNetworkSubnetCIDR)
 	}
 }

--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	clientv1 "k8s.io/client-go/listers/core/v1"
 	v1helper "k8s.io/cloud-provider/node/helpers"
 
 	cm "k8s.io/cloud-provider-vsphere/pkg/common/connectionmanager"
@@ -36,8 +35,8 @@ type MyNodeManager struct {
 	NodeManager
 }
 
-func newMyNodeManager(cm *cm.ConnectionManager, lister clientv1.NodeLister) *MyNodeManager {
-	return &MyNodeManager{*newNodeManager(cm, lister)}
+func newMyNodeManager(cm *cm.ConnectionManager) *MyNodeManager {
+	return &MyNodeManager{*newNodeManager(nil, cm)}
 }
 
 // Used to populate the networking info
@@ -76,7 +75,7 @@ func TestInstance(t *testing.T) {
 	 * Setup
 	 */
 	connMgr := cm.NewConnectionManager(cfg, nil, nil)
-	nm := newMyNodeManager(connMgr, nil)
+	nm := newMyNodeManager(connMgr)
 	instances := newInstances(&nm.NodeManager)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
@@ -155,7 +154,7 @@ func TestInvalidInstance(t *testing.T) {
 	 * Setup
 	 */
 	connMgr := cm.NewConnectionManager(cfg, nil, nil)
-	nm := newMyNodeManager(connMgr, nil)
+	nm := newMyNodeManager(connMgr)
 	instances := newInstances(&nm.NodeManager)
 
 	name := ""       //junk name

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -220,7 +220,6 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 			klog.V(4).Info("Skipping device because not a vNIC")
 			continue
 		}
-		vmNetworkName := v.Network
 
 		// Only return a single IP address based on the preference of IPFamily
 		// Must break out of loop in the event of ipv6,ipv4 where the NIC does
@@ -245,22 +244,12 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 						return fmt.Errorf("can't parse IP: %s", ip)
 					}
 
-					if internalIP == "" {
-						if internalNetworkSubnet != nil && internalNetworkSubnet.Contains(parsedIP) {
-							internalIP = ip
-						} else if nm.cpiCfg.Nodes.InternalVMNetworkName != "" &&
-							strings.EqualFold(nm.cpiCfg.Nodes.InternalVMNetworkName, vmNetworkName) {
-							internalIP = ip
-						}
+					if internalIP == "" && internalNetworkSubnet != nil && internalNetworkSubnet.Contains(parsedIP) {
+						internalIP = ip
 					}
 
-					if externalIP == "" {
-						if externalNetworkSubnet != nil && externalNetworkSubnet.Contains(parsedIP) {
-							externalIP = ip
-						} else if nm.cpiCfg.Nodes.ExternalVMNetworkName != "" &&
-							strings.EqualFold(nm.cpiCfg.Nodes.ExternalVMNetworkName, vmNetworkName) {
-							externalIP = ip
-						}
+					if externalIP == "" && externalNetworkSubnet != nil && externalNetworkSubnet.Contains(parsedIP) {
+						externalIP = ip
 					}
 				}
 

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -220,6 +220,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 			klog.V(4).Info("Skipping device because not a vNIC")
 			continue
 		}
+		vmNetworkName := v.Network
 
 		// Only return a single IP address based on the preference of IPFamily
 		// Must break out of loop in the event of ipv6,ipv4 where the NIC does
@@ -244,12 +245,22 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 						return fmt.Errorf("can't parse IP: %s", ip)
 					}
 
-					if internalIP == "" && internalNetworkSubnet != nil && internalNetworkSubnet.Contains(parsedIP) {
-						internalIP = ip
+					if internalIP == "" {
+						if internalNetworkSubnet != nil && internalNetworkSubnet.Contains(parsedIP) {
+							internalIP = ip
+						} else if nm.cpiCfg.Nodes.InternalVMNetworkName != "" &&
+							strings.EqualFold(nm.cpiCfg.Nodes.InternalVMNetworkName, vmNetworkName) {
+							internalIP = ip
+						}
 					}
 
-					if externalIP == "" && externalNetworkSubnet != nil && externalNetworkSubnet.Contains(parsedIP) {
-						externalIP = ip
+					if externalIP == "" {
+						if externalNetworkSubnet != nil && externalNetworkSubnet.Contains(parsedIP) {
+							externalIP = ip
+						} else if nm.cpiCfg.Nodes.ExternalVMNetworkName != "" &&
+							strings.EqualFold(nm.cpiCfg.Nodes.ExternalVMNetworkName, vmNetworkName) {
+							externalIP = ip
+						}
 					}
 				}
 

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -38,7 +38,7 @@ func TestRegUnregNode(t *testing.T) {
 	connMgr := cm.NewConnectionManager(cfg, nil, nil)
 	defer connMgr.Logout()
 
-	nm := newNodeManager(connMgr, nil)
+	nm := newNodeManager(nil, connMgr)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name
@@ -88,7 +88,7 @@ func TestDiscoverNodeByName(t *testing.T) {
 	connMgr := cm.NewConnectionManager(cfg, nil, nil)
 	defer connMgr.Logout()
 
-	nm := newNodeManager(connMgr, nil)
+	nm := newNodeManager(nil, connMgr)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	vm.Guest.HostName = strings.ToLower(vm.Name) // simulator.SearchIndex.FindByDnsName matches against the guest.hostName property
@@ -119,7 +119,7 @@ func TestExport(t *testing.T) {
 	connMgr := cm.NewConnectionManager(cfg, nil, nil)
 	defer connMgr.Logout()
 
-	nm := newNodeManager(connMgr, nil)
+	nm := newNodeManager(nil, connMgr)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name

--- a/pkg/cloudprovider/vsphere/zones_test.go
+++ b/pkg/cloudprovider/vsphere/zones_test.go
@@ -47,7 +47,7 @@ func TestZones(t *testing.T) {
 	connMgr := cm.NewConnectionManager(cfg, nil, nil)
 	defer connMgr.Logout()
 
-	nm := newNodeManager(connMgr, nil)
+	nm := newNodeManager(nil, connMgr)
 	zones := newZones(nm, cfg.Labels.Zone, cfg.Labels.Region)
 
 	// Create vSphere client


### PR DESCRIPTION
**What this PR does / why we need it**:
After attempting to test PR https://github.com/kubernetes/cloud-provider-vsphere/pull/271, I found that the config wasn't initializing properly, the new CPIConfig wasn't being passed to NodeManager needed to handle the address selection, and also there were some must needed use-cases which need to be implemented in order for a minimum viable feature.

I found a bug that was causing the CPIConfig to never get initialized. It stems from problem that io.Reader can only be read exactly once. In the initial implementation, first pass/read of the io.Reader was being used to initialize vcfg.Config (https://github.com/kubernetes/cloud-provider-vsphere/blob/master/pkg/cloudprovider/vsphere/cloud.go#L44) which did so successfully. However, the io.Reader was being utilized again (https://github.com/kubernetes/cloud-provider-vsphere/blob/master/pkg/cloudprovider/vsphere/cloud.go#L49) to read the CPIConfig which would immediately exit and leave an empty CPIConfig because the io.Reader was already at EOF.

The other bug was that NodeManager was never initialized with the new CPIConfig which turns out wouldn't have mattered because the CPIConfig was empty anyways (https://github.com/kubernetes/cloud-provider-vsphere/blob/master/pkg/cloudprovider/vsphere/cloud.go#L153-L158).

This refactors the CPIConfig to embed the vcfg.Config into the object such that the io.Reader only needs to be used exactly once. The change in implementation also happens to allow the need for a single reference to CPIConfig which ends up extending vcfg.Config so that we don't need 2 separate pointers to different vcfg.Config and CPIConfig objects.

Removes the unreferenced `lister clientv1.NodeLister` from `newNodeManager` since it was never used.

As for the new use-case, this PR implements `InternalVMNetworkName` and `ExternalVMNetworkName` in the CPIConfig which uses the VirtualMachine's VM Network names to filter on for status.addresses fields. 

Use Case 1
This is needed in the event that you only have a single subnet in which to hand out IP addresses for both the external and internal k8s addresses. If you are using a single subnet (which happens to be my case in my test environment), the requirement is that a single IP address (either IPv4 or IPv6) be bound to the vNIC and called out by setting `InternalVMNetworkName` and `ExternalVMNetworkName` fields in the config. This has the added feature for enabling chargeback to specific vNICs for external traffic 😉

Use Case 2
This is a complex use case but this effectively allows you to use both the subnet filtering and the VM Network Name as a secondary filter. In other words... there exists multiple IPs on the same subnet for both external and internal addresses (think 2 or more) on other vNICs that you don't want to register for kubernetes nodes.

Example 1:
_Config_
```
[Nodes]
internal-network-subnet-cidr = 192.0.2.0/24
external-network-subnet-cidr = 198.51.100.0/24
internal-vm-network-name = "Internal K8s Traffic"
external-vm-network-name = "External/Outbound Traffic"
```

_IPs on VM Networks_
192.0.2.1 on Internal K8s Traffic
192.0.2.2 on SomeThirdVMNetwork <--- based on the config above, this IP would not be registered to k8s
198.51.100.1 on External/Outbound Traffic
198.51.100.2 on SomeThirdVMNetwork <--- based on the config above, this IP would not be registered to k8s

Example 2:
_Config_
```
[Nodes]
internal-network-subnet-cidr = 192.0.2.0/24
external-network-subnet-cidr = 198.51.100.0/24
internal-vm-network-name = "Internal K8s Traffic"
external-vm-network-name = "External/Outbound Traffic"
```

_IPs on VM Networks_
192.0.2.1 on Internal K8s Traffic
192.0.2.2 on External/Outbound Traffic <--- based on the config above, this IP would not be registered to k8s
198.51.100.1 on External/Outbound Traffic
198.51.100.2 on Internal K8s Traffic <--- based on the config above, this IP would not be registered to k8s


**Which issue this PR fixes**:
Fixed both https://github.com/kubernetes/cloud-provider-vsphere/issues/270 and https://github.com/kubernetes/cloud-provider-vsphere/issues/266

**Special notes for your reviewer**:
Tested and verified working on the following configuration:
- vSphere 6.7u3
- Kubernetes 1.16.3
- Multi-vNICs on different VM Networks 

Default (old previous to both PRs) behavior is preserved. Single IP is registered to k8s as both the internal/external IP address.

**Release note**:
NA