### PR TITLE
Removed references to 'official' from README

### DIFF
--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -1,10 +1,10 @@
 # Kubernetes vSphere Cloud Provider
 
-This is the official documentation for the [Kubernetes vSphere Cloud Provider](https://github.com/kubernetes/cloud-provider-vsphere/).
+This is some example documentation for the [Kubernetes vSphere Cloud Provider](https://github.com/kubernetes/cloud-provider-vsphere/).
 
 ## Introduction
 
-This is the official documentation for the running Kubernetes on vSphere, with particular attention paid to the Container Storage Interface and Cloud Provider Interfaces. This document covers key concepts, features, known issues, installation requirements and steps for Kubernetes clusters running on vSphere. Before reading this document, it's worth noting that a Kubernetes cluster can still run on vSphere without the cloud provider integration enabled. However, your Kubernetes clusters will not have integration with the underlying infrastructure without the Cloud Provider Interface (CPI). Note that the term Cloud Control Manager (CCM) is now being referred to as the Cloud Provider Interface (CPI). For the purposes of this document, we will be using the CPI designation to cover the CPI/CCM feature.
+This is some example documentation for the running Kubernetes on vSphere, with particular attention paid to the Container Storage Interface and Cloud Provider Interfaces. This document covers key concepts, features, known issues, installation requirements and steps for Kubernetes clusters running on vSphere. Before reading this document, it's worth noting that a Kubernetes cluster can still run on vSphere without the cloud provider integration enabled. However, your Kubernetes clusters will not have integration with the underlying infrastructure without the Cloud Provider Interface (CPI). Note that the term Cloud Control Manager (CCM) is now being referred to as the Cloud Provider Interface (CPI). For the purposes of this document, we will be using the CPI designation to cover the CPI/CCM feature.
 
 ## History
 


### PR DESCRIPTION
There were some internal queries about the use of the word 'official' in
this repo with reference to CSI from a documentation perspective. The
'official' source is docs.vmware.com, however this repo is more up to
date. We've been asked to remove the reference to official, net effect
other than the verbiage change is nothing.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
