### PR TITLE
Added fstype to default storageclass

### DIFF
--- a/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
+++ b/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
@@ -1001,6 +1001,7 @@ metadata:
 provisioner: csi.vsphere.vmware.com
 parameters:
   storagepolicyname: "Space-Efficient"
+  fstype: ext4
 ```
 
 ```bash


### PR DESCRIPTION
In testing, found that no default fstype is used unless specified (CentOS 7, kernel 3.10.0-1062.9.1.el7.x86_64, k8s 1.17.0). Added fstype in storageclass to avoid this issue. Can also specify other fstype such as xfs, etc.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Adds file system type to the default storageclass to allow containers to consume the persistent volumes. Needed for certain scenarios where a filesystem type will be left blank when unspecified. 

**Special notes for your reviewer**:
This is my first PR, so I apologize if I've missed anything. Please let me know if I need to add more info or update my comments.


```release-note None
```
