### PR TITLE
Update CPI image to use non-root account

### DIFF
--- a/cluster/images/controller-manager/Dockerfile
+++ b/cluster/images/controller-manager/Dockerfile
@@ -52,5 +52,8 @@ RUN go build -a -ldflags='-w -s -extldflags=static -X main.version=${VERSION}' -
 # Copy the manager into the distroless image.
 FROM ${DISTROLESS_IMAGE}
 LABEL maintainer="Travis Rhoden <trhoden@vmware.com>"
+
+USER nobody
+
 COPY --from=builder /build/vsphere-cloud-controller-manager /bin/vsphere-cloud-controller-manager
 ENTRYPOINT [ "/bin/vsphere-cloud-controller-manager" ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Forces the CPI to run on a non-root account. In the distroless image, there is an account called `nobody` which will now be utilized. This will make the container image more secure!

**Which issue this PR fixes**:
Helps address https://github.com/kubernetes/cloud-provider-vsphere/issues/295

**Special notes for your reviewer**:
Tested on 6.7u3 and made sure all nodes initialized properly.

**Release note**:
NA