### PR TITLE
Added detail to CPI/CSI how-to doc to clarify ProviderID requirement

### DIFF
--- a/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
+++ b/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
@@ -441,7 +441,9 @@ You can check if the node has joined by running `# kubectl get nodes` on the mas
 
 ## Install the vSphere Cloud Provider Interface
 
-The following steps are only done on the master. Please note that the CSI driver requires the presence of the Cloud Provider Interface (CPI), so the step of installing the CPI is mandatory.
+The following steps are only done on the master.
+
+Please note that the CSI driver requires the presence of a `ProviderID` label on each node in the K8s cluster. This can be populated by whatever means is most convenient - Ideally, the Cloud Provider Interface (CPI) would be used as it is actively maintained and updated, but if the vSphere Cloud Provider (VCP) must be used due to brownfield requirements or architectural constraints of your distribution - that is also acceptable. As long as the `ProviderID` is populated by some means - the vSphere CSI driver will work.
 
 ### Create a CPI configMap
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to clarify what the exact dependency of the CSI on the CPI or otherwise to make it functional. This clarifies VMware's support stance on CSI and support therein - that as long as `ProviderID` is set, we will support the vSphere CSI.
```release-note
```
