### PR TITLE
Fix OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,15 +3,14 @@
 aliases:
   sig-cloud-provider-leads:
     - andrewsykim
-    - hogepodge
-    - jagosan
+    - cheftako
   cloud-provider-vsphere-maintainers:
     - abrarshivani
     - andrewsykim
     - baludontu
     - divyenpatel
     - dougm
+    - dvonthenen
     - frapposelli
     - imkin
     - sandeeppissay
-    - dvonthenen


### PR DESCRIPTION
This PR fixes the OWNER_ALIASES file for the repo, removing emeritus sig-cloud-provider leads and adding @cheftako as new lead. The list is now in alphabetical order

/kind bug

Fixes: #308