### PR TITLE
Don't cache instances if addresses are not found

### DIFF
--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/vmware/govmomi/simulator"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,10 +51,10 @@ func (nm *MyNodeManager) RegisterNode(node *v1.Node) {
 	v1helper.AddToNodeAddresses(&addrs,
 		v1.NodeAddress{
 			Type:    v1.NodeExternalIP,
-			Address: "127.0.0.1",
+			Address: "10.0.0.1",
 		}, v1.NodeAddress{
 			Type:    v1.NodeInternalIP,
-			Address: "127.0.0.1",
+			Address: "10.0.0.1",
 		}, v1.NodeAddress{
 			Type:    v1.NodeHostName,
 			Address: node.Name,
@@ -81,6 +82,12 @@ func TestInstance(t *testing.T) {
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	name := vm.Name
 	vm.Guest.HostName = name
+	vm.Guest.Net = []vimtypes.GuestNicInfo{
+		{
+			Network:   "foo-bar",
+			IpAddress: []string{"10.0.0.1"},
+		},
+	}
 	UUID := strings.ToUpper(vm.Config.Uuid)
 	k8sUUID := ConvertK8sUUIDtoNormal(UUID)
 

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/vmware/govmomi/simulator"
+	vimtypes "github.com/vmware/govmomi/vim25/types"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,6 +42,14 @@ func TestRegUnregNode(t *testing.T) {
 	nm := newNodeManager(nil, connMgr)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	vm.Guest.HostName = vm.Name
+	vm.Guest.Net = []vimtypes.GuestNicInfo{
+		{
+			Network:   "foo-bar",
+			IpAddress: []string{"10.0.0.1"},
+		},
+	}
+
 	name := vm.Name
 	UUID := vm.Config.Uuid
 	k8sUUID := ConvertK8sUUIDtoNormal(UUID)
@@ -92,6 +101,12 @@ func TestDiscoverNodeByName(t *testing.T) {
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	vm.Guest.HostName = strings.ToLower(vm.Name) // simulator.SearchIndex.FindByDnsName matches against the guest.hostName property
+	vm.Guest.Net = []vimtypes.GuestNicInfo{
+		{
+			Network:   "foo-bar",
+			IpAddress: []string{"10.0.0.1"},
+		},
+	}
 	name := vm.Name
 
 	err := connMgr.Connect(context.Background(), connMgr.VsphereInstanceMap[cfg.Global.VCenterIP])
@@ -122,6 +137,13 @@ func TestExport(t *testing.T) {
 	nm := newNodeManager(nil, connMgr)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	vm.Guest.HostName = strings.ToLower(vm.Name) // simulator.SearchIndex.FindByDnsName matches against the guest.hostName property
+	vm.Guest.Net = []vimtypes.GuestNicInfo{
+		{
+			Network:   "foo-bar",
+			IpAddress: []string{"10.0.0.1"},
+		},
+	}
 	name := vm.Name
 	UUID := vm.Config.Uuid
 	k8sUUID := ConvertK8sUUIDtoNormal(UUID)

--- a/pkg/cloudprovider/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/vsphere/vsphere_test.go
@@ -112,13 +112,14 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc b
 	}
 	cfg.VirtualCenter = make(map[string]*vcfg.VirtualCenterConfig)
 	cfg.VirtualCenter[s.URL.Hostname()] = &vcfg.VirtualCenterConfig{
-		User:         cfg.Global.User,
-		Password:     cfg.Global.Password,
-		TenantRef:    cfg.Global.VCenterIP,
-		VCenterIP:    cfg.Global.VCenterIP,
-		VCenterPort:  cfg.Global.VCenterPort,
-		InsecureFlag: cfg.Global.InsecureFlag,
-		Datacenters:  cfg.Global.Datacenters,
+		User:             cfg.Global.User,
+		Password:         cfg.Global.Password,
+		TenantRef:        cfg.Global.VCenterIP,
+		VCenterIP:        cfg.Global.VCenterIP,
+		VCenterPort:      cfg.Global.VCenterPort,
+		InsecureFlag:     cfg.Global.InsecureFlag,
+		Datacenters:      cfg.Global.Datacenters,
+		IPFamilyPriority: []string{"ipv4"},
 	}
 
 	// Configure region and zone categories

--- a/pkg/cloudprovider/vsphere/zones_test.go
+++ b/pkg/cloudprovider/vsphere/zones_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 
 	cm "k8s.io/cloud-provider-vsphere/pkg/common/connectionmanager"
 	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
@@ -59,6 +60,13 @@ func TestZones(t *testing.T) {
 
 	// Get a simulator VM
 	myvm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	myvm.Guest.HostName = myvm.Name
+	myvm.Guest.Net = []types.GuestNicInfo{
+		{
+			Network:   "foo-bar",
+			IpAddress: []string{"10.0.0.1"},
+		},
+	}
 	name := myvm.Name
 	UUID := myvm.Config.Uuid
 	k8sUUID := ConvertK8sUUIDtoNormal(UUID)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We should stop caching nodes if no addresses were found to ensure we check again when the addresses do become available or if there was an error checking the first time. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bug fix: don't cache nodes if no addresses are found
```
