### PR TITLE
set gitVersion in cloud-controller-manager LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ GOOS ?= linux
 GOARCH ?= amd64
 
 LDFLAGS := $(shell cat hack/make/ldflags.txt)
-LDFLAGS_CCM := $(LDFLAGS) -X "main.version=$(VERSION)"
+LDFLAGS_CCM := $(LDFLAGS) -X "main.version=$(VERSION)" -X "k8s.io/kubernetes/pkg/version.gitVersion=$(VERSION)" -X "k8s.io/component-base/pkg/version.gitVersion=$(VERSION)"
 
 # The cloud controller binary.
 CCM_BIN_NAME := vsphere-cloud-controller-manager


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The currently vendored verison of k8s.io/kubernetes reads the version info from `k8s.io/kubernetes/pkg/version`. Future versions of k8s.io/kubernetes reads it from `k8s.io/component-base/version`. This PR adds LDFLAGS to set both to the current version so the correct version is logged as part of the cloud-controller-manager lib. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bug fix: properly log version info from cloud-controller-manager
```
