### PR TITLE
skip staticcheck for SA1019

### DIFF
--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -25,6 +25,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 go get honnef.co/go/tools/cmd/staticcheck
 CMD=$(go list -f \{\{\.Target\}\} honnef.co/go/tools/cmd/staticcheck)
 
-CHECKS="all,-ST1*"
+# re-enable SA1019 when we upgrade to Go 1.14
+CHECKS="all,-ST1*,-SA1019"
 
 "${CMD}" -checks "${CHECKS}" ./...


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We can't remove tlsConfig.BuildNameToCertificate() until we're on Go 1.14 so we should ignore the linter for now.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
