### PR TITLE
Remove ToLower when using FQDN

### DIFF
--- a/pkg/common/credentialmanager/credentialmanager.go
+++ b/pkg/common/credentialmanager/credentialmanager.go
@@ -193,7 +193,6 @@ func parseConfig(data map[string][]byte, config map[string]*Credential) error {
 		return ErrCredentialMissing
 	}
 	for credentialKey, credentialValue := range data {
-		credentialKey = strings.ToLower(credentialKey)
 		if strings.HasSuffix(credentialKey, "password") {
 			vcServer := strings.Split(credentialKey, ".password")[0]
 			if _, ok := config[vcServer]; !ok {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes using FQDN with case when searching for creds in the credmanager. The FQDN is set to lower case before storing as the key.

**Which issue this PR fixes**:
https://github.com/kubernetes/cloud-provider-vsphere/issues/351

**Special notes for your reviewer**:
This code was lifted from the in-tree cloud provider and could potentially exist there as well.

**Release note**:
NA