### PR TITLE
Fixed a bug in InstanceExistsByProviderID()

### DIFF
--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -159,13 +159,14 @@ func (i *instances) InstanceExistsByProviderID(ctx context.Context, providerID s
 		return true, nil
 	}
 
-	if err := i.nodeManager.DiscoverNode(uid, cm.FindVMByUUID); err == nil {
+	err := i.nodeManager.DiscoverNode(uid, cm.FindVMByUUID)
+	if err == nil {
 		klog.V(2).Info("instances.InstanceExistsByProviderID() EXISTS with ", uid)
-		return true, err
+		return true, nil
 	}
 
 	klog.V(4).Info("instances.InstanceExistsByProviderID() NOT FOUND with ", uid)
-	return false, nil
+	return false, err
 }
 
 // InstanceShutdownByProviderID returns true if the instance is in safe state to detach volumes

--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -196,8 +196,8 @@ func TestInvalidInstance(t *testing.T) {
 	}
 
 	exists, err := instances.InstanceExistsByProviderID(ctx, providerID)
-	if err != nil {
-		t.Errorf("InstanceExistsByProviderID failed err=%v", err)
+	if err == nil {
+		t.Errorf("InstanceExistsByProviderID expected failure but err=nil")
 	}
 	if exists {
 		t.Error("InstanceExistsByProviderID excepted not exists")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

There seems to be a bug that does not report an error to the CCM code. That may lead to Node deletion when an API access fails.

**Special notes for your reviewer**:

I mean... it does look like a bug, but can't shake a feeling that I've missed something.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Errors during InstanceExistsByProviderID() stopped leading to Node object deletion
```
