### PR TITLE
Documentation How-To for CPI version 1.1.0 and earlier

### DIFF
--- a/docs/book/tutorials/deploying_cpi_and_csi_with_multi_dc_vc_aka_zones.md
+++ b/docs/book/tutorials/deploying_cpi_and_csi_with_multi_dc_vc_aka_zones.md
@@ -69,6 +69,8 @@ Steps that will be covered in order to setup zones for the vSphere CPI, vSphere 
 
 The zones implementation depends on 2 sets of vSphere tags to be used on objects, such as datacenters or clusters. The first is a `region` tag and the second is a `zone` tag. vSphere tags are very simply put key/value pairs that can be assigned to objects and instead of using fixed keys to denote a `region` or a `zone`, we give the end-user the ability to come up with their own keys for a `region` and `zone` in the form of vSphere Tag Catagory. It just allows for a level of indirection in case you already have regions and zones setup in your configuration. Once a key/label or vSphere Tag Category is selected for each, create a `labels:` section in the `vsphere.conf` then assign tag names for both `region` and `zone`.
 
+**NOTE:** If you are using CPI version 1.1.0 or earlier, please use the `INI` based cloud configuration as outlined in the [Deploying a Kubernetes Cluster on vSphere with CSI and CPI](https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md) documentation.
+
 In the example `vsphere.conf` below, `k8s-region` and `k8s-zone` was selected:
 
 ```bash
@@ -103,6 +105,15 @@ vcenter:
 labels:
   region: k8s-region
   zone: k8s-zone
+```
+
+**NOTE:** For the `INI` based configuration the zones configuration would appear as the following at the end of your cloud-config file:
+
+```bash
+# labels for regions and zones
+[Labels]
+region = k8s-region
+zone = k8s-zone
 ```
 
 ### 2. Creating Zones in your vSphere Environment via Tags

--- a/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
+++ b/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
@@ -475,6 +475,8 @@ Please note that the CSI driver requires the presence of a `ProviderID` label on
 
 This cloud-config configmap file, passed to the CPI on initialization, contains details about the vSphere configuration. This file, which here we have called `vsphere.conf` has been populated with some sample values. Obviously, you will need to modify this file to reflect your own vSphere configuration.
 
+**NOTE:** As of CPI version 1.2.0 or higher, the preferred cloud-config format will be `YAML` based. The `INI` based format will be deprecated but supported until the transition to the preferred `YAML` based configuration has been completed. This deprecation notice will be placed in the CPI logs when using the `INI` based configuration format.
+
 ```bash
 # tee /etc/kubernetes/vsphere.conf >/dev/null <<EOF
 
@@ -492,7 +494,7 @@ vcenter:
   tenant-finance:
     server: 1.1.1.1
     datacenters:
-      - globalfinanace
+      - finanace
   tenant-hr:
     server: 192.168.0.1
     datacenters:
@@ -501,8 +503,7 @@ vcenter:
   tenant-engineering:
     server: 10.0.0.1
     datacenters:
-      - engrwest1
-      - engrwest2
+      - engineering
     secretName: cpi-engineering-secret
     secretNamespace: kube-system
 
@@ -522,6 +523,31 @@ Here is a description of the fields used in the vsphere.conf configmap.
 * `secretNamespace` is set to the namespace where the secret has been created.
 * `port` is the vCenter Server Port. The default is 443 if not specified.
 * `datacenters` should be the list of datacenters where kubernetes node VMs are present.
+
+For those users deploying CPI versions 1.1.0 or earlier, the corresponding `INI` based configuration that mirrors the above configuration appears as the following:
+
+```bash
+# tee /etc/kubernetes/vsphere.conf >/dev/null <<EOF
+
+[Global]
+port = "443"
+insecure-flag = "true"
+secret-name = "cpi-global-secret"
+secret-namespace = "kube-system"
+
+[VirtualCenter "1.1.1.1"]
+datacenters = "finance"
+
+[VirtualCenter "192.168.0.1"]
+datacenters = "hrwest,hreast"
+
+[VirtualCenter "10.0.0.1"]
+datacenters = "engineering"
+secret-name = "cpi-engineering-secret"
+secret-namespace = "kube-system"
+
+EOF
+```
 
 Create the configmap by running the following command:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Documentation to describe configuring the cloud-config using the INI based format for CPI versions 1.1.0 and earlier.

**Which issue this PR fixes**: 
https://github.com/kubernetes/cloud-provider-vsphere/issues/357

**Special notes for your reviewer**:
None

**Release note**:
Documentation changes only
