### PR TITLE
InstanceExistsByProviderID Signal Deletion to K8s

### DIFF
--- a/docs/book/tutorials/deploying_cpi_and_csi_with_multi_dc_vc_aka_zones.md
+++ b/docs/book/tutorials/deploying_cpi_and_csi_with_multi_dc_vc_aka_zones.md
@@ -78,7 +78,7 @@ In the example `vsphere.conf` below, `k8s-region` and `k8s-zone` was selected:
 global:
   user: YourVCenterUser
   password: YourVCenterPass
-  port: "443"
+  port: 443
   # set insecureFlag to true if the vCenter uses a self-signed cert
   insecureFlag: true
   # settings for using k8s secret

--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -196,8 +196,8 @@ func TestInvalidInstance(t *testing.T) {
 	}
 
 	exists, err := instances.InstanceExistsByProviderID(ctx, providerID)
-	if err == nil {
-		t.Errorf("InstanceExistsByProviderID expected failure but err=nil")
+	if err != nil {
+		t.Errorf("InstanceExistsByProviderID unexpected failure but err=%s", err)
 	}
 	if exists {
 		t.Error("InstanceExistsByProviderID excepted not exists")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the default behavior to mimic other cloud providers controllers so that if the vSphere VM is no longer accessible/present according to the vCenter Server, the node VM will be deleted.

An option exists (via an environment variable) to prevent the deletion of the VM which preserves the original behavior.

**Which issue this PR fixes**: https://github.com/kubernetes/cloud-provider-vsphere/issues/348

**Special notes for your reviewer**:
New capability is behind a switch... default behavior is unchanged.

**Release note**:
NA
