### PR TITLE
Add support for Resource Pool and Folder traversal for Zones/Regions

### DIFF
--- a/pkg/common/connectionmanager/zones.go
+++ b/pkg/common/connectionmanager/zones.go
@@ -345,7 +345,7 @@ func (cm *ConnectionManager) LookupZoneByMoref(ctx context.Context, tenantRef st
 			tags, err := client.ListAttachedTags(ctx, obj)
 			if err != nil {
 				klog.Errorf("Cannot list attached tags. Err: %v", err)
-				return err
+				continue
 			}
 			for _, value := range tags {
 				tag, err := client.GetTag(ctx, value)


### PR DESCRIPTION
**What this PR does / why we need it**:
- This adds support for regions/zones on resource pools (and nested resource pools) and also folders (as in the VM and Templates view).
- Fixes an issue where we weren't traversing the entire ancestor chain (return err -> continue). Having zero tags would throw an error which in turn cause to skip the rest of the ancestor chain.

**Which issue this PR fixes**:
NA

**Special notes for your reviewer**:
I kinda need this for KubeCon 😀

**Release note**:
No user doc or interface changes