### PR TITLE
fix version logging on start up

### DIFF
--- a/cmd/vsphere-cloud-controller-manager/main.go
+++ b/cmd/vsphere-cloud-controller-manager/main.go
@@ -62,7 +62,7 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	klog.V(1).Infof("vsphere-cloud-controller-manager version: %s", version)
+	klog.Infof("vsphere-cloud-controller-manager version: %s", version)
 
 	// Set cloud-provider flag to vsphere
 	command.Flags().VisitAll(func(flag *pflag.Flag) {


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The version log message on start-up is not logging since we haven't parsed the klog flags yet. Fix this by not setting the verbosity level on the log message

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix version log message on start up
```
