### PR TITLE
Minimum NSX-T Support

### DIFF
--- a/pkg/cloudprovider/vsphere/loadbalancer/README.md
+++ b/pkg/cloudprovider/vsphere/loadbalancer/README.md
@@ -21,6 +21,10 @@ required (S, M, L or XL).
 For every service port a dedicated virtual server is managed which is
 connected to this load balancer service.
 
+## Minimum Requirements
+
+This is an alpha feature and as such, your mileage might vary with the functionality of this feature. Support will be provided on a best effort basis. Since this is an alpha feature, it should go without saying that this should never be enabled in a production environment. The feature minimally requires NSX-T 2.5 or higher.
+
 ## Features
 
 The load balancer controller part of the vsphere cloud controller manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Just lists the minimum NSX-T version required for support which is 2.5. Also note, this is listed as an alpha feature so breaking changes may (and will probably) occur.

**Which issue this PR fixes**: https://github.com/kubernetes/cloud-provider-vsphere/issues/306

**Special notes for your reviewer**:
NA

**Release note**:
NA