### PR TITLE
Remove inactive members from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,6 @@ aliases:
     - andrewsykim
     - cheftako
   cloud-provider-vsphere-maintainers:
-    - abrarshivani
     - andrewsykim
     - baludontu
     - divyenpatel


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019)s, this commit removes abrarshivani from the
OWNERS_ALIASES file.

/kind cleanup
/assign @andrewsykim 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
