### PR TITLE
README for vcsim keys used in go test

### DIFF
--- a/pkg/common/vclib/fixtures/README.md
+++ b/pkg/common/vclib/fixtures/README.md
@@ -1,0 +1,10 @@
+# Security Go(lang) Testing
+
+The files below are only used for our Go test framework for making sure the simulated vCenter Server (vcsim) is able to authenticate in a secure manner. The files don't actually access any valid resource anywhere. These files include:
+
+- ca.key
+- ca.pem
+- server.csr
+- server.key
+- server.pem
+- invalid.pem


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a README explaining what the keys are used for in this folder as not to throw red flags for security-minded people. These files are only used for `go test` and don't access any resource or system.

**Which issue this PR fixes**: https://github.com/kubernetes/cloud-provider-vsphere/issues/364

**Special notes for your reviewer**:
NA

**Release note**:
NA