### PR TITLE
nodemanager: wait for hostname before registering node

### DIFF
--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -196,8 +196,8 @@ func TestInvalidInstance(t *testing.T) {
 	}
 
 	exists, err := instances.InstanceExistsByProviderID(ctx, providerID)
-	if err != nil {
-		t.Errorf("InstanceExistsByProviderID unexpected failure but err=%s", err)
+	if err == nil {
+		t.Errorf("InstanceExistsByProviderID expected failure, but err=nil")
 	}
 	if exists {
 		t.Error("InstanceExistsByProviderID excepted not exists")

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -28,6 +28,7 @@ import (
 	pb "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/proto"
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
 	cm "k8s.io/cloud-provider-vsphere/pkg/common/connectionmanager"
+	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
 	v1helper "k8s.io/cloud-provider/node/helpers"
 	"k8s.io/klog"
 
@@ -111,6 +112,10 @@ func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, 
 		if err == nil {
 			klog.Info("Discovered VM using FQDN or short-hand name")
 			return vmDI, err
+		}
+
+		if err != vclib.ErrNoVMFound {
+			return nil, err
 		}
 
 		vmDI, err = nm.connectionManager.WhichVCandDCByNodeID(ctx, nodeID, cm.FindVMByIP)

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -186,6 +186,10 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		return errors.New("VirtualMachine Guest property was nil")
 	}
 
+	if oVM.Guest.HostName == "" {
+		return errors.New("VM Guest hostname is empty")
+	}
+
 	tenantRef := vmDI.VcServer
 	if vmDI.TenantRef != "" {
 		tenantRef = vmDI.TenantRef

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -135,6 +135,10 @@ func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, 
 		return vmDI, err
 	}
 
+	if err != vclib.ErrNoVMFound {
+		return nil, err
+	}
+
 	// Need to lookup the original format of the UUID because photon 2.0 formats the UUID
 	// different from Photon 3, RHEL, CentOS, Ubuntu, and etc
 	klog.Errorf("WhichVCandDCByNodeID failed using normally formatted UUID. Err: %v", err)

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -111,7 +111,7 @@ func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, 
 		vmDI, err := nm.connectionManager.WhichVCandDCByNodeID(ctx, nodeID, cm.FindVM(searchBy))
 		if err == nil {
 			klog.Info("Discovered VM using FQDN or short-hand name")
-			return vmDI, err
+			return vmDI, nil
 		}
 
 		if err != vclib.ErrNoVMFound {
@@ -121,7 +121,7 @@ func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, 
 		vmDI, err = nm.connectionManager.WhichVCandDCByNodeID(ctx, nodeID, cm.FindVMByIP)
 		if err == nil {
 			klog.Info("Discovered VM using IP address")
-			return vmDI, err
+			return vmDI, nil
 		}
 
 		klog.Errorf("WhichVCandDCByNodeID failed using VM name. Err: %v", err)
@@ -132,7 +132,7 @@ func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, 
 	vmDI, err := nm.connectionManager.WhichVCandDCByNodeID(ctx, nodeID, cm.FindVM(searchBy))
 	if err == nil {
 		klog.Info("Discovered VM using normal UUID format")
-		return vmDI, err
+		return vmDI, nil
 	}
 
 	if err != vclib.ErrNoVMFound {
@@ -146,7 +146,7 @@ func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, 
 	vmDI, err = nm.connectionManager.WhichVCandDCByNodeID(ctx, reverseUUID, cm.FindVM(searchBy))
 	if err == nil {
 		klog.Info("Discovered VM using reverse UUID format")
-		return vmDI, err
+		return vmDI, nil
 	}
 
 	klog.Errorf("WhichVCandDCByNodeID failed using UUID. Err: %v", err)

--- a/pkg/common/connectionmanager/search.go
+++ b/pkg/common/connectionmanager/search.go
@@ -18,6 +18,7 @@ package connectionmanager
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"time"
@@ -46,7 +47,7 @@ func (f FindVM) String() string {
 func (cm *ConnectionManager) WhichVCandDCByNodeID(ctx context.Context, nodeID string, searchBy FindVM) (*VMDiscoveryInfo, error) {
 	if nodeID == "" {
 		klog.V(3).Info("WhichVCandDCByNodeID called but nodeID is empty")
-		return nil, vclib.ErrNoVMFound
+		return nil, errors.New("nodeID is empty")
 	}
 	type vmSearch struct {
 		tenantRef  string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Follow-up bug fix from https://github.com/kubernetes/cloud-provider-vsphere/pull/359

* Updates node manager to only discover a node if vmtools is reporting a valid hostname. 
* Only check VM by IP if not found by node name.
* Only check VM by reverse UUID if not found by normal UUID
* return explicit nil for better readability. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix a bug where a node can be reported as 'not found' prior to vmtools running on the host.
```
