### PR TITLE
Cherrypick 387 to release-1.2

### DIFF
--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -121,19 +121,8 @@ func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (st
 		return i.nodeManager.nodeNameMap[string(nodeName)].UUID, nil
 	}
 
-	if err != vclib.ErrNoVMFound {
-		klog.V(4).Infof("instances.InstanceID() failed with err: %v", err)
-		return "", err
-	}
-
-	// at this point, err is vclib.ErrNoVMFound
-	if _, ok := os.LookupEnv("SKIP_NODE_DELETION"); ok {
-		klog.V(4).Infof("instances.InstanceID() NOT FOUND for node %s. Override and prevent deletion.", string(nodeName))
-		return "", err
-	}
-
-	klog.V(4).Info("instances.InstanceID() NOT FOUND with ", string(nodeName))
-	return "", cloudprovider.InstanceNotFound
+	klog.V(4).Infof("instances.InstanceID() failed with err: %v", err)
+	return "", err
 }
 
 // InstanceType returns the type of the instance identified by name.


### PR DESCRIPTION
Skip node deletion by VM name since a VM will not exist according to vCenter between the time the node reports itself to the apiserver (as NotReady) and when vmtools is correctly reporting the hostname. By only deleting a VM by UUID, we ensure only existing registered nodes can be deleted when it no longer exists. The caveat here is that cloud provider will no longer delete nodes that failed to register and no longer exist, but this is much better than accidentally deleting a VM where vmtools was slow to report the hostname

Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
