### PR TITLE
Use Exists operator in node-role.kubernetes.io/master toleration

### DIFF
--- a/releases/v1.18/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.18/vsphere-cloud-controller-manager.yaml
@@ -225,6 +225,7 @@ spec:
           effect: NoSchedule
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
+          operator: Exists
         - key: node.kubernetes.io/not-ready
           effect: NoSchedule
           operator: Exists


### PR DESCRIPTION
**What this PR does / why we need it**:
Extend list of tolerations for cloud-controller-manager. For further details visit the linked issue.

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

**Which issue this PR fixes** *:
fixes #391

**Special notes for your reviewer**:
Does not break the DaemonSet already existing tolerations, just extend it.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
