### PR TITLE
optionally check for orphan, unmanaged load balancer service

### DIFF
--- a/pkg/cloudprovider/vsphere/loadbalancer/interface.go
+++ b/pkg/cloudprovider/vsphere/loadbalancer/interface.go
@@ -31,7 +31,7 @@ import (
 type LBProvider interface {
 	cloudprovider.LoadBalancer
 	Initialize(clusterName string, client clientset.Interface, stop <-chan struct{})
-	CleanupServices(clusterName string, services map[types.NamespacedName]corev1.Service) error
+	CleanupServices(clusterName string, services map[types.NamespacedName]corev1.Service, ensureLBServiceDeleted bool) error
 }
 
 // NSXTAccess provides methods for dealing with NSX-T objects


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The load balancer cleanup code of cloud-provider-vsphere is used as dependency in [gardener-extension-provider-vsphere](https://github.com/gardener/gardener-extension-provider-vsphere).
If there are no virtual servers, currently the method `LBProvider.CleanupServices` does not delete the orphan load balancer service (only relevant in the "managed" case). We need the changes in this PR to deal with this corner case.
There is no change in the behaviour of the load balancer provider, if the cloud-provider-vsphere is used directly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
