### PR TITLE
Update to k8s references to v1.18.9 on the release-1.18 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,10 @@ module k8s.io/cloud-provider-vsphere
 go 1.13
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/protobuf v1.3.2
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/imdario/mergo v0.3.7 // indirect
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.9.0
 	github.com/prometheus/client_golang v1.0.0
 	github.com/spf13/cobra v0.0.5
@@ -21,7 +17,6 @@ require (
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.1.1
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
-	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	golang.org/x/tools v0.0.0-20200301222351-066e0c02454c // indirect
 	google.golang.org/grpc v1.26.0
 	gopkg.in/gcfg.v1 v1.2.3
@@ -29,14 +24,14 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.2.8
 	honnef.co/go/tools v0.0.1-2020.1.3 // indirect
-	k8s.io/api v0.18.6
-	k8s.io/apimachinery v0.18.6
-	k8s.io/client-go v0.18.6
+	k8s.io/api v0.18.9
+	k8s.io/apimachinery v0.18.9
+	k8s.io/client-go v0.18.9
 	k8s.io/cloud-provider v0.0.0
 	k8s.io/component-base v0.0.0
 	k8s.io/klog v1.0.0
-	k8s.io/kubernetes v1.18.6
-	k8s.io/sample-controller v0.18.6
+	k8s.io/kubernetes v1.18.9
+	k8s.io/sample-controller v0.18.9
 	sigs.k8s.io/kind v0.7.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,7 @@ github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v0.0.0-20160318181535-f6a740d52f96/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
@@ -972,6 +973,7 @@ k8s.io/kubernetes v1.15.0 h1:0P6jAdZ1cF5/wSc14HqHCjWlbnwYzmFJBYeXBezZEE0=
 k8s.io/kubernetes v1.15.0/go.mod h1:3RE5ikMc73WK+dSxk4pQuQ6ZaJcPXiZX2dj98RcdCuM=
 k8s.io/kubernetes v1.18.6 h1:2rkR3ffvd5YVyPYU4LAUDCKoKQZtjuuj8ga15mbv96o=
 k8s.io/kubernetes v1.18.6/go.mod h1:Efg82S+Ti02A/Mww53bxroc7IgzX2bgPsf6hT8gAs3M=
+k8s.io/kubernetes v1.18.9/go.mod h1:1uB7+7NGbXMLX7XOjMcXnk2Lc1v2J3NcBFDUTn1JkX8=
 k8s.io/kubernetes/staging/src/k8s.io/api v0.0.0-20190615005809-e8462b5b5dc2 h1:QL6koOuCIVuZykmePms3wYWWW7mYEuPQhFZbdm7naas=
 k8s.io/kubernetes/staging/src/k8s.io/api v0.0.0-20190615005809-e8462b5b5dc2/go.mod h1:rcBmQEBoKrTUCORrHN/yvdmJPQsGpCEL61sZkMpMX/8=
 k8s.io/kubernetes/staging/src/k8s.io/api v0.0.0-20200715165012-dff82dc0de47 h1:l/uxU4KK2L6u1whk4aoSloAOExfKH6byKLccAXlKanQ=
@@ -1034,6 +1036,7 @@ k8s.io/sample-controller v0.0.0-20190731144349-6f8905ae4ee5 h1:ea2vnvAbw4TFNz3/s
 k8s.io/sample-controller v0.0.0-20190731144349-6f8905ae4ee5/go.mod h1:2MhJKrmNXzVhvWtN8vzWei6Riv0ceIP7KPKePk+Wkh8=
 k8s.io/sample-controller v0.18.6 h1:Uz0m2EscQY6nhrtRCeHcNGE80EjQCSR95Le1OsudxyQ=
 k8s.io/sample-controller v0.18.6/go.mod h1:xn1exAmtuaxuIbp0+7c7Al7UYobXtspFzAfMYWDy/z0=
+k8s.io/sample-controller v0.18.9/go.mod h1:18MzCgLscoc8+1Dw+/tCdVOwQPLnXfo4h9RYB0RM638=
 k8s.io/system-validators v1.0.4/go.mod h1:HgSgTg4NAGNoYYjKsUyk52gdNi2PVDswQ9Iyn66R7NI=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da h1:ElyM7RPonbKnQqOcw7dG2IK5uvQQn3b/WPHqD5mBvP4=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=


### PR DESCRIPTION
**What this PR does / why we need it**:
This is one of 3 PR to address the `Minor versions should track Kubernetes minor versions` issue https://github.com/kubernetes/cloud-provider-vsphere/issues/277.

This PR addresses the Kubernetes 1.18 compatible version of the CPI.

**Which issue this PR fixes**: https://github.com/kubernetes/cloud-provider-vsphere/issues/277

**Special notes for your reviewer**:
Other than updating k8s references to 1.18.9, the backing CPI code is the same as the 1.2 release.

**Release note**:
NA