### PR TITLE
Add test for dual stack with internal/external subnet and fix for not discovering the ip when specify internal/external with ipv4/ipv6

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -403,6 +403,8 @@ func (nm *NodeManager) GetNode(UUID string, node *pb.Node) error {
 
 	for _, address := range nodeInfo.NodeAddresses {
 		switch address.Type {
+		case v1.NodeInternalIP:
+			node.Addresses = append(node.Addresses, address.Address)
 		case v1.NodeExternalIP:
 			node.Addresses = append(node.Addresses, address.Address)
 		case v1.NodeHostName:
@@ -466,6 +468,8 @@ func (nm *NodeManager) datacenterToNodeList(vmList map[string]*NodeInfo, nodeLis
 		}
 		for _, address := range node.NodeAddresses {
 			switch address.Type {
+			case v1.NodeInternalIP:
+				pbNode.Addresses = append(pbNode.Addresses, address.Address)
 			case v1.NodeExternalIP:
 				pbNode.Addresses = append(pbNode.Addresses, address.Address)
 			case v1.NodeHostName:

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -187,7 +187,8 @@ func TestAlphaDualStack(t *testing.T) {
 
 	ipv4Ips := returnIPsFromSpecificFamily(vcfg.IPv4Family, ips)
 	size := len(ipv4Ips)
-	if size != 1 {
+	// size need to equal to 2, one for internal and one for external, in this case they are the same
+	if size != 2 {
 		t.Errorf("Should only return single IPv4 address. expected: 1, actual: %d", size)
 	} else if !strings.EqualFold(ipv4Ips[0], ipv4Ip) {
 		t.Errorf("IPv6 does not match. expected: %s, actual: %s", ipv4Ip, ipv4Ips[0])
@@ -195,7 +196,7 @@ func TestAlphaDualStack(t *testing.T) {
 
 	ipv6Ips := returnIPsFromSpecificFamily(vcfg.IPv6Family, ips)
 	size = len(ipv6Ips)
-	if size != 1 {
+	if size != 2 {
 		t.Errorf("Should only return single IPv6 address. expected: 1, actual: %d", size)
 	} else if !strings.EqualFold(ipv6Ips[0], ipv6Ip) {
 		t.Errorf("IPv6 does not match. expected: fd01:0:101:2609:bdd2:ee20:7bd7:5836, actual: %s", ipv6Ips[0])


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR adds additional tests for dual stack feature. Mainly for uses case with internal/external subnets
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
