### PR TITLE
remove latest tagging during releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ release: | $(DOCKER_SOCK)
 ################################################################################
 .PHONY: release-push
 release-push: | $(DOCKER_SOCK)
-	hack/release.sh -p -l
+	hack/release.sh -p
 
 ################################################################################
 ##                                  CI IMAGE                                  ##

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -36,7 +36,6 @@ readonly CPI_IMAGE_CI=${CPI_IMAGE_CI:-${BASE_IMAGE_REPO}/cpi/ci/manager}
 
 AUTH=
 PUSH=
-LATEST=
 CPI_IMAGE_NAME=
 VERSION=$(git describe --dirty --always 2>/dev/null)
 GCR_KEY_FILE="${GCR_KEY_FILE:-}"
@@ -66,8 +65,6 @@ FLAGS
   -h    show this help and exit
   -k    path to GCR key file. Used to login to registry if specified
         (defaults to: ${GCR_KEY_FILE})
-  -l    tag the images as \"latest\" in addition to their version
-        when used with -p, both tags will be pushed
   -p    push the images to the public container registry
   -t    the build/release type (defaults to: ${BUILD_RELEASE_TYPE})
         one of [ci,pr,release]
@@ -111,10 +108,6 @@ function build_images() {
     --build-arg "VERSION=${VERSION}" \
     --build-arg "GOPROXY=${GOPROXY}" \
     .
-  if [ "${LATEST}" ]; then
-    echo "tagging image ${CPI_IMAGE_NAME}:${VERSION} as latest"
-    docker tag "${CPI_IMAGE_NAME}:${VERSION}" "${CPI_IMAGE_NAME}:latest"
-  fi
 }
 
 function logout() {
@@ -141,10 +134,6 @@ function push_images() {
 
   echo "pushing ${CPI_IMAGE_NAME}:${VERSION}"
   docker push "${CPI_IMAGE_NAME}":"${VERSION}"
-  if [ "${LATEST}" ]; then
-    echo "also pushing ${CPI_IMAGE_NAME}:${VERSION} as latest"
-    docker push "${CPI_IMAGE_NAME}":latest
-  fi
 }
 
 function build_ccm_bin() {
@@ -166,16 +155,13 @@ function push_ccm_bin() {
 }
 
 # Start of main script
-while getopts ":hk:lpt:" opt; do
+while getopts ":hk:pt:" opt; do
   case ${opt} in
     h)
       error "${USAGE}" && exit 1
       ;;
     k)
       GCR_KEY_FILE="${OPTARG}"
-      ;;
-    l)
-      LATEST=1
       ;;
     p)
       PUSH=1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes a problem which a newly built release is always tagged as the latest, which causes confusion and it's error-prone for the alpha releases.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
