### PR TITLE
Upgrade kind version for integration tests

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -26,7 +26,7 @@ kind:
 	./install_kind.sh
 
 cluster-up: $(KIND_CONFIG) kind | $(DOCKER_SOCK)
-	kind create cluster --config "$(KIND_CONFIG)" --name "$(CLUSTER_NAME)"
+	kind create cluster --config "$(KIND_CONFIG)" --name "$(CLUSTER_NAME)" --kubeconfig "$(KUBECONFIG_ORIG)"
 ifeq (true,$(DOCKER_SOCK_FROM_HOST))
 	ipv4=$$(docker exec "$(CLUSTER_NAME)-control-plane" ip route get dev eth0 1 | awk '{print $$NF;exit}') && \
 	sed -e 's~server: .\{1,\}$$~server: https://'"$${ipv4}":6443'~g' <"$(KUBECONFIG_ORIG)" >"$(KUBECONFIG_DIND)"

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -52,7 +52,7 @@ delete-vcsim:
 	kubectl -n kube-system delete service vcsim
 
 deploy-ccm:
-	kubectl -n kube-system create configmap vsphere-cloud-config --from-file=vsphere.conf && \
+	kubectl -n kube-system create configmap cloud-config --from-file=vsphere.conf && \
 	kubectl -n kube-system create -f secrets.yaml && \
 	kubectl -n kube-system apply -f ../../manifests/controller-manager/cloud-controller-manager-roles.yaml && \
 	kubectl -n kube-system apply -f ../../manifests/controller-manager/cloud-controller-manager-role-bindings.yaml && \

--- a/test/integration/install_kind.sh
+++ b/test/integration/install_kind.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KIND_VERSION="v0.5.1"
+KIND_VERSION="v0.8.1"
 KIND_PATH="/usr/local/bin/kind"
 
 # Check if KIND already exists

--- a/test/vcsim/deployment.yaml
+++ b/test/vcsim/deployment.yaml
@@ -18,7 +18,7 @@ metadata:
   name: vcsim
   namespace: kube-system
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: vcsim
@@ -26,6 +26,9 @@ metadata:
 spec:
   serviceName: "vcsim"
   replicas: 1
+  selector:
+    matchLabels:
+      app: vcsim
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Integration tests have been broken, largely because we bumped the k8s.io/kubernetes version to v1.18 and our CI is running a really old version of Kind that doesn't support some of the APIs that k8s.io/kubernetes@v1.18 requires. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
