### PR TITLE
Remove NSX-T LB alpha feature gate

### DIFF
--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -211,19 +211,6 @@ func buildVSphereFromConfig(cfg *ccfg.CPIConfig, nsxtcfg *ncfg.Config, lbcfg *lc
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := os.LookupEnv("ENABLE_ALPHA_NSXT_LB"); ok {
-		if lb == nil {
-			klog.Warning("To enable NSX-T load balancer support you need to configure section LoadBalancer")
-		} else {
-			klog.Infof("NSX-T load balancer support enabled. This feature is alpha, use in production at your own risk.")
-			// redirect vapi logging from the NSX-T GO SDK to klog
-			log.SetLogger(NewKlogBridge())
-		}
-	} else {
-		// explicitly nil the LB interface if ENABLE_ALPHA_NSXT_LB is not set even if the LBConfig is valid
-		// ENABLE_ALPHA_NSXT_LB must be explicitly enabled
-		lb = nil
-	}
 
 	// add alpha dual stack feature
 	for tenant := range cfg.VirtualCenter {

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -17,7 +17,7 @@ limitations under the License.
 package vsphere
 
 import (
-	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -48,6 +48,9 @@ const (
 	ProviderName string = "vsphere"
 	// ClientName is the user agent passed into the controller client builder.
 	ClientName string = "vsphere-cloud-controller-manager"
+
+	// dualStackFeatureGateEnv is a required environment variable when enabling dual-stack nodes
+	dualStackFeatureGateEnv string = "ENABLE_ALPHA_DUAL_STACK"
 )
 
 func init() {
@@ -212,17 +215,15 @@ func buildVSphereFromConfig(cfg *ccfg.CPIConfig, nsxtcfg *ncfg.Config, lbcfg *lc
 		return nil, err
 	}
 
-	// add alpha dual stack feature
-	for tenant := range cfg.VirtualCenter {
-		if len(cfg.VirtualCenter[tenant].IPFamilyPriority) > 1 {
-			if _, ok := os.LookupEnv("ENABLE_ALPHA_DUAL_STACK"); !ok {
-				klog.Errorf("number of ip family provided for VCenter %s is 2, ENABLE_ALPHA_DUAL_STACK env var is not set", tenant)
-				return nil, errors.New("two IP families provided, but dual stack feature is not enabled")
-			}
-		}
+	routes, err := route.NewRouteProvider(routecfg, ncm.GetConnector())
+	if err != nil {
+		return nil, err
 	}
 
-	routes, err := route.NewRouteProvider(routecfg, ncm.GetConnector())
+	// redirect vapi logging from the NSX-T GO SDK to klog
+	log.SetLogger(NewKlogBridge())
+
+	err = validateDualStack(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -239,6 +240,23 @@ func buildVSphereFromConfig(cfg *ccfg.CPIConfig, nsxtcfg *ncfg.Config, lbcfg *lc
 		server:           server.NewServer(cfg.Global.APIBinding, nm),
 	}
 	return &vs, nil
+}
+
+// validateDualStack returns an error if dual-stack was configured but not enabled
+// using the alpha environment variable feature gate ENABLE_ALPHA_DUAL_STACK
+func validateDualStack(cfg *ccfg.CPIConfig) error {
+	_, dualStackEnabled := os.LookupEnv(dualStackFeatureGateEnv)
+	if dualStackEnabled {
+		return nil
+	}
+
+	for vcName, vcConfig := range cfg.VirtualCenter {
+		if len(vcConfig.IPFamilyPriority) > 1 {
+			return fmt.Errorf("mulitple IP families specified for virtual center %q but ENABLE_ALPHA_DUAL_STACK env var is not set", vcName)
+		}
+	}
+
+	return nil
 }
 
 func logout(vs *VSphere) {

--- a/pkg/cloudprovider/vsphere/cloud_test.go
+++ b/pkg/cloudprovider/vsphere/cloud_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	ccfg "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/config"
+	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
+)
+
+func Test_validateDualStack(t *testing.T) {
+	testcases := []struct {
+		name          string
+		gateEnabled   bool
+		cfg           *ccfg.CPIConfig
+		expectedError error
+	}{
+		{
+			name:        "config dual-stack, gate enabled",
+			gateEnabled: true,
+			cfg: &ccfg.CPIConfig{
+				Config: vcfg.Config{
+					VirtualCenter: map[string]*vcfg.VirtualCenterConfig{
+						"vcenter.local": {
+							IPFamilyPriority: []string{"v4", "v6"},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:        "config dual-stack, gate disabled",
+			gateEnabled: false,
+			cfg: &ccfg.CPIConfig{
+				Config: vcfg.Config{
+					VirtualCenter: map[string]*vcfg.VirtualCenterConfig{
+						"vcenter.local": {
+							IPFamilyPriority: []string{"v4", "v6"},
+						},
+					},
+				},
+			},
+			expectedError: fmt.Errorf("mulitple IP families specified for virtual center %q but ENABLE_ALPHA_DUAL_STACK env var is not set", "vcenter.local"),
+		},
+		{
+			name:        "config single-stack, gate enabled",
+			gateEnabled: true,
+			cfg: &ccfg.CPIConfig{
+				Config: vcfg.Config{
+					VirtualCenter: map[string]*vcfg.VirtualCenterConfig{
+						"vcenter.local": {
+							IPFamilyPriority: []string{"v4"},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:        "config single-stack, gate disabled",
+			gateEnabled: false,
+			cfg: &ccfg.CPIConfig{
+				Config: vcfg.Config{
+					VirtualCenter: map[string]*vcfg.VirtualCenterConfig{
+						"vcenter.local": {
+							IPFamilyPriority: []string{"v4"},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:        "config default, gate enabled",
+			gateEnabled: true,
+			cfg: &ccfg.CPIConfig{
+				Config: vcfg.Config{
+					VirtualCenter: map[string]*vcfg.VirtualCenterConfig{
+						"vcenter.local": {
+							IPFamilyPriority: []string{"v4"},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:        "config default, gate disabled",
+			gateEnabled: false,
+			cfg: &ccfg.CPIConfig{
+				Config: vcfg.Config{
+					VirtualCenter: map[string]*vcfg.VirtualCenterConfig{
+						"vcenter.local": {
+							IPFamilyPriority: []string{"v4"},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			if testcase.gateEnabled {
+				if err := os.Setenv(dualStackFeatureGateEnv, "true"); err != nil {
+					t.Fatalf("failed to set ENABLE_ALPHA_DUAL_STACK: %v", err)
+				}
+
+				defer os.Unsetenv(dualStackFeatureGateEnv)
+			}
+
+			err := validateDualStack(testcase.cfg)
+			if !reflect.DeepEqual(err, testcase.expectedError) {
+				t.Logf("actual error: %v", err)
+				t.Logf("expected error: %v", err)
+				t.Error("unexpected error")
+			}
+		})
+	}
+}

--- a/pkg/cloudprovider/vsphere/route/config/config.go
+++ b/pkg/cloudprovider/vsphere/route/config/config.go
@@ -18,21 +18,9 @@ package config
 
 import (
 	"fmt"
-	"os"
 
 	klog "k8s.io/klog/v2"
 )
-
-// FromEnv initializes the provided configuration object with values
-// obtained from environment variables. If an environment variable is set
-// for a property that's already initialized, the environment variable's value
-// takes precedence.
-func (cfg *RouteConfig) FromEnv() error {
-	if v := os.Getenv("NSXT_ROUTER_PATH"); v != "" {
-		cfg.RouterPath = v
-	}
-	return nil
-}
 
 /*
 	TODO:
@@ -57,11 +45,6 @@ func ReadRouteConfig(configData []byte) (*Config, error) {
 		klog.Info("ReadConfig INI succeeded. Route INI-based cloud-config is deprecated and will be removed in 2.0. Please use YAML based cloud-config.")
 	} else {
 		klog.Info("ReadRouteConfig YAML succeeded")
-	}
-
-	// Env Vars should override config file entries if present
-	if err := cfg.Route.FromEnv(); err != nil {
-		return nil, err
 	}
 
 	klog.Info("Route Config initialized")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Removes the NSX-T LB alpha feature gate. This feature has been in use by some folks for a while now and vetted enough to not require an alpha feature gate. Use of the feature still requires opt-in via configuration but the feature gate is probably not warranted. 

Also removes the ability to configure NSX-T routes via env vars. This wasn't supported for NSX-T LBs and given almost all users use configuration files I think it's safe to remove.

This PR also refactors the dual-stack validation logic and adds some tests.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Remove NSX-T LB alpha env var feature gate
```
