### PR TITLE
Change the providerID Prefix of vsphere-paravirtual to 'vsphere'

### DIFF
--- a/cmd/vsphere-cloud-controller-manager/main.go
+++ b/cmd/vsphere-cloud-controller-manager/main.go
@@ -93,11 +93,11 @@ func main() {
 			// Default to the vsphere cloud provider if not set
 			cloudProviderFlag := cmd.Flags().Lookup("cloud-provider")
 			if cloudProviderFlag.Value.String() == "" {
-				cloudProviderFlag.Value.Set(vsphere.ProviderName)
+				cloudProviderFlag.Value.Set(vsphere.RegisteredProviderName)
 			}
 
 			cloudProvider := cloudProviderFlag.Value.String()
-			if cloudProvider != vsphere.ProviderName && cloudProvider != vsphereparavirtual.ProviderName {
+			if cloudProvider != vsphere.RegisteredProviderName && cloudProvider != vsphereparavirtual.RegisteredProviderName {
 				klog.Fatalf("unknown cloud provider %s, only 'vsphere' and 'vsphere-paravirtual' are supported", cloudProvider)
 			}
 
@@ -174,8 +174,8 @@ func main() {
 	// Set cloud-provider flag to vsphere
 	command.Flags().VisitAll(func(flag *pflag.Flag) {
 		if flag.Name == "cloud-provider" {
-			flag.Value.Set(vsphere.ProviderName)
-			flag.DefValue = vsphere.ProviderName
+			flag.Value.Set(vsphere.RegisteredProviderName)
+			flag.DefValue = vsphere.RegisteredProviderName
 			return
 		}
 	})

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -43,9 +43,13 @@ import (
 )
 
 const (
-	// ProviderName is the name of the cloud provider registered with
+	// RegisteredProviderName is the name of the cloud provider registered with
 	// Kubernetes.
+	RegisteredProviderName string = "vsphere"
+
+	// ProviderName is the name used for constructing Provider ID
 	ProviderName string = "vsphere"
+
 	// ClientName is the user agent passed into the controller client builder.
 	ClientName string = "vsphere-cloud-controller-manager"
 
@@ -54,7 +58,7 @@ const (
 )
 
 func init() {
-	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+	cloudprovider.RegisterCloudProvider(RegisteredProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		byConfig, err := ioutil.ReadAll(config)
 		if err != nil {
 			klog.Errorf("ReadAll failed: %s", err)

--- a/pkg/cloudprovider/vsphere/util.go
+++ b/pkg/cloudprovider/vsphere/util.go
@@ -28,7 +28,7 @@ import (
 const (
 	// ProviderPrefix is the Kubernetes cloud provider prefix for this
 	// cloud provider.
-	ProviderPrefix = "vsphere://"
+	ProviderPrefix = ProviderName + "://"
 
 	// MinUUIDLen is the min length for a valid UUID
 	MinUUIDLen int = 36

--- a/pkg/cloudprovider/vsphereparavirtual/cloud.go
+++ b/pkg/cloudprovider/vsphereparavirtual/cloud.go
@@ -32,10 +32,14 @@ import (
 )
 
 const (
-	// ProviderName is the name of the cloud provider registered with
+	// RegisteredProviderName is the name of the cloud provider registered with
 	// Kubernetes.
-	ProviderName string = "vsphere-paravirtual"
-	clientName   string = "vsphere-paravirtual-cloud-controller-manager"
+	RegisteredProviderName string = "vsphere-paravirtual"
+
+	// ProviderName is the name used for constructing Provider ID
+	ProviderName string = "vsphere"
+
+	clientName string = "vsphere-paravirtual-cloud-controller-manager"
 
 	// CloudControllerManagerNS is the namespace for vsphere paravirtual cluster cloud provider
 	CloudControllerManagerNS = "vmware-system-cloud-provider"
@@ -47,7 +51,7 @@ var (
 )
 
 func init() {
-	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+	cloudprovider.RegisterCloudProvider(RegisteredProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		if config == nil {
 			return nil, errors.New("no vSphere paravirtual cloud provider config file given")
 		}
@@ -166,6 +170,9 @@ func (cp *VSphereParavirtual) Routes() (cloudprovider.Routes, bool) {
 }
 
 // ProviderName returns the cloud provider ID.
+// Note: Returns 'vsphere' instead of 'vsphere-paravirtual'
+// since CAPV expects the ProviderID to be in form 'vsphere://***'
+// https://github.com/kubernetes/cloud-provider-vsphere/issues/447
 func (cp *VSphereParavirtual) ProviderName() string {
 	return ProviderName
 }

--- a/pkg/cloudprovider/vsphereparavirtual/instances.go
+++ b/pkg/cloudprovider/vsphereparavirtual/instances.go
@@ -44,6 +44,8 @@ type instances struct {
 }
 
 const (
+	// providerPrefix is the Kubernetes cloud provider prefix for this
+	// cloud provider.
 	providerPrefix = ProviderName + "://"
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CAPV are expecting the providerID prefix to be `vsphere`. 
If using cloud-controller-manager with flag `vsphere-paravirtual`, the ProviderName is `vsphere-paravirtual` In cloud-provider https://github.com/kubernetes/cloud-provider/blob/2c911671bd3eeff09ec2e093a5544ed56dd7f06f/cloud.go#L114, it will construct providerID by using `ProviderName + ://`. Thus making ProviderPrefix `vsphere-paravirtual`. Cloud Provider machine_controller can't find corresponding node by using providerID


I didn't change this https://github.com/kubernetes/cloud-provider-vsphere/blob/master/pkg/cloudprovider/vsphereparavirtual/cloud.go#L37
because when starting it will register all CP and put their names into a map https://github.com/kubernetes/cloud-provider-vsphere/blob/master/cmd/vsphere-cloud-controller-manager/main.go#L100-L105

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/cloud-provider-vsphere/issues/447
**Special notes for your reviewer**:
*Note* testing manually now
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
