### PR TITLE
when nodes have multiple NICs, we need to go through all listed items before returning error.

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -355,7 +355,9 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 				break
 			}
 		}
+	}
 
+	if len(oVM.Guest.Net) > 0 {
 		if !foundInternal && !foundExternal {
 			return fmt.Errorf("unable to find suitable IP address for node %s with IP family %s", nodeID, ipFamily)
 		}

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -138,7 +138,7 @@ func TestDiscoverNodeWithMultiIFByName(t *testing.T) {
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
 	vm.Guest.HostName = strings.ToLower(vm.Name) // simulator.SearchIndex.FindByDnsName matches against the guest.hostName property
-	expected_ip := "10.10.108.12"
+	expectedIP := "10.10.108.12"
 	vm.Guest.Net = []vimtypes.GuestNicInfo{
 		{
 			Network: "test_k8s_tenant_c123",
@@ -149,7 +149,7 @@ func TestDiscoverNodeWithMultiIFByName(t *testing.T) {
 		{
 			Network: "test_k8s_tenant_c123",
 			IpAddress: []string{
-				expected_ip,
+				expectedIP,
 				"10.10.108.10",
 				"fe80::250:56ff:fe89:d2c7",
 			},
@@ -178,13 +178,13 @@ func TestDiscoverNodeWithMultiIFByName(t *testing.T) {
 	if nodeInfo, ok := nm.nodeNameMap[strings.ToLower(name)]; ok {
 		for _, adr := range nodeInfo.NodeAddresses {
 			if adr.Type == "InternalIP" {
-				if adr.Address != expected_ip {
-					t.Errorf("failed: InternalIP should be %v, not %v.", expected_ip, adr.Address)
+				if adr.Address != expectedIP {
+					t.Errorf("failed: InternalIP should be %v, not %v.", expectedIP, adr.Address)
 				}
 			}
 			if adr.Type == "ExternalIP" {
-				if adr.Address != expected_ip {
-					t.Errorf("failed: InternalIP should be %v, not %v.", expected_ip, adr.Address)
+				if adr.Address != expectedIP {
+					t.Errorf("failed: InternalIP should be %v, not %v.", expectedIP, adr.Address)
 				}
 			}
 		}

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -127,6 +127,72 @@ func TestDiscoverNodeByName(t *testing.T) {
 	}
 }
 
+func TestDiscoverNodeWithMultiIFByName(t *testing.T) {
+	cfg, ok := configFromEnvOrSim(true)
+	defer ok()
+
+	connMgr := cm.NewConnectionManager(cfg, nil, nil)
+	defer connMgr.Logout()
+
+	nm := newNodeManager(nil, connMgr)
+
+	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	vm.Guest.HostName = strings.ToLower(vm.Name) // simulator.SearchIndex.FindByDnsName matches against the guest.hostName property
+	expected_ip := "10.10.108.12"
+	vm.Guest.Net = []vimtypes.GuestNicInfo{
+		{
+			Network: "test_k8s_tenant_c123",
+			IpAddress: []string{
+				"fe80::250:56ff:fe89:d2c7",
+			},
+		},
+		{
+			Network: "test_k8s_tenant_c123",
+			IpAddress: []string{
+				expected_ip,
+				"10.10.108.10",
+				"fe80::250:56ff:fe89:d2c7",
+			},
+		},
+	}
+	name := vm.Name
+
+	err := connMgr.Connect(context.Background(), connMgr.VsphereInstanceMap[cfg.Global.VCenterIP])
+	if err != nil {
+		t.Errorf("Failed to Connect to vSphere: %s", err)
+	}
+
+	err = nm.DiscoverNode(name, cm.FindVMByName)
+	if err != nil {
+		t.Errorf("Failed DiscoverNode: %s", err)
+	}
+
+	if len(nm.nodeNameMap) != 1 {
+		t.Errorf("Failed: nodeNameMap should be a length of 1")
+	}
+
+	if len(nm.nodeUUIDMap) != 1 {
+		t.Errorf("Failed: nodeUUIDMap should be a length of  1")
+	}
+
+	if nodeInfo, ok := nm.nodeNameMap[strings.ToLower(name)]; ok {
+		for _, adr := range nodeInfo.NodeAddresses {
+			if adr.Type == "InternalIP" {
+				if adr.Address != expected_ip {
+					t.Errorf("failed: InternalIP should be %v, not %v.", expected_ip, adr.Address)
+				}
+			}
+			if adr.Type == "ExternalIP" {
+				if adr.Address != expected_ip {
+					t.Errorf("failed: InternalIP should be %v, not %v.", expected_ip, adr.Address)
+				}
+			}
+		}
+	} else {
+		t.Errorf("failed: %v not found", name)
+	}
+}
+
 func TestExport(t *testing.T) {
 	cfg, ok := configFromEnvOrSim(true)
 	defer ok()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
when nodes have multiple NICs (oVM.Guest.Net has two or more items) ,  current node manager won't go through all of them, and return error immediately if the first net object doesn't have the correct IP.

instead, node manager need to continue until it either exhausts oVM.Guest.Net or find the internal/external ips.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/450

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
