### PR TITLE
Add docs for providing release version matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,8 @@ If you find a bug or a feature request related to cloud-provider-vsphere you can
 * [Slack](https://kubernetes.slack.com/messages/sig-vmware)
 * [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-vmware)
 * Please check the [sig-vmware community page](https://github.com/kubernetes/community/blob/2213de9ac19324422c781549541c25d90e9729e9/sig-vmware/README.md) for meeting times and more details.
+
+## More about CCM
+
+* [Concepts Underlying the Cloud Controller Manager](https://kubernetes.io/docs/concepts/architecture/cloud-controller/)
+* [Developing Cloud Controller Manager](https://kubernetes.io/docs/tasks/administer-cluster/developing-cloud-controller-manager/)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ This project replaces the deprecated in-tree vSphere cloud provider located with
 
 There is ongoing work for refactoring cloud providers out of the upstream repository. For more details, please check [this KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md).
 
+## Compatibility with Kubernetes
+
+The vSphere cloud provider is released with a specific semantic version `MAJOR.MINOR.PATCH` that correlates with the Kubernetes upstream version. Compatibility with a new Kubernetes version requires upgrading existing cloud provider components since compatibility is ONLY guaranteed between a specific release and its corresponding Kubernetes version.
+
+In the future, the major and minor versions of releases should be equivalent to the compatible upstream Kubernetes release, and the patch version is used for bug fixes pertaining to specific Kubernetes releases. See [the external cloud provider versioning KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cloud-provider/1771-versioning-policy-for-external-cloud-providers) for more details.
+
+Version matrix:
+
+| Kubernetes Version | vSphere Cloud Provider Release Version | Cloud Provider Branch |
+| ----------- | ----------- | ----------- |
+| v1.20.X | v1.20.X | release-1.20 |
+| v1.19.X | v1.19.X | release-1.19 |
+| v1.18.X | v1.18.X | release-1.18 |
+
 ## Quickstart
 
 Get started with Cloud controller manager for vSphere with Kubeadm with this [quickstart](https://cloud-provider-vsphere.sigs.k8s.io/tutorials/kubernetes-on-vsphere-with-kubeadm.html).


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add docs for providing release version matrix among Kubernetes Version, vSphere Cloud Provider Release Version and Cloud Provider Branch

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/457

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
