### PR TITLE
when nodes have multiple NICs, we need to go through all listed items before returning error

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -355,7 +355,9 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 				break
 			}
 		}
+	}
 
+	if len(oVM.Guest.Net) > 0 {
 		if !foundInternal && !foundExternal {
 			return fmt.Errorf("unable to find suitable IP address for node %s with IP family %s", nodeID, ipFamily)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR cherry-picks  a04551953ec1c854358f5bad1ab4ce10f06818c3. ce85bea3cb39de7e2aedd485e9caca42706e24d3 and 649912ca4e9d340ee7d3c6ae35873ef5fb0997cd from release-1.19 and adds them to master.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes: https://github.com/kubernetes/cloud-provider-vsphere/issues/450

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
