### PR TITLE
Migrate the helm chart to /charts repo and update related docs

### DIFF
--- a/charts/vsphere-cpi/.helmignore
+++ b/charts/vsphere-cpi/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/vsphere-cpi/Chart.yaml
+++ b/charts/vsphere-cpi/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+appVersion: 1.21.0
+description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
+name: vsphere-cpi
+version: 0.2.3
+keywords:
+  - vsphere
+  - vmware
+  - cloud
+  - provider
+home: https://github.com/kubernetes/cloud-provider-vsphere
+icon: https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/docs/vmware_logo.png
+sources:
+  - https://github.com/kubernetes/cloud-provider-vsphere

--- a/charts/vsphere-cpi/README.md
+++ b/charts/vsphere-cpi/README.md
@@ -1,0 +1,134 @@
+# vSphere Cloud-Controler-Manager Helm Chart
+
+[vSphere Cloud Provider Interface](https://github.com/kubernetes/cloud-provider-vsphere) handles cloud specific functionality for VMware vSphere infrastructure running on Kubernetes.
+
+## Introduction
+
+This chart deploys all components required to run the external vSphere CPI as described on it's [GitHub page](https://github.com/kubernetes/cloud-provider-vsphere).
+
+## Prerequisites
+
+- Has been tested on Kubernetes 1.13.X+
+- Assumes your Kubernetes cluster has been configured to use the external cloud provider. Please take a look at configuration guidelines located in the [Kubernetes documentation](https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager).
+
+## Installing the Chart using Helm 3.0+
+
+[The Github project of Helm chart repositories](https://github.com/helm/charts) is now an archive and no longer under active development since Nov 13, 2020. For more information, see the [Helm Charts Deprecation and Archive Notice](https://github.com/helm/charts#%EF%B8%8F-deprecation-and-archive-notice), and [Update](https://helm.sh/blog/charts-repo-deprecation/).
+
+To add the Helm Stable Charts for cloud-provider-vsphere, you can run the following command:
+
+```bash
+helm repo add vsphere-cpi https://kubernetes.github.io/cloud-provider-vsphere
+helm repo update
+```
+
+See [help repo](https://helm.sh/docs/helm/helm_repo/) for command documentation.
+
+Then to install the chart and by providing vCenter information/credentials, run the following command:
+
+```bash
+helm install vsphere-cpi vsphere-cpi/vsphere-cpi --namespace kube-system --set config.enabled=true --set config.vcenter=<vCenter IP> --set config.username=<vCenter Username> --set config.password=<vCenter Password> --set config.datacenter=<vCenter Datacenter>
+```
+
+See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation.
+
+> **Tip**: List all releases using `helm list --all`
+
+If you want to provide your own `vsphere.conf` and Kubernetes secret `vsphere-cpi` (for example, to handle multple datacenters/vCenters or for using zones), you can learn more about the `vsphere.conf` and `vsphere-cpi` secret by reading the following [documentation](https://cloud-provider-vsphere.sigs.k8s.io/tutorials/kubernetes-on-vsphere-with-kubeadm.html) and then running the following command:
+
+```bash
+helm install vsphere-cpi vsphere-cpi/vsphere-cpi --namespace kube-system
+```
+
+## Installing the Chart using Helm 2.X
+
+To install this chart with the release name `vsphere-cpi` and by providing a vCenter information/credentials, run the following command:
+
+```bash
+helm install vsphere-cpi/vsphere-cpi --name vsphere-cpi --namespace kube-system --set config.enabled=true --set config.vcenter=<vCenter IP> --set config.username=<vCenter Username> --set config.password=<vCenter Password> --set config.datacenter=<vCenter Datacenter>
+```
+
+If you provide your own `vsphere.conf` and Kubernetes secret `vsphere-cpi`, then deploy the chart running the following command:
+
+```bash
+helm install vsphere-cpi/vsphere-cpi --name vsphere-cpi --namespace kube-system
+```
+
+## Uninstalling the Chart
+
+Note: `helm delete` command has been renamed to `helm uninstall`.
+
+To uninstall/delete the `vsphere-cpi` deployment:
+
+```bash
+# Helm 2
+$ helm delete vsphere-cpi --namespace kube-system
+
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation.
+
+> **Tip**: To permanently remove the release using Helm v2.X, run `helm delete --purge vsphere-cpi --namespace kube-system`
+
+## Configuration
+
+The following table lists the configurable parameters of the vSphere CPI chart and their default values.
+
+|             Parameter                    |            Description              |                  Default               |
+|------------------------------------------|-------------------------------------|----------------------------------------|
+| `podSecurityPolicy.enabled`              | Enable pod sec policy (k8s > 1.17)  |  true                                  |
+| `podSecurityPolicy.annotations`          | Annotations for pd sec policy       |  nil                                   |
+| `securityContext.enabled`                | Enable sec context for container    |  false                                 |
+| `securityContext.runAsUser`              | RunAsUser. Default is `nobody` in   |  1001                                 |
+|                                          |    distroless image                 |                                        |
+| `securityContext.fsGroup`                | FsGroup. Default is `nobody` in     |  1001                                 |
+|                                          |    distroless image                 |                                        |
+| `config.enabled`                         | Create a simple single VC config    |  false                                 |
+| `config.vcenter`                         | FQDN or IP of vCenter               |  vcenter.local                         |
+| `config.username`                        | vCenter username                    |  user                                  |
+| `config.password`                        | vCenter password                    |  pass                                  |
+| `config.datacenter`                      | Datacenters within the vCenter      |  dc                                    |
+| `rbac.create`                            | Create roles and role bindings      |  true                                  |
+| `serviceAccount.create`                  | Create the service account          |  true                                  |
+| `serviceAccount.name`                    | Name of the created service account |  cloud-controller-manager              |
+| `daemonset.annotations`                  | Annotations for CPI pod             |  nil                                   |
+| `daemonset.image`                        | Image for vSphere CPI               |  gcr.io/cloud-provider-vsphere/        |
+|                                          |                                     |       vsphere-cloud-controller-manager |
+| `daemonset.tag`                          | Tag for vSphere CPI                 |  latest                                |
+| `daemonset.pullPolicy`                   | CPI image pullPolicy                |  IfNotPresent                          |
+| `daemonset.dnsPolicy`                    | CPI dnsPolicy                       |  ClusterFirst                          |
+| `daemonset.cmdline.logging`              | Logging level                       |  2                                     |
+| `daemonset.cmdline.cloudConfig.dir`      | vSphere conf directory              |  /etc/cloud                            |
+| `daemonset.cmdline.cloudConfig.file`     | vSphere conf filename               |  vsphere.conf                          |
+| `daemonset.replicaCount`                 | Node resources                      | `[]`                                   |
+| `daemonset.resources`                    | Node resources                      | `[]`                                   |
+| `daemonset.podAnnotations`               | Annotations for CPI pod             |  nil                                   |
+| `daemonset.podLabels`                    | Labels for CPI pod                  |  nil                                   |
+| `daemonset.nodeSelector`                 | User-defined node selectors         |  nil                                   |
+| `daemonset.tolerations`                  | User-defined tolerations            |  nil                                   |
+| `service.enabled`                        | Enabled the CPI API endpoint        |  false                                 |
+| `service.annotations`                    | Annotations for API service         |  nil                                   |
+| `service.type`                           | Service type                        |  ClusterIP                             |
+| `service.loadBalancerSourceRanges`       | list of IP CIDRs allowed access     | `[]`                                   |
+| `service.endpointPort`                   | External accessible port            |  43001                                 |
+| `service.targetPort`                     | Internal API port                   |  43001                                 |
+| `ingress.enabled`                        | Allow external traffic access       |  false                                 |
+| `ingress.annotations`                    | Annotations for Ingress             |  nil                                   |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install` using Helm v3.X. For example,
+
+```bash
+$ helm install vsphere-cpi \
+    stable/vsphere-cpi \
+    --set daemonset.pullPolicy=Always
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart.
+
+### Image tags
+
+vSphere CPI offers a multitude of [tags](https://github.com/kubernetes/cloud-provider-vsphere/releases) for the various components used in this chart.

--- a/charts/vsphere-cpi/templates/NOTES.txt
+++ b/charts/vsphere-cpi/templates/NOTES.txt
@@ -1,0 +1,27 @@
+The vSphere Cloud Controller Manager API over gRPC exists at the following location:
+
+{{- if not .Values.service.enabled }}
+
+  vSphere CPI API is disabled
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "cpi.fullname" . }}-query)
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo h$NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "sphere-cpi.fullname" . }}-query'
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "sphere-cpi.fullname" . }}-query -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo $SERVICE_IP:50051
+
+{{- else if contains "ClusterIP"  .Values.service.type }}
+
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "release={{ .Release.Name }},component=cloud-controller-manager" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:8080/
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 43001:43001
+
+{{- end }}

--- a/charts/vsphere-cpi/templates/_helpers.tpl
+++ b/charts/vsphere-cpi/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cpi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec)
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cpi.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a fully qualified daemonset name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cpi.daemonset.name" -}}
+{{- $nameGlobalOverride := printf "%s-daemonset" (include "cpi.fullname" .) -}}
+{{- if .Values.daemonset.fullnameOverride -}}
+{{- printf "%s" .Values.daemonset.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $nameGlobalOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "api.binding" -}}
+{{- printf ":%.0f" .Values.service.endpointPort | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Configure list of IP CIDRs allowed access to load balancer (if supported)
+*/}}
+{{- define "loadBalancerSourceRanges" -}}
+{{- if .service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .service.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/vsphere-cpi/templates/common.yaml
+++ b/charts/vsphere-cpi/templates/common.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cpi.fullname" . }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: common-configmap
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller-manager
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  api.binding: "{{ template "api.binding" . }}"

--- a/charts/vsphere-cpi/templates/configmap.yaml
+++ b/charts/vsphere-cpi/templates/configmap.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.config.enabled | default .Values.global.config.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-config
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: cloud-config
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  vsphere.conf: |
+    # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+    global:
+      port: 443
+      # set insecure-flag to true if the vCenter uses a self-signed cert
+      insecureFlag: true
+      # settings for using k8s secret
+      secretName: vsphere-cpi
+      secretNamespace: {{ .Release.Namespace }}
+
+    # VirtualCenter section
+    vcenter:
+      {{ .Release.Name }}:
+        server: {{ .Values.config.vcenter | default .Values.global.config.vcenter }}
+        datacenters:
+          - {{ .Values.config.datacenter | default .Values.global.config.datacenter }}
+{{- end -}}

--- a/charts/vsphere-cpi/templates/daemonset.yaml
+++ b/charts/vsphere-cpi/templates/daemonset.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "cpi.name" . }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: daemonset
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller-manager
+    tier: control-plane
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+    {{- if .Values.daemonset.annotations }}
+    {{- toYaml .Values.daemonset.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "cpi.name" . }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      {{- if .Values.daemonset.podAnnotations }}
+      annotations:
+      {{- toYaml .Values.daemonset.podAnnotations | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ template "cpi.name" . }}
+        component: cloud-controller-manager
+        tier: control-plane
+        release: {{ .Release.Name }}
+        vsphere-cpi-infra: daemonset
+        {{- if .Values.daemonset.podLabels }}
+        {{- toYaml .Values.daemonset.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      {{- if .Values.daemonset.nodeSelector }}
+      {{- toYaml .Values.daemonset.nodeSelector | nindent 8 }}
+      {{- end }}
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
+        effect: NoSchedule
+        operator: Exists
+      {{- if .Values.daemonset.tolerations }}
+      {{- toYaml .Values.daemonset.tolerations | nindent 6 }}
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- end }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      hostNetwork: true
+      dnsPolicy: {{ .Values.daemonset.dnsPolicy }}
+      containers:
+      - name: {{ template "cpi.name" . }}
+        image: {{ .Values.daemonset.image }}:{{ .Values.daemonset.tag }}
+        imagePullPolicy: {{ .Values.daemonset.pullPolicy }}
+        args:
+          - --cloud-provider=vsphere
+          - --v={{ .Values.daemonset.cmdline.logging }}
+          - --cloud-config={{ .Values.daemonset.cmdline.cloudConfig.dir }}/{{ .Values.daemonset.cmdline.cloudConfig.file }}
+          {{- range $key, $value := .Values.daemonset.cmdline.additionalParams }}
+          - --{{ $key }}{{ if $value }}={{ $value }}{{ end }}
+          {{- end }}
+        {{- if .Values.service.enabled }}
+        env:
+          - name: VSPHERE_API_DISABLE
+            value: "true"
+          - name: VSPHERE_API_BINDING
+            valueFrom:
+              configMapKeyRef:
+                name: {{ template "cpi.fullname" . }}
+                key: api.binding
+        ports:
+        - containerPort: {{ .Values.service.endpointPort }}
+          protocol: TCP
+        {{- end }}
+        volumeMounts:
+          - mountPath: {{ .Values.daemonset.cmdline.cloudConfig.dir }}
+            name: vsphere-config-volume
+            readOnly: true
+        {{- if .Values.daemonset.resources }}
+        resources:
+          {{- toYaml .Values.daemonset.resources | nindent 10 }}
+        {{- end }}
+      volumes:
+        - name: vsphere-config-volume
+          configMap:
+            name: cloud-config

--- a/charts/vsphere-cpi/templates/ingress.yaml
+++ b/charts/vsphere-cpi/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "cpi.name" . }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: ingress
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.ingress.annotations }}
+  annotations:
+  {{- toYaml .Values.ingress.annotations | indent 4 }}
+  {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "cpi.name" $ }}
+              servicePort: {{ .Values.service.endpointPort }}
+    {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+  {{- toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/vsphere-cpi/templates/podsecuritypolicy.yaml
+++ b/charts/vsphere-cpi/templates/podsecuritypolicy.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "cpi.name" . }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: pod-security-policy
+    component: cloud-controller-manager
+    release: {{ .Release.Name }}
+  {{- if .Values.podSecurityPolicy.annotations }}
+  annotations:
+  {{- toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
+  {{- end }}
+spec:
+  allowPrivilegeEscalation: false
+  privileged: false
+  volumes:
+    - 'configMap'
+    - 'secret'
+    - 'emptyDir'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.securityContext.runAsUser }}
+        max: {{ .Values.securityContext.runAsUser }}
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: {{ .Values.securityContext.runAsUser }}
+        max: {{ .Values.securityContext.runAsUser }}
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+  requiredDropCapabilities:
+    - ALL
+{{- end }}

--- a/charts/vsphere-cpi/templates/role-binding.yaml
+++ b/charts/vsphere-cpi/templates/role-binding.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.rbac.create -}}
+apiVersion: v1
+kind: List
+metadata: {}
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: servicecatalog.k8s.io:apiserver-authentication-reader
+    labels:
+      app: {{ template "cpi.name" . }}
+      vsphere-cpi-infra: role-binding
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      component: cloud-controller-manager
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: extension-apiserver-authentication-reader
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+  - apiGroup: ""
+    kind: User
+    name: {{ .Values.serviceAccount.name }}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: {{ .Values.serviceAccount.name }}
+    labels:
+      app: {{ template "cpi.name" . }}
+      vsphere-cpi-infra: cluster-role-binding
+      chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      component: cloud-controller-manager
+      heritage: {{ .Release.Service }}
+      release: {{ .Release.Name }}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: {{ .Values.serviceAccount.name }}
+  subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}
+  - kind: User
+    name: {{ .Values.serviceAccount.name }}
+{{- end -}}

--- a/charts/vsphere-cpi/templates/role.yaml
+++ b/charts/vsphere-cpi/templates/role.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: role
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller-manager
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{- end -}}

--- a/charts/vsphere-cpi/templates/secret.yaml
+++ b/charts/vsphere-cpi/templates/secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.config.enabled | default .Values.global.config.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-cpi
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: secret
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller-manager
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+stringData:
+  {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.username: {{ .Values.config.username | default .Values.global.config.username }}
+  {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.password: {{ .Values.config.password | default .Values.global.config.password }}
+{{- end -}}

--- a/charts/vsphere-cpi/templates/service-account.yaml
+++ b/charts/vsphere-cpi/templates/service-account.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: service-account
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller-manager
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/vsphere-cpi/templates/service.yaml
+++ b/charts/vsphere-cpi/templates/service.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cpi.name" . }}
+  labels:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: service
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: cloud-controller-manager
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.service.annotations }}
+  annotations:
+  {{- toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
+spec:
+  ports:
+  - name: cpi-api
+    port: {{ .Values.service.endpointPort }}
+    protocol: TCP
+    targetPort: {{ .Values.service.targetPort }}
+  selector:
+    app: {{ template "cpi.name" . }}
+    vsphere-cpi-infra: service
+    component: cloud-controller-manager
+  type: {{ .Values.service.type }}
+{{- template "loadBalancerSourceRanges" .Values }}
+{{- end -}}

--- a/charts/vsphere-cpi/values.yaml
+++ b/charts/vsphere-cpi/values.yaml
@@ -1,0 +1,100 @@
+# Default values for vSphere CPI.
+# This is a YAML-formatted file.
+# vSohere CPI values are grouped by component
+
+global:
+  config:
+    enabled: false
+
+config:
+  enabled: false
+  vcenter: "vcenter.local"
+  username: "user"
+  password: "pass"
+  datacenter: "dc"
+
+## Specify if a Pod Security Policy for kube-state-metrics must be created
+## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+podSecurityPolicy:
+  enabled: false
+  annotations: {}
+    # Specify pod annotations
+    # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+    # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+    # Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+    #
+    # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
+    # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
+
+# Run containers to have security context. Default is 'nobody' (65534/65534) in distroless
+securityContext:
+  enabled: true
+  runAsUser: 1001
+  fsGroup: 1001
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  name: cloud-controller-manager
+
+daemonset:
+  annotations: {}
+  image: gcr.io/cloud-provider-vsphere/cpi/release/manager
+  tag: v1.21.0
+  pullPolicy: IfNotPresent
+  dnsPolicy: ClusterFirst
+  cmdline:
+    logging: 2
+    # Location of the cloud configmap to be mounted on the filesystem
+    cloudConfig:
+      dir: "/etc/cloud"
+      file: "vsphere.conf"
+    additionalParams: {}
+  replicaCount: 1
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #    cpu: 256m
+    #    memory: 128Mi
+  podAnnotations: {}
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+  ## Allows for the default selector to be replaced with user-defined ones
+  nodeSelector: {}
+  ## Allows for the default tolerations to be replaced with user-defined ones
+  tolerations: []
+
+service:
+  enabled: false
+  annotations: {}
+  type: ClusterIP
+  # List of IP ranges that are allowed to access the load balancer (if supported)
+  loadBalancerSourceRanges: []
+  # endpointPort: externally accessible port for UI and API
+  endpointPort: 43001
+  # targetPort: the internal port the UI and API are exposed on
+  targetPort: 43001
+
+ingress:
+  enabled: false
+  annotations: {}
+  # Used to create an Ingress record.
+  # hosts:
+  #   - chart-example.local
+  # annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local

--- a/docs/book/tutorials/kubernetes-on-vsphere-with-helm.md
+++ b/docs/book/tutorials/kubernetes-on-vsphere-with-helm.md
@@ -8,44 +8,39 @@ Review the comprehensive guide locate at [Deploying a Kubernetes Cluster on vSph
 
 ### Helm requirements
 
-The [Helm Chart for vSphere CPI](https://github.com/helm/charts/tree/master/stable/vsphere-cpi) has been tested and verified working using Helm v.2.16.X and v3.0.0+. It is highly recommended that Helm v3.0.0+ be used when deploying the Helm Chart for vSphere CPI. At any point should you have additional questions regarding Helm, please visit this website for the official [Helm documentation](https://helm.sh/docs/).
+[Helm charts](https://github.com/helm/charts) has been fully deprecated since Nov 13th 2020.
+
+The [Helm Chart for vSphere CPI](https://github.com/helm/charts/tree/master/stable/vsphere-cpi) has been moved to [this repo](https://github.com/kubernetes/cloud-provider-vsphere/tree/master/charts/stable/vsphere-cpi). It has been tested and verified working using Helm v.2.16.X and v3.0.0+. It is highly recommended that Helm v3.0.0+ be used when deploying the Helm Chart for vSphere CPI. At any point should you have additional questions regarding Helm, please visit this website for the official [Helm documentation](https://helm.sh/docs/).
 
 ## Setting up Helm
 
 Before you begin, all outlined steps below are carried out on the master node only.
 
-Download the [latest release](https://github.com/helm/helm/releases) of Helm appropriate for your platform. At the time of writing this Helm quickstart guide, the latest release is [v3.0.1](https://github.com/helm/helm/releases/tag/v3.0.1). It is highly recommended using Helm v3.0.0+ when deploying the Helm Chart for vSphere CPI.
+### Option 1: From the Binary Releases
 
-After the download is complete, unpack and install Helm v3.0.0.
+Download the [latest release](https://github.com/helm/helm/releases) of Helm appropriate for your platform. At the time of writing this Helm quickstart guide, the latest release is [v3.6.0](https://github.com/helm/helm/releases/tag/v3.6.0). It is highly recommended using Helm v3.0.0+ when deploying the Helm Chart for vSphere CPI.
+
+After the download is complete, unpack and install Helm v3.0.0+.
 
 ```bash
-# tar -zxvf helm-v3.0.1-linux-amd64.tgz
+# tar -zxvf helm-v3.6.0-linux-amd64.tgz
 # sudo mv linux-amd64/helm /usr/local/bin/helm
 ```
+
+### Option 2: From Script
+
+```bash
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+```
+
+See [Install Helm](https://helm.sh/docs/intro/install/) for more options.
 
 Verify that Helm installed successfully by running the following command:
 
 ```bash
-# helm help
-```
-
-For Helm v3.0.0+, we need to add the `stable` charts repo on Helm in order to consume those charts. This can be done by executing the following command:
-
-```bash
-# helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-"stable" has been added to your repositories
-# helm repo update
-Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "stable" chart repository
-Update Complete. ⎈ Happy Helming!⎈
-```
-
-You can verify access to the `stable` repo by search for the Helm chart for vSphere CPI.
-
-```bash
-# helm search repo vsphere-cpi
-NAME                CHART VERSION   APP VERSION     DESCRIPTION
-stable/vsphere-cpi  0.1.2           1.0.0           A Helm chart for vSphere Cloud Provider Interfa...
+helm help
 ```
 
 ### Check that all nodes are tainted
@@ -263,7 +258,8 @@ You may now remove the `vsphere.conf` file created at `/etc/kubernetes/`.
 To uninstall/delete the vsphere-cpi deployment:
 
 ```bash
-# helm delete vsphere-cpi
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
 ```
 
 You can delete the `configMap` and `secret` for the vSphere CPI if they are no longer needed.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
https://github.com/helm/charts has been fully deprecated since Nov 13th 2020. 
Migrate the helm chart for cloud-provider-vsphere inside /charts repo and update related docs.
Original repo: https://github.com/helm/charts/tree/master/stable/vsphere-cpi

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/436 and https://github.com/kubernetes/cloud-provider-vsphere/issues/480

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Migrate the helm chart for cloud-provider-vsphere inside /charts repo and update related docs.
```
