### PR TITLE
fix issue 485: panic error after not finding matching VM in k3s

### DIFF
--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -19,6 +19,7 @@ package vsphere
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	v1 "k8s.io/api/core/v1"
@@ -130,14 +131,20 @@ func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (st
 // InstanceType returns the type of the instance identified by name.
 func (i *instances) InstanceType(ctx context.Context, name types.NodeName) (string, error) {
 	klog.V(4).Info("instances.InstanceType() called")
-	return i.nodeManager.nodeNameMap[string(name)].NodeType, nil
+	if nodeInfo, ok := i.nodeManager.nodeNameMap[string(name)]; ok {
+		return nodeInfo.NodeType, nil
+	}
+	return "", fmt.Errorf("cannot find node with nodeName %s in nodeNameMap", name)
 }
 
 // InstanceTypeByProviderID returns the type of the instance identified by providerID.
 func (i *instances) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
 	klog.V(4).Info("instances.InstanceTypeByProviderID() called")
 	uid := GetUUIDFromProviderID(providerID)
-	return i.nodeManager.nodeUUIDMap[uid].NodeType, nil
+	if nodeInfo, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
+		return nodeInfo.NodeType, nil
+	}
+	return "", fmt.Errorf("cannot find node with providerID %s in nodeUUIDMap", providerID)
 }
 
 // AddSSHKeyToAllInstances is not implemented; it always returns an error.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/485

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix issue 485: panic error after not finding matching VM in k3s
```
