### PR TITLE
Support dualstack node IP discovery

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/vmware/govmomi/simulator"
 	vimtypes "github.com/vmware/govmomi/vim25/types"
+	ccfg "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/config"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -265,5 +266,860 @@ func TestReturnIPsFromSpecificFamily(t *testing.T) {
 		t.Errorf("Should only return single IPv4 address. expected: 1, actual: %d", size)
 	} else if !strings.EqualFold(ips[0], "10.161.34.192") {
 		t.Errorf("IPv6 does not match. expected: 10.161.34.192, actual: %s", ips[0])
+	}
+}
+
+func TestDiscoverNodeIPs(t *testing.T) {
+	type testSetup struct {
+		ipFamilyPriority []string
+		cpiConfig        *ccfg.CPIConfig
+		networks         []vimtypes.GuestNicInfo
+	}
+	testcases := []struct {
+		testName               string
+		setup                  testSetup
+		expectedIPs            []v1.NodeAddress
+		expectedErrorSubstring string
+	}{
+
+		{
+			testName: "BySubnet",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "10.10.0.0/16",
+						ExternalNetworkSubnetCIDR: "172.15.0.0/16",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+							"20.30.40.50",
+							"10.10.1.22",
+							"10.10.1.23",
+							"172.15.108.10",
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.1.22"},
+				{Type: "ExternalIP", Address: "172.15.108.10"},
+			},
+		},
+		{
+			testName: "ByNetworkName",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalVMNetworkName: "test_k8s_tenant_c123_internal",
+						ExternalVMNetworkName: "test_k8s_tenant_c123_external",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123_internal",
+						IpAddress: []string{
+							"127.0.0.6",
+							"10.10.1.22",
+							"10.10.1.23",
+						},
+					},
+					{
+						Network: "test_k8s_tenant_c123_external",
+						IpAddress: []string{
+							"127.0.0.7",
+							"172.15.108.10",
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.1.22"},
+				{Type: "ExternalIP", Address: "172.15.108.10"},
+			},
+		},
+		{
+			testName: "ByDefaultSelection",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+							"10.10.1.22",
+							"10.10.1.23",
+						},
+					},
+					{
+						Network: "test_another_nic",
+						IpAddress: []string{
+							"127.0.0.7",
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.1.22"},
+				{Type: "ExternalIP", Address: "10.10.1.22"},
+			},
+		},
+		{
+			testName: "BySubnetIPv6",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv6"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "fd00:cccc::/64",
+						ExternalNetworkSubnetCIDR: "fd00:bbbb::/64",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"fe80::1",
+							"fd00:aaaa::1",
+							"fd00:cccc::1",
+							"fd00:cccc::2",
+							"fd00:bbbb::1",
+							"fd00:bbbb::2",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "fd00:cccc::1"},
+				{Type: "ExternalIP", Address: "fd00:bbbb::1"},
+			},
+		},
+		{
+			testName: "ByNetworkNameIPv6",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv6"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalVMNetworkName: "internal_net",
+						ExternalVMNetworkName: "external_net",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"fe80::3",
+							"fd00:cccc::1",
+							"fd00:cccc::2",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"fe80::2",
+							"fd00:bbbb::1",
+							"fd00:bbbb::2",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "fd00:cccc::1"},
+				{Type: "ExternalIP", Address: "fd00:bbbb::1"},
+			},
+		},
+		{
+			testName: "ByDefaultSelectionIPv6",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv6"},
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"fe80::3",
+							"fd00:cccc::1",
+							"fd00:cccc::2",
+						},
+					},
+					{
+						Network: "test_another_nic",
+						IpAddress: []string{
+							"fe80::2",
+							"fd00:bbbb::1",
+							"fd00:bbbb::2",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "fd00:cccc::1"},
+				{Type: "ExternalIP", Address: "fd00:cccc::1"},
+			},
+		},
+		{
+			testName: "ByNetworkNameAndTwoNICs_desiredIPsAfterFirstNIC",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalVMNetworkName: "internal_net",
+						ExternalVMNetworkName: "external_net",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+							"169.0.1.2",
+						},
+					},
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"10.10.10.10",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.10.10"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+		{
+			// This seems like undesireable behavior.
+			testName: "BySubnetAndTwoNICs_desiredIPsAfterFirstNIC",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "10.10.0.0/16",
+						ExternalNetworkSubnetCIDR: "172.15.0.0/16",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+							"169.0.1.2",
+						},
+					},
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"10.10.1.22",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "169.0.1.2"},
+				{Type: "ExternalIP", Address: "169.0.1.2"},
+			},
+		},
+		{
+			testName: "BySubnetAndTwoNICs_desiredIPsAreSplitAcrossNICs",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "10.10.0.0/16",
+						ExternalNetworkSubnetCIDR: "172.15.0.0/16",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+							"169.0.1.2",
+							"10.10.1.22",
+						},
+					},
+					{
+						Network: "test_another_nic",
+						IpAddress: []string{
+							"127.0.0.7",
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.1.22"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+		{
+			testName: "BySubnet_whenExternalCIDRHasNoMatch_itReturnsOnlyInternalIP",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "10.10.0.0/16",
+						ExternalNetworkSubnetCIDR: "172.15.0.0/16",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+							"169.0.1.2",
+							"10.10.1.22",
+						},
+					},
+					{
+						Network: "test_another_nic",
+						IpAddress: []string{
+							"127.0.0.7",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.1.22"},
+			},
+		},
+		{
+			testName: "BySubnet_whenInternalCIDRHasNoMatch_itReturnsOnlyExternalIP",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "10.10.0.0/16",
+						ExternalNetworkSubnetCIDR: "172.15.0.0/16",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+							"169.0.1.2",
+							"172.15.108.11",
+						},
+					},
+					{
+						Network: "test_another_nic",
+						IpAddress: []string{
+							"127.0.0.7",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+		{
+			testName: "ByNetworkName_whenInternalNameHasNoMatch_itReturnsOnlyExternalIP",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalVMNetworkName: "no-matches",
+						ExternalVMNetworkName: "external_net",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+						},
+					},
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"10.10.5.8",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"172.15.2.3",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "ExternalIP", Address: "172.15.2.3"},
+			},
+		},
+		{
+			testName: "ByNetworkName_whenExternalNameHasNoMatch_itReturnsOnlyInternalIP",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalVMNetworkName: "internal_net",
+						ExternalVMNetworkName: "no-matches",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+						},
+					},
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"10.10.5.8",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"172.15.2.3",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.5.8"},
+			},
+		},
+		{
+			testName: "BySubnet_whenOnlyExternalCIDRIsSet_itReturnsOnlyExternalIP",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						ExternalNetworkSubnetCIDR: "172.15.0.0/16",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+							"20.30.40.50",
+							"10.10.1.22",
+							"10.10.1.23",
+							"172.15.108.10",
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "ExternalIP", Address: "172.15.108.10"},
+			},
+		},
+		{
+			testName: "BySubnet_whenOnlyInternalCIDRIsSet_itReturnsOnlyInternalIP",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "10.10.0.0/16",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+							"20.30.40.50",
+							"10.10.1.22",
+							"10.10.1.23",
+							"172.15.108.10",
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.1.22"},
+			},
+		},
+
+		{
+			testName: "BySubnet_selectsIgnoringCase",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalVMNetworkName: "InTerNal_NEt",
+						ExternalVMNetworkName: "ExTeRnAL_NeT",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"127.0.0.6",
+							"20.30.40.50",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"127.0.0.6",
+							"20.30.40.51",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "20.30.40.50"},
+				{Type: "ExternalIP", Address: "20.30.40.51"},
+			},
+		},
+		{
+			// Is this desirable behavior? It is going through the fallback behavior.
+			// The inverse of this case (ByNetwork_whenOnlyInternalNetworkIsSet_itReturnsOnlyInternalIP)
+			// has a different behavior, I would at least expect these two
+			// cases to have similar behavior. Note: this isn't because the
+			// InternalVMNetworkName acts diffferently from the
+			// ExternalVMNetworkName, but because of which NIC it is on.
+			testName: "ByNetwork_whenOnlyExternalNetworkIsSet_itReturnsOnlyExternalIP",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						ExternalVMNetworkName: "test_k8s_tenant_c123_external",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123_internal",
+						IpAddress: []string{
+							"127.0.0.6",
+							"10.10.1.22",
+							"10.10.1.23",
+						},
+					},
+					{
+						Network: "test_k8s_tenant_c123_external",
+						IpAddress: []string{
+							"127.0.0.7",
+							"172.15.108.10",
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.1.22"},
+				{Type: "ExternalIP", Address: "10.10.1.22"},
+			},
+		},
+		{
+			testName: "ByNetwork_whenOnlyInternalNetworkIsSet_itReturnsOnlyInternalIP",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalVMNetworkName: "test_k8s_tenant_c123_internal",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123_internal",
+						IpAddress: []string{
+							"127.0.0.6",
+							"10.10.1.22",
+							"10.10.1.23",
+						},
+					},
+					{
+						Network: "test_k8s_tenant_c123_external",
+						IpAddress: []string{
+							"127.0.0.7",
+							"172.15.108.10",
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.1.22"},
+			},
+		},
+		{
+			testName: "BySubnetAndNetworkNameTwoNICs_desiredIPsAreSplitAcrossNICs",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "10.10.0.0/16",
+						ExternalVMNetworkName:     "test_another_nic",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "test_k8s_tenant_c123",
+						IpAddress: []string{
+							"127.0.0.6",
+							"169.0.1.2",
+							"10.10.1.22",
+						},
+					},
+					{
+						Network: "test_another_nic",
+						IpAddress: []string{
+							"127.0.0.7",
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.1.22"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+		{
+			// This seems like undesireable behavior. The IPs that are returned
+			// depend on ordering within the NICs or which NIC they are on.
+			// There is no sensible precedence with the configuration.
+			testName: "BySettingBothNetworkNameAndSubnets_precedenceIsNotObvious",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "10.10.0.0/16",
+						ExternalNetworkSubnetCIDR: "172.15.0.0/16",
+						InternalVMNetworkName:     "internal_net",
+						ExternalVMNetworkName:     "external_net",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"22.22.22.22",
+							"172.15.108.11",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"33.33.33.33",
+							"10.10.1.22",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "22.22.22.22"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+		{
+			testName: "BySettingANetworkNameThatDoesntExist",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalVMNetworkName: "internal_net",
+						ExternalVMNetworkName: "external_net",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "net_a",
+						IpAddress: []string{
+							"10.10.1.22",
+						},
+					},
+					{
+						Network: "net_b",
+						IpAddress: []string{
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedErrorSubstring: "unable to find suitable IP address for node",
+		},
+		{
+			testName: "ByDefaultSelection_TheSecondNICHasNoIPs",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "net_a",
+						IpAddress: []string{
+							"172.15.108.11",
+						},
+					},
+					{
+						Network:   "net_b",
+						IpAddress: []string{},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "172.15.108.11"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+		{
+			testName: "ByDefaultSelection_TheFirstNICHasNoIPs",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network:   "net_a",
+						IpAddress: []string{},
+					},
+					{
+						Network: "net_b",
+						IpAddress: []string{
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "172.15.108.11"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+		{
+			testName: "ByDefaultSelection_TheFirstNICHasNoIPsOfTheDesiredFamily",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "net_a",
+						IpAddress: []string{
+							"fd00:cccc::1",
+						},
+					},
+					{
+						Network: "net_b",
+						IpAddress: []string{
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "172.15.108.11"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+		{
+			testName: "ByDefaultSelection_TheSecondNICHasNoIPsOfTheDesiredFamily",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "net_a",
+						IpAddress: []string{
+							"172.15.108.11",
+							"fe80:cccc::1",
+						},
+					},
+					{
+						Network: "net_b",
+						IpAddress: []string{
+							"fe80:cccc::2",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "172.15.108.11"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.testName, func(t *testing.T) {
+			cfg, fin := configFromEnvOrSim(true)
+			defer fin()
+
+			cfg.VirtualCenter[cfg.Global.VCenterIP].IPFamilyPriority = testcase.setup.ipFamilyPriority
+			connMgr := cm.NewConnectionManager(cfg, nil, nil)
+			defer connMgr.Logout()
+
+			nm := newNodeManager(testcase.setup.cpiConfig, connMgr)
+
+			vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+			vm.Guest.HostName = strings.ToLower(vm.Name) // simulator.SearchIndex.FindByDnsName matches against the guest.hostName property
+			vm.Guest.Net = testcase.setup.networks
+
+			name := vm.Name
+
+			err := connMgr.Connect(context.Background(), connMgr.VsphereInstanceMap[cfg.Global.VCenterIP])
+			if err != nil {
+				t.Errorf("Failed to Connect to vSphere: %s", err)
+			}
+
+			// subject
+			err = nm.DiscoverNode(name, cm.FindVMByName)
+			if testcase.expectedErrorSubstring != "" {
+				if err == nil {
+					t.Errorf("failed: expected DiscoverNode to return error containing: %q but no error occurred", testcase.expectedErrorSubstring)
+					return
+				}
+				if !strings.Contains(err.Error(), testcase.expectedErrorSubstring) {
+					t.Errorf("failed: expected DiscoverNode to return error containing: %q but was %q", testcase.expectedErrorSubstring, err.Error())
+				}
+				return
+			} else {
+				if err != nil {
+					t.Errorf("Failed DiscoverNode: %s", err)
+					return
+				}
+			}
+
+			nodeInfo, ok := nm.nodeNameMap[strings.ToLower(name)]
+			if !ok {
+				t.Errorf("failed: %v not found", name)
+			}
+
+			// hostname is always returned first, then the expected ips
+			expectations := append(
+				[]v1.NodeAddress{{Type: "Hostname", Address: strings.ToLower(vm.Name)}},
+				testcase.expectedIPs...,
+			)
+			if len(nodeInfo.NodeAddresses) != len(expectations) {
+				t.Errorf("failed: nodeInfo.NodeAddresses should be length %d but was %d", len(testcase.expectedIPs)+1, len(nodeInfo.NodeAddresses))
+			}
+			for i, nodeAddress := range expectations {
+				if nodeInfo.NodeAddresses[i].Address != nodeAddress.Address {
+					t.Errorf("failed: NodeAddresses[%d].Address should eq %q but was %q", i, nodeAddress.Address, nodeInfo.NodeAddresses[i].Address)
+				}
+				if nodeInfo.NodeAddresses[i].Type != nodeAddress.Type {
+					t.Errorf("failed: NodeAddresses[%d].Type should eq %q but was %q", i, nodeAddress.Type, nodeInfo.NodeAddresses[i].Type)
+				}
+			}
+		})
 	}
 }

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -294,7 +294,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 							"20.30.40.50",
@@ -317,13 +317,13 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				ipFamilyPriority: []string{"ipv4"},
 				cpiConfig: &ccfg.CPIConfig{
 					Nodes: ccfg.Nodes{
-						InternalVMNetworkName: "test_k8s_tenant_c123_internal",
-						ExternalVMNetworkName: "test_k8s_tenant_c123_external",
+						InternalVMNetworkName: "internal_net",
+						ExternalVMNetworkName: "external_net",
 					},
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123_internal",
+						Network: "internal_net",
 						IpAddress: []string{
 							"127.0.0.6",
 							"10.10.1.22",
@@ -331,7 +331,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 						},
 					},
 					{
-						Network: "test_k8s_tenant_c123_external",
+						Network: "external_net",
 						IpAddress: []string{
 							"127.0.0.7",
 							"172.15.108.10",
@@ -352,7 +352,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				cpiConfig:        nil,
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 							"10.10.1.22",
@@ -385,7 +385,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"fe80::1",
 							"fd00:aaaa::1",
@@ -443,7 +443,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				cpiConfig:        nil,
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"fe80::3",
 							"fd00:cccc::1",
@@ -477,7 +477,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 							"169.0.1.2",
@@ -503,7 +503,6 @@ func TestDiscoverNodeIPs(t *testing.T) {
 			},
 		},
 		{
-			// This seems like undesireable behavior.
 			testName: "BySubnetAndTwoNICs_desiredIPsAfterFirstNIC",
 			setup: testSetup{
 				ipFamilyPriority: []string{"ipv4"},
@@ -515,7 +514,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 							"169.0.1.2",
@@ -536,8 +535,8 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 			},
 			expectedIPs: []v1.NodeAddress{
-				{Type: "InternalIP", Address: "169.0.1.2"},
-				{Type: "ExternalIP", Address: "169.0.1.2"},
+				{Type: "InternalIP", Address: "10.10.1.22"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
 			},
 		},
 		{
@@ -552,7 +551,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 							"169.0.1.2",
@@ -585,7 +584,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 							"169.0.1.2",
@@ -616,7 +615,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 							"169.0.1.2",
@@ -647,7 +646,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 						},
@@ -682,7 +681,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 						},
@@ -716,7 +715,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 							"20.30.40.50",
@@ -743,7 +742,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 							"20.30.40.50",
@@ -793,23 +792,18 @@ func TestDiscoverNodeIPs(t *testing.T) {
 			},
 		},
 		{
-			// Is this desirable behavior? It is going through the fallback behavior.
-			// The inverse of this case (ByNetwork_whenOnlyInternalNetworkIsSet_itReturnsOnlyInternalIP)
-			// has a different behavior, I would at least expect these two
-			// cases to have similar behavior. Note: this isn't because the
-			// InternalVMNetworkName acts diffferently from the
-			// ExternalVMNetworkName, but because of which NIC it is on.
-			testName: "ByNetwork_whenOnlyExternalNetworkIsSet_itReturnsOnlyExternalIP",
+			testName: "ByNetworkName_whenOnlyExternalNetworkIsSet_onlyExternalNetIsSet",
 			setup: testSetup{
 				ipFamilyPriority: []string{"ipv4"},
 				cpiConfig: &ccfg.CPIConfig{
 					Nodes: ccfg.Nodes{
-						ExternalVMNetworkName: "test_k8s_tenant_c123_external",
+						// TODO: update test net names
+						ExternalVMNetworkName: "external_net",
 					},
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123_internal",
+						Network: "internal_net",
 						IpAddress: []string{
 							"127.0.0.6",
 							"10.10.1.22",
@@ -817,7 +811,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 						},
 					},
 					{
-						Network: "test_k8s_tenant_c123_external",
+						Network: "external_net",
 						IpAddress: []string{
 							"127.0.0.7",
 							"172.15.108.10",
@@ -827,22 +821,21 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 			},
 			expectedIPs: []v1.NodeAddress{
-				{Type: "InternalIP", Address: "10.10.1.22"},
-				{Type: "ExternalIP", Address: "10.10.1.22"},
+				{Type: "ExternalIP", Address: "172.15.108.10"},
 			},
 		},
 		{
-			testName: "ByNetwork_whenOnlyInternalNetworkIsSet_itReturnsOnlyInternalIP",
+			testName: "ByNetworkName_whenOnlyInternalNetworkIsSet_itReturnsOnlyInternalIP",
 			setup: testSetup{
 				ipFamilyPriority: []string{"ipv4"},
 				cpiConfig: &ccfg.CPIConfig{
 					Nodes: ccfg.Nodes{
-						InternalVMNetworkName: "test_k8s_tenant_c123_internal",
+						InternalVMNetworkName: "internal_net",
 					},
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123_internal",
+						Network: "internal_net",
 						IpAddress: []string{
 							"127.0.0.6",
 							"10.10.1.22",
@@ -850,7 +843,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 						},
 					},
 					{
-						Network: "test_k8s_tenant_c123_external",
+						Network: "external_net",
 						IpAddress: []string{
 							"127.0.0.7",
 							"172.15.108.10",
@@ -875,7 +868,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 				networks: []vimtypes.GuestNicInfo{
 					{
-						Network: "test_k8s_tenant_c123",
+						Network: "net_123abc",
 						IpAddress: []string{
 							"127.0.0.6",
 							"169.0.1.2",
@@ -897,10 +890,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 			},
 		},
 		{
-			// This seems like undesireable behavior. The IPs that are returned
-			// depend on ordering within the NICs or which NIC they are on.
-			// There is no sensible precedence with the configuration.
-			testName: "BySettingBothNetworkNameAndSubnets_precedenceIsNotObvious",
+			testName: "BySettingBothNetworkNameAndSubnets_SubnetSelectionHasPrecedenceWhenMatchesAreFound",
 			setup: testSetup{
 				ipFamilyPriority: []string{"ipv4"},
 				cpiConfig: &ccfg.CPIConfig{
@@ -929,8 +919,84 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				},
 			},
 			expectedIPs: []v1.NodeAddress{
-				{Type: "InternalIP", Address: "22.22.22.22"},
+				{Type: "InternalIP", Address: "10.10.1.22"},
 				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+		{
+			testName: "BySettingBothNetworkNameAndSubnets_whenSubnetsMatchNoIPs_itUsesNetworkNameSelection",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "254.10.0.0/16",
+						ExternalNetworkSubnetCIDR: "253.15.0.0/16",
+						InternalVMNetworkName:     "internal_net",
+						ExternalVMNetworkName:     "external_net",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"22.22.22.22",
+							"172.15.108.11",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"33.33.33.33",
+							"10.10.1.22",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "22.22.22.22"},
+				{Type: "ExternalIP", Address: "33.33.33.33"},
+			},
+		},
+		{
+			testName: "ItIgnoresVNICDevices",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "254.10.0.0/16",
+						ExternalNetworkSubnetCIDR: "253.15.0.0/16",
+						InternalVMNetworkName:     "internal_net",
+						ExternalVMNetworkName:     "external_net",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						DeviceConfigId: -1,
+						Network:        "vnic-device",
+						IpAddress: []string{
+							"254.10.1.2",
+							"253.15.2.4",
+						},
+					},
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"22.22.22.22",
+							"172.15.108.11",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"33.33.33.33",
+							"10.10.1.22",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "22.22.22.22"},
+				{Type: "ExternalIP", Address: "33.33.33.33"},
 			},
 		},
 		{
@@ -961,7 +1027,36 @@ func TestDiscoverNodeIPs(t *testing.T) {
 			expectedErrorSubstring: "unable to find suitable IP address for node",
 		},
 		{
-			testName: "ByDefaultSelection_TheSecondNICHasNoIPs",
+			testName: "ByDiscoveringAnUnParsableIP_itIsIgnored",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4"},
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "net_123abc",
+						IpAddress: []string{
+							"blarg",
+							"127.0.0.6",
+							"10.10.1.22",
+							"10.10.1.23",
+						},
+					},
+					{
+						Network: "test_another_nic",
+						IpAddress: []string{
+							"127.0.0.7",
+							"172.15.108.11",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "10.10.1.22"},
+				{Type: "ExternalIP", Address: "10.10.1.22"},
+			},
+		},
+		{
+			testName: "ByDefaultSelection_whenTheSecondNICHasNoIPs",
 			setup: testSetup{
 				ipFamilyPriority: []string{"ipv4"},
 				cpiConfig:        nil,
@@ -984,7 +1079,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 			},
 		},
 		{
-			testName: "ByDefaultSelection_TheFirstNICHasNoIPs",
+			testName: "ByDefaultSelection_whenTheFirstNICHasNoIPs",
 			setup: testSetup{
 				ipFamilyPriority: []string{"ipv4"},
 				cpiConfig:        nil,
@@ -1007,7 +1102,7 @@ func TestDiscoverNodeIPs(t *testing.T) {
 			},
 		},
 		{
-			testName: "ByDefaultSelection_TheFirstNICHasNoIPsOfTheDesiredFamily",
+			testName: "ByDefaultSelection_whenTheFirstNICHasNoIPsOfTheDesiredFamily",
 			setup: testSetup{
 				ipFamilyPriority: []string{"ipv4"},
 				cpiConfig:        nil,
@@ -1057,6 +1152,113 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				{Type: "ExternalIP", Address: "172.15.108.11"},
 			},
 		},
+		{
+			testName: "ByDefaultSelection_whenDualStackIPv4Primary_itReturnsIPv4AddrsFirst",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4", "ipv6"},
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "net_a",
+						IpAddress: []string{
+							"172.15.108.11",
+							"fd00:cccc::1",
+						},
+					},
+					{
+						Network: "net_b",
+						IpAddress: []string{
+							"fd00:cccc::2",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "172.15.108.11"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+				{Type: "InternalIP", Address: "fd00:cccc::1"},
+				{Type: "ExternalIP", Address: "fd00:cccc::1"},
+			},
+		},
+		{
+			testName: "ByDefaultSelection_DualStackIPv6Primary_itReturnsIPv6AddrsFirst",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv6", "ipv4"},
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "net_a",
+						IpAddress: []string{
+							"172.15.108.11",
+							"fd00:cccc::1",
+						},
+					},
+					{
+						Network: "net_b",
+						IpAddress: []string{
+							"fd00:cccc::2",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "fd00:cccc::1"},
+				{Type: "ExternalIP", Address: "fd00:cccc::1"},
+				{Type: "InternalIP", Address: "172.15.108.11"},
+				{Type: "ExternalIP", Address: "172.15.108.11"},
+			},
+		},
+		{
+			testName: "ByNetworkName_whenDualStack",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv6", "ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalVMNetworkName: "internal_net",
+						ExternalVMNetworkName: "external_net",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"172.15.108.11",
+							"fd00:cccc::1",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"fd00:cccc::2",
+							"172.15.108.12",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "fd00:cccc::1"},
+				{Type: "ExternalIP", Address: "fd00:cccc::2"},
+				{Type: "InternalIP", Address: "172.15.108.11"},
+				{Type: "ExternalIP", Address: "172.15.108.12"},
+			},
+		},
+		{
+			testName: "DualStack_whenNoIPsOfOneFamilyAreDiscovered",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv6", "ipv4"},
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"127.0.0.1",
+							"fd00:cccc::1",
+						},
+					},
+				},
+			},
+			expectedErrorSubstring: "unable to find suitable IP address for node",
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -1092,11 +1294,9 @@ func TestDiscoverNodeIPs(t *testing.T) {
 					t.Errorf("failed: expected DiscoverNode to return error containing: %q but was %q", testcase.expectedErrorSubstring, err.Error())
 				}
 				return
-			} else {
-				if err != nil {
-					t.Errorf("Failed DiscoverNode: %s", err)
-					return
-				}
+			} else if err != nil {
+				t.Errorf("Failed DiscoverNode: %s", err)
+				return
 			}
 
 			nodeInfo, ok := nm.nodeNameMap[strings.ToLower(name)]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- ipv4 and ipv6 ips from each family are added to the node status.
- network name can be used to select ips, as long as both external ipv4 and ipv6
  ips are on the same device. The same goes for internal IPs.
- This commit does not address the fact that only one subnet may be
  specified for each internal and external network. This means subnet
  selection does not work in dualstack mode. This functionality can be
  addressed in a later PR. We'd like discussion with interested parties
  before we begin that work.
- some tests expectations, backfilled in previous commit, were updated
  to match new functionality. We believe the new behavior and
  expectations are preferable to the prior behavior.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This PR is based on PR #507. That PR should be reviewed and perhaps merged before this PR. 


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
when running dualstack, ipv4 and ipv6 ips from each family are added to the node status
```
