### PR TITLE
disable node registration when UUID is empty

### DIFF
--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -36,9 +36,6 @@ var (
 	// ErrNotFound is returned by NodeAddresses, NodeAddressesByProviderID,
 	// and InstanceID when a node cannot be found.
 	ErrNodeNotFound = errors.New("Node not found")
-
-	// ErrNodeUUIDEmpty is returned by InstanceID when UUID of a node is empty.
-	ErrNodeUUIDEmpty = errors.New("Node UUID is empty")
 )
 
 func newInstances(nodeManager *NodeManager) cloudprovider.Instances {
@@ -114,10 +111,6 @@ func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (st
 	// Check if node has been discovered already
 	if node, ok := i.nodeManager.nodeNameMap[string(nodeName)]; ok {
 		klog.V(2).Info("instances.InstanceID() CACHED with ", string(nodeName))
-		if node.UUID == "" {
-			klog.Errorf("UUID of node %s is empty", string(nodeName))
-			return "", ErrNodeUUIDEmpty
-		}
 		return node.UUID, nil
 	}
 

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -193,6 +193,10 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		return err
 	}
 
+	if vmDI.UUID == "" {
+		return errors.New("Discovered VM UUID is empty")
+	}
+
 	var oVM mo.VirtualMachine
 	err = vmDI.VM.Properties(ctx, vmDI.VM.Reference(), []string{"guest", "summary"}, &oVM)
 	if err != nil {
@@ -312,7 +316,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 
 	klog.V(2).Infof("Found node %s as vm=%+v in vc=%s and datacenter=%s",
 		nodeID, vmDI.VM, vmDI.VcServer, vmDI.DataCenter.Name())
-	klog.V(2).Info("Hostname: ", oVM.Guest.HostName, " UUID: ", oVM.Summary.Config.Uuid)
+	klog.V(2).Info("Hostname: ", oVM.Guest.HostName, " UUID: ", vmDI.UUID)
 
 	os := "unknown"
 	if g, ok := GuestOSLookup[oVM.Summary.Config.GuestId]; ok {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CPI generates providerID by combining "provider_name + system UUID" e.g. "vsphere://UUID", but the system UUID we fetched from vCenter (via govmomi) is empty. So the final providerID we get is "vsphere://", which is invalid.
In such case, we should disable node registration when UUID is empty

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/521

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
disable node registration when UUID is empty
```
