### PR TITLE
Internal & External subnets accepts multiple CIDRs

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -222,23 +222,19 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		klog.Warningf("Unable to find vcInstance for %s. Defaulting to ipv4.", tenantRef)
 	}
 
-	var internalNetworkSubnet *net.IPNet
-	var externalNetworkSubnet *net.IPNet
+	var internalNetworkSubnets []*net.IPNet
+	var externalNetworkSubnets []*net.IPNet
 	var internalVMNetworkName string
 	var externalVMNetworkName string
 
 	if nm.cfg != nil {
-		if nm.cfg.Nodes.InternalNetworkSubnetCIDR != "" {
-			_, internalNetworkSubnet, err = net.ParseCIDR(nm.cfg.Nodes.InternalNetworkSubnetCIDR)
-			if err != nil {
-				return err
-			}
+		internalNetworkSubnets, err = parseCIDRs(nm.cfg.Nodes.InternalNetworkSubnetCIDR)
+		if err != nil {
+			return err
 		}
-		if nm.cfg.Nodes.ExternalNetworkSubnetCIDR != "" {
-			_, externalNetworkSubnet, err = net.ParseCIDR(nm.cfg.Nodes.ExternalNetworkSubnetCIDR)
-			if err != nil {
-				return err
-			}
+		externalNetworkSubnets, err = parseCIDRs(nm.cfg.Nodes.ExternalNetworkSubnetCIDR)
+		if err != nil {
+			return err
 		}
 		internalVMNetworkName = nm.cfg.Nodes.InternalVMNetworkName
 		externalVMNetworkName = nm.cfg.Nodes.ExternalVMNetworkName
@@ -282,8 +278,8 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		discoveredInternal, discoveredExternal := discoverIPs(
 			nonLocalhostIPs,
 			ipFamily,
-			internalNetworkSubnet,
-			externalNetworkSubnet,
+			internalNetworkSubnets,
+			externalNetworkSubnets,
 			internalVMNetworkName,
 			externalVMNetworkName,
 		)
@@ -339,7 +335,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 // The returned ipAddrNetworkNames will match the given ipFamily.
 //
 // The returned ipAddrNetworkNames will be selected first by attempting to
-// match the given internalNetworkSubnet and externalNetworkSubnet. Subnet
+// match the given internalNetworkSubnets and externalNetworkSubnets. Subnet
 // matching has the highest precedence.
 //
 // If subnet matches are not found, or if subnets are not provided, then an
@@ -352,7 +348,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 //
 // If either of these IPs cannot be discovered, nil will be returned instead.
 func discoverIPs(ipAddrNetworkNames []*ipAddrNetworkName, ipFamily string,
-	internalNetworkSubnet, externalNetworkSubnet *net.IPNet,
+	internalNetworkSubnets, externalNetworkSubnets []*net.IPNet,
 	internalVMNetworkName, externalVMNetworkName string) (internal *ipAddrNetworkName, external *ipAddrNetworkName) {
 
 	ipFamilyMatches := collectMatchesForIPFamily(ipAddrNetworkNames, ipFamily)
@@ -361,11 +357,11 @@ func discoverIPs(ipAddrNetworkNames []*ipAddrNetworkName, ipFamily string,
 	var discoveredExternal *ipAddrNetworkName
 
 	if len(ipFamilyMatches) != 0 {
-		discoveredInternal = findSubnetMatch(ipFamilyMatches, internalNetworkSubnet)
+		discoveredInternal = findSubnetMatch(ipFamilyMatches, internalNetworkSubnets)
 		if discoveredInternal != nil {
 			klog.V(2).Infof("Adding Internal IP by AddressMatching: %s", discoveredInternal.ipAddr)
 		}
-		discoveredExternal = findSubnetMatch(ipFamilyMatches, externalNetworkSubnet)
+		discoveredExternal = findSubnetMatch(ipFamilyMatches, externalNetworkSubnets)
 		if discoveredExternal != nil {
 			klog.V(2).Infof("Adding External IP by AddressMatching: %s", discoveredExternal.ipAddr)
 		}
@@ -419,6 +415,24 @@ func collectNonVNICDevices(guestNicInfos []types.GuestNicInfo) []types.GuestNicI
 		toReturn = append(toReturn, v)
 	}
 	return toReturn
+}
+
+// parseCIDRs converts a comma delimited string of CIDRs to
+// a slice of IPNet pointers.
+func parseCIDRs(cidrsString string) ([]*net.IPNet, error) {
+	if cidrsString != "" {
+		cidrStringSlice := strings.Split(cidrsString, ",")
+		subnets := make([]*net.IPNet, len(cidrStringSlice))
+		for i, cidrString := range cidrStringSlice {
+			_, ipNet, err := net.ParseCIDR(cidrString)
+			if err != nil {
+				return nil, err
+			}
+			subnets[i] = ipNet
+		}
+		return subnets, nil
+	}
+	return nil, nil
 }
 
 // toIPAddrNetworkNames maps an array of GuestNicInfo to and array of *ipAddrNetworkName.
@@ -475,17 +489,16 @@ func filter(ipAddrNetworkNames []*ipAddrNetworkName, predicate func(*ipAddrNetwo
 }
 
 // findSubnetMatch finds the first *ipAddrNetworkName that has an IP in the
-// given network subnet.
-func findSubnetMatch(ipAddrNetworkNames []*ipAddrNetworkName, networkSubnet *net.IPNet) *ipAddrNetworkName {
-	if networkSubnet != nil {
-		subnetMatches := filter(ipAddrNetworkNames, func(candidate *ipAddrNetworkName) bool {
+// given network subnets.
+func findSubnetMatch(ipAddrNetworkNames []*ipAddrNetworkName, networkSubnets []*net.IPNet) *ipAddrNetworkName {
+	for _, networkSubnet := range networkSubnets {
+		match := findFirst(ipAddrNetworkNames, func(candidate *ipAddrNetworkName) bool {
 			return networkSubnet.Contains(candidate.ip())
 		})
 
-		if len(subnetMatches) > 0 {
-			return subnetMatches[0]
+		if match != nil {
+			return match
 		}
-		return nil
 	}
 	return nil
 }
@@ -494,14 +507,19 @@ func findSubnetMatch(ipAddrNetworkNames []*ipAddrNetworkName, networkSubnet *net
 // given network name, ignoring case.
 func findNetworkNameMatch(ipAddrNetworkNames []*ipAddrNetworkName, networkName string) *ipAddrNetworkName {
 	if networkName != "" {
-		networkNameMatches := filter(ipAddrNetworkNames, func(candidate *ipAddrNetworkName) bool {
+		return findFirst(ipAddrNetworkNames, func(candidate *ipAddrNetworkName) bool {
 			return strings.EqualFold(networkName, candidate.networkName)
 		})
+	}
+	return nil
+}
 
-		if len(networkNameMatches) > 0 {
-			return networkNameMatches[0]
+// findFirst returns the first occurance that matches the given predicate
+func findFirst(ipAddrNetworkNames []*ipAddrNetworkName, predicate func(*ipAddrNetworkName) bool) *ipAddrNetworkName {
+	for _, item := range ipAddrNetworkNames {
+		if predicate(item) {
+			return item
 		}
-		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
internal-network-subnet-cidr and external-network-subnet-cidr config
variables accept a list of comma separated CIDRs. Encountered IPs are
matched against each list of CIDRs.

**Which issue this PR fixes**

This is related to issue #302

**Special notes for your reviewer**:
Verification steps:
 - added unit tests for new functionality
 - built and pushed a ccm image to a dualstack env.
 - updated the internal-network-subnet-cidr and external-network-subnet-cidr to contain comma separated lists of CIDRs
 - verified the Node objects spec settings contained the desired IPs
 - verified the logs showed the IPs were assigned via subnet matching. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
internal-network-subnet-cidr and external-network-subnet-cidr config
variables accept a list of comma separated CIDRs
```
