### PR TITLE
chart: fix helm errors by quoting credentials

### DIFF
--- a/charts/vsphere-cpi/templates/secret.yaml
+++ b/charts/vsphere-cpi/templates/secret.yaml
@@ -9,6 +9,6 @@ metadata:
     component: cloud-controller-manager
   namespace: {{ .Release.Namespace }}
 stringData:
-  {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.username: {{ .Values.config.username | default .Values.global.config.username }}
-  {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.password: {{ .Values.config.password | default .Values.global.config.password }}
+  {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.username: {{ .Values.config.username | default .Values.global.config.username | quote }}
+  {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.password: {{ .Values.config.password | default .Values.global.config.password | quote }}
 {{- end -}}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: Surround the username and password for vCenter in quotes. This prevents YAML to JSON conversion errors when the username or password contain special characters that invalidate the YAML syntax in the Helm template for `Secret`.

**Which issue this PR fixes**: No issue exists for this yet, but I have experienced the problem that this PR solves.

**Special notes for your reviewer**:
Steps to reproduce the problem:
```bash
$ helm template vsphere-cpi vsphere-cpi/vsphere-cpi --namespace kube-system --set config.enabled=true --set config.password="%&/()=?"
Error: YAML parse error on vsphere-cpi/templates/secret.yaml: error converting YAML to JSON: yaml: line 12: found character that cannot start any token
```
With the submitted patch we will get a valid YAML output for the Helm chart.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
