### PR TITLE
Add notifier for config map updates.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module k8s.io/cloud-provider-vsphere
 go 1.16
 
 require (
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.1.2


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Notify the app to stop and reload pod if there's an update to `vsphere-cloud-config` config map.

**Which issue this PR fixes**: fixes #531

**Special notes for your reviewer**:
This feature has been tested manually.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cloud controller manager pods will restart whenever there is update to the vsphere-cloud-config configmap.
```
