### PR TITLE
show vsphere-cloud-controller-manager version in the log correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,4 +327,5 @@ squash:
 docker-image:
 	docker build \
 	-f cluster/images/controller-manager/Dockerfile \
-	-t "$(IMAGE):$(BRANCH_NAME)" . \
+	-t "$(IMAGE):$(BRANCH_NAME)" \
+	--build-arg "VERSION=${VERSION}" . \

--- a/cluster/images/controller-manager/Dockerfile
+++ b/cluster/images/controller-manager/Dockerfile
@@ -33,7 +33,7 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static@sha256:9b60270ec0991bc4f14bda475e8
 FROM ${GOLANG_IMAGE} as builder
 
 # This build arg is the version to embed in the CPI binary
-ARG VERSION=unknown
+ARG VERSION=1.22.3
 
 # This build arg controls the GOPROXY setting
 ARG GOPROXY
@@ -44,7 +44,7 @@ COPY pkg/    pkg/
 COPY cmd/    cmd/
 ENV CGO_ENABLED=0
 ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
-RUN go build -a -ldflags='-w -s -extldflags=static -X main.version=${VERSION}' -o vsphere-cloud-controller-manager ./cmd/vsphere-cloud-controller-manager
+RUN go build -a -ldflags="-w -s -extldflags=static -X main.version=${VERSION}" -o vsphere-cloud-controller-manager ./cmd/vsphere-cloud-controller-manager
 
 ################################################################################
 ##                               MAIN STAGE                                   ##


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
vsphere-cloud-controller-manager version is shown as ${VERSION} in the log:
```
I1201 10:00:32.996286       1 main.go:81] vsphere-cloud-controller-manager version: ${VERSION}
```
we should see a version number instead of `${VERSION}`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/533

**Special notes for your reviewer**:
verified the fix:
```
I1203 00:09:19.942725       1 main.go:81] vsphere-cloud-controller-manager version: 1.22.3
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
show vsphere-cloud-controller-manager version in the log correctly
```
