### PR TITLE
Remove cached node based on UUID when unregister node

### DIFF
--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -35,7 +35,7 @@ import (
 var (
 	// ErrNotFound is returned by NodeAddresses, NodeAddressesByProviderID,
 	// and InstanceID when a node cannot be found.
-	ErrNodeNotFound = errors.New("Node not found")
+	ErrNodeNotFound = errors.New("node not found")
 )
 
 func newInstances(nodeManager *NodeManager) cloudprovider.Instances {

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -81,11 +81,11 @@ func TestRegUnregNode(t *testing.T) {
 
 	nm.UnregisterNode(node)
 
-	if len(nm.nodeNameMap) != 1 {
-		t.Errorf("Failed: nodeNameMap should be a length of  1")
+	if len(nm.nodeNameMap) != 0 {
+		t.Errorf("Failed: nodeNameMap should be a length of  0")
 	}
-	if len(nm.nodeUUIDMap) != 1 {
-		t.Errorf("Failed: nodeUUIDMap should be a length of  1")
+	if len(nm.nodeUUIDMap) != 0 {
+		t.Errorf("Failed: nodeUUIDMap should be a length of  0")
 	}
 	if len(nm.nodeRegUUIDMap) != 0 {
 		t.Errorf("Failed: nodeRegUUIDMap should be a length of 0")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently, we don't clean uuidMap or nameMap when node is deleted due to some historical edge case bug.
We Should clear the cache at least since it brings other issue

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/cloud-provider-vsphere/issues/501

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Clean up nodeUUIDMap and nodeNameMap based on node uuid when node is deleted
```
