### PR TITLE
Cherry pick node cache fix 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,4 +327,5 @@ squash:
 docker-image:
 	docker build \
 	-f cluster/images/controller-manager/Dockerfile \
-	-t "$(IMAGE):$(BRANCH_NAME)" . \
+	-t "$(IMAGE):$(BRANCH_NAME)" \
+	--build-arg "VERSION=${VERSION}" . \

--- a/cluster/images/controller-manager/Dockerfile
+++ b/cluster/images/controller-manager/Dockerfile
@@ -33,7 +33,7 @@ ARG DISTROLESS_IMAGE=gcr.io/distroless/static@sha256:9b60270ec0991bc4f14bda475e8
 FROM ${GOLANG_IMAGE} as builder
 
 # This build arg is the version to embed in the CPI binary
-ARG VERSION=unknown
+ARG VERSION=1.22.3
 
 # This build arg controls the GOPROXY setting
 ARG GOPROXY
@@ -44,7 +44,7 @@ COPY pkg/    pkg/
 COPY cmd/    cmd/
 ENV CGO_ENABLED=0
 ENV GOPROXY ${GOPROXY:-https://proxy.golang.org}
-RUN go build -a -ldflags='-w -s -extldflags=static -X main.version=${VERSION}' -o vsphere-cloud-controller-manager ./cmd/vsphere-cloud-controller-manager
+RUN go build -a -ldflags="-w -s -extldflags=static -X main.version=${VERSION}" -o vsphere-cloud-controller-manager ./cmd/vsphere-cloud-controller-manager
 
 ################################################################################
 ##                               MAIN STAGE                                   ##

--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -35,7 +35,7 @@ import (
 var (
 	// ErrNotFound is returned by NodeAddresses, NodeAddressesByProviderID,
 	// and InstanceID when a node cannot be found.
-	ErrNodeNotFound = errors.New("Node not found")
+	ErrNodeNotFound = errors.New("node not found")
 )
 
 func newInstances(nodeManager *NodeManager) cloudprovider.Instances {

--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -52,12 +52,6 @@ var _ cloudprovider.Instances = &instances{}
 func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v1.NodeAddress, error) {
 	klog.V(4).Info("instances.NodeAddresses() called with ", string(nodeName))
 
-	// Check if node has been discovered already
-	if node, ok := i.nodeManager.nodeNameMap[string(nodeName)]; ok {
-		klog.V(2).Info("instances.NodeAddresses() CACHED with ", string(nodeName))
-		return node.NodeAddresses, nil
-	}
-
 	if err := i.nodeManager.DiscoverNode(string(nodeName), cm.FindVMByName); err == nil {
 		if i.nodeManager.nodeNameMap[string(nodeName)] == nil {
 			klog.Errorf("DiscoverNode succeeded, but CACHE missed for node=%s. If this is a Linux VM, hostnames are case sensitive. Make sure they match.", string(nodeName))
@@ -77,12 +71,7 @@ func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) 
 func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
 	klog.V(4).Info("instances.NodeAddressesByProviderID() called with ", providerID)
 
-	// Check if node has been discovered already
 	uid := GetUUIDFromProviderID(providerID)
-	if node, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
-		klog.V(2).Info("instances.NodeAddressesByProviderID() CACHED with ", uid)
-		return node.NodeAddresses, nil
-	}
 
 	if err := i.nodeManager.DiscoverNode(uid, cm.FindVMByUUID); err == nil {
 		klog.V(2).Info("instances.NodeAddressesByProviderID() FOUND with ", uid)

--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -80,7 +80,7 @@ func TestInstance(t *testing.T) {
 	instances := newInstances(&nm.NodeManager)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
-	name := vm.Name
+	name := strings.ToLower(vm.Name)
 	vm.Guest.HostName = name
 	vm.Guest.Net = []vimtypes.GuestNicInfo{
 		{

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -44,7 +44,7 @@ var (
 
 	// ErrDatacenterNotFound is returned when the configured datacenter cannot
 	// be found.
-	ErrDatacenterNotFound = errors.New("Datacenter not found")
+	ErrDatacenterNotFound = errors.New("datacenter not found")
 
 	// ErrVMNotFound is returned when the specified VM cannot be found.
 	ErrVMNotFound = errors.New("VM not found")
@@ -104,6 +104,19 @@ func (nm *NodeManager) removeNode(uuid string, node *v1.Node) {
 	klog.V(4).Info("removeNode NodeName: ", node.GetName(), ", UID: ", uuid)
 	delete(nm.nodeRegUUIDMap, uuid)
 	nm.nodeRegInfoLock.Unlock()
+
+	nm.nodeInfoLock.Lock()
+	klog.V(4).Info("removeNode from UUID and Name cache. NodeName: ", node.GetName(), ", UID: ", uuid)
+	// in case of a race condition that node with same name create happens before delete event,
+	// delete the node based on uuid
+	name := nm.getNodeNameByUUID(uuid)
+	if name != "" {
+		delete(nm.nodeNameMap, name)
+	} else {
+		klog.V(4).Info("node name: ", node.GetName(), " has a different uuid. Skip deleting this node from cache.")
+	}
+	delete(nm.nodeUUIDMap, uuid)
+	nm.nodeInfoLock.Unlock()
 }
 
 func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, searchBy cm.FindVM) (*cm.VMDiscoveryInfo, error) {
@@ -194,7 +207,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 	}
 
 	if vmDI.UUID == "" {
-		return errors.New("Discovered VM UUID is empty")
+		return errors.New("discovered VM UUID is empty")
 	}
 
 	var oVM mo.VirtualMachine
@@ -671,4 +684,14 @@ func (nm *NodeManager) FindNodeInfo(UUID string) (*NodeInfo, error) {
 
 	klog.V(4).Infof("FindNodeInfo( %s ) FOUND", UUIDlower)
 	return nodeInfo, nil
+}
+
+func (nm *NodeManager) getNodeNameByUUID(UUID string) string {
+	for k, v := range nm.nodeNameMap {
+		if v.UUID == UUID {
+			return k
+		}
+
+	}
+	return ""
 }

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -82,11 +82,11 @@ func TestRegUnregNode(t *testing.T) {
 
 	nm.UnregisterNode(node)
 
-	if len(nm.nodeNameMap) != 1 {
-		t.Errorf("Failed: nodeNameMap should be a length of  1")
+	if len(nm.nodeNameMap) != 0 {
+		t.Errorf("Failed: nodeNameMap should be a length of  0")
 	}
-	if len(nm.nodeUUIDMap) != 1 {
-		t.Errorf("Failed: nodeUUIDMap should be a length of  1")
+	if len(nm.nodeUUIDMap) != 0 {
+		t.Errorf("Failed: nodeUUIDMap should be a length of  0")
 	}
 	if len(nm.nodeRegUUIDMap) != 0 {
 		t.Errorf("Failed: nodeRegUUIDMap should be a length of 0")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
cherry pick
https://github.com/kubernetes/cloud-provider-vsphere/pull/541
https://github.com/kubernetes/cloud-provider-vsphere/pull/540
https://github.com/kubernetes/cloud-provider-vsphere/pull/535



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
show vsphere-cloud-controller-manager version in the log correctly
clean up nodeUUIDMap and nodeNameMap based on node uuid when node is deleted
do not use the cached node addresses when NodeAddresses is invoked.
```
