### PR TITLE
chart: allow configuration of configmap and secret name

### DIFF
--- a/charts/vsphere-cpi/README.md
+++ b/charts/vsphere-cpi/README.md
@@ -94,15 +94,18 @@ The following table lists the configurable parameters of the vSphere CPI chart a
 | `podSecurityPolicy.enabled`              | Enable pod sec policy (k8s > 1.17)  |  true                                  |
 | `podSecurityPolicy.annotations`          | Annotations for pd sec policy       |  nil                                   |
 | `securityContext.enabled`                | Enable sec context for container    |  false                                 |
-| `securityContext.runAsUser`              | RunAsUser. Default is `nobody` in   |  1001                                 |
+| `securityContext.runAsUser`              | RunAsUser. Default is `nobody` in   |  1001                                  |
 |                                          |    distroless image                 |                                        |
-| `securityContext.fsGroup`                | FsGroup. Default is `nobody` in     |  1001                                 |
+| `securityContext.fsGroup`                | FsGroup. Default is `nobody` in     |  1001                                  |
 |                                          |    distroless image                 |                                        |
 | `config.enabled`                         | Create a simple single VC config    |  false                                 |
+| `config.name`                            | Name of the created VC configmap    |  false                                 |
 | `config.vcenter`                         | FQDN or IP of vCenter               |  vcenter.local                         |
 | `config.username`                        | vCenter username                    |  user                                  |
 | `config.password`                        | vCenter password                    |  pass                                  |
 | `config.datacenter`                      | Datacenters within the vCenter      |  dc                                    |
+| `config.secret.create`                   | Create secret for VC config         |  true                                  |
+| `config.secret.name`                     | Name of the created VC secret       |  vsphere-cloud-secret                  |
 | `rbac.create`                            | Create roles and role bindings      |  true                                  |
 | `serviceAccount.create`                  | Create the service account          |  true                                  |
 | `serviceAccount.name`                    | Name of the created service account |  cloud-controller-manager              |

--- a/charts/vsphere-cpi/templates/configmap.yaml
+++ b/charts/vsphere-cpi/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vsphere-cloud-config
+  name: {{ .Values.config.name | default "cloud-config" }}
   labels:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: cloud-config
@@ -16,7 +16,7 @@ data:
       # set insecure-flag to true if the vCenter uses a self-signed cert
       insecureFlag: true
       # settings for using k8s secret
-      secretName: vsphere-cloud-secret
+      secretName: {{ .Values.config.secret.name }}
       secretNamespace: {{ .Release.Namespace }}
 
     # vcenter section

--- a/charts/vsphere-cpi/templates/daemonset.yaml
+++ b/charts/vsphere-cpi/templates/daemonset.yaml
@@ -98,4 +98,4 @@ spec:
       volumes:
         - name: vsphere-config-volume
           configMap:
-            name: cloud-config
+            name: {{ if .Values.config.enabled }}{{- .Values.config.name }}{{- else }}cloud-config{{- end }}

--- a/charts/vsphere-cpi/templates/secret.yaml
+++ b/charts/vsphere-cpi/templates/secret.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.config.enabled | default .Values.global.config.enabled -}}
+{{- if and .Values.config.secret.create .Values.config.enabled | default .Values.global.config.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: vsphere-cloud-secret
+  name: {{ .Values.config.secret.name | default "vsphere-cloud-secret" }}
   labels:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: secret

--- a/charts/vsphere-cpi/values.yaml
+++ b/charts/vsphere-cpi/values.yaml
@@ -1,6 +1,6 @@
 # Default values for vSphere CPI.
 # This is a YAML-formatted file.
-# vSohere CPI values are grouped by component
+# vSphere CPI values are grouped by component
 
 global:
   config:
@@ -8,12 +8,20 @@ global:
 
 config:
   enabled: false
+  name: vsphere-cloud-config
   vcenter: "vcenter.local"
   username: "user"
   password: "pass"
   datacenter: "dc"
   region: "k8s-region"
   zone: "k8s-zone"
+
+  secret:
+    # Specifies whether Secret should be created from config values
+    create: true
+    # The name of the Secret referred to in the vsphere-cloud-config ConfigMap
+    # If your Kubernetes platform provides this secret, set create to false and adjust the secret name
+    name: vsphere-cloud-secret
 
 ## Specify if a Pod Security Policy for kube-state-metrics must be created
 ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**: This PRs allow to set the name of created `Secret` and `ConfigMap` objects.

Regarding ConfigMap: The chart had a mismatch between DaemonSet volume (requesting ConfigMap volume by `name: cloud-config`) and the ConfigMap creation (with `name: vsphere-cloud-config`). With this PR the ConfigMap name will default to `cloud-config` if config is disabled. With config enabled it will default to  `vsphere-cloud-config` and create this ConfigMap.

Regarding Secret: A Kubernetes platform might create the vSphere secret in the correct syntax, so we may want to reuse this secret and not create a duplicate with this Helm chart. For OpenShift on vSphere I can set `config.secret.create: false` and `config.secret.name: vsphere-creds` when deploying into `kube-system` namespace.

**Which issue this PR fixes**
No issue reported.

**Special notes for your reviewer**:
Please **make a Helm Chart release**. I can create another PR if that is desired.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
allow setting name of secret and configmap with config.name, config.secret.name
allow disabling creation of vSphere secret with config.secret.create
```
