### PR TITLE
For paravirtual, empty ProviderUUID appears for node

### DIFF
--- a/pkg/cloudprovider/vsphereparavirtual/instances.go
+++ b/pkg/cloudprovider/vsphereparavirtual/instances.go
@@ -18,6 +18,7 @@ package vsphereparavirtual
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -55,6 +56,10 @@ var DiscoverNodeBackoff = wait.Backoff{
 	Duration: 50 * time.Millisecond,
 	Jitter:   1.0,
 }
+
+var (
+	errBiosUUIDEmpty = errors.New("discovered Bios UUID is empty")
+)
 
 func checkError(err error) bool {
 	return err != nil
@@ -195,6 +200,10 @@ func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (st
 	if vm == nil {
 		klog.V(4).Info("instances.InstanceID() InstanceNotFound ", nodeName)
 		return "", cloudprovider.InstanceNotFound
+	}
+
+	if vm.Status.BiosUUID == "" {
+		return "", errBiosUUIDEmpty
 	}
 
 	klog.V(4).Infof("instances.InstanceID() called to get vm: %v uuid: %v", nodeName, vm.Status.BiosUUID)

--- a/pkg/cloudprovider/vsphereparavirtual/instances_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/instances_test.go
@@ -21,22 +21,17 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
-
-	"github.com/stretchr/testify/assert"
-
+	"k8s.io/cloud-provider-vsphere/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-
-	"k8s.io/apimachinery/pkg/types"
-
-	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
-
-	"k8s.io/cloud-provider-vsphere/pkg/util"
 )
 
 var (
@@ -136,6 +131,12 @@ func TestInstanceID(t *testing.T) {
 			testVM:             createTestVM(string(testVMName), "bogus", testVMUUID),
 			expectedInstanceID: "",
 			expectedErr:        cloudprovider.InstanceNotFound,
+		},
+		{
+			name:               "cannot find virtualmachine with empty bios uuid",
+			testVM:             createTestVM(string(testVMName), testClusterNameSpace, ""),
+			expectedInstanceID: "",
+			expectedErr:        errBiosUUIDEmpty,
 		},
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/kubernetes/cloud-provider-vsphere/issues/545

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix paravirtual mode ProviderID could be empty bug
```
