### PR TITLE
Remove dead code

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -167,25 +167,6 @@ func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, 
 	return nil, err
 }
 
-func returnIPsFromSpecificFamily(family string, ips []string) []string {
-	var matching []string
-
-	for _, ip := range ips {
-		if err := ErrOnLocalOnlyIPAddr(ip); err != nil {
-			klog.V(4).Infof("IP is local only or there was an error. ip=%q err=%v", ip, err)
-			continue
-		}
-
-		if strings.EqualFold(family, vcfg.IPv6Family) && net.ParseIP(ip).To4() == nil {
-			matching = append(matching, ip)
-		} else if strings.EqualFold(family, vcfg.IPv4Family) && net.ParseIP(ip).To4() != nil {
-			matching = append(matching, ip)
-		}
-	}
-
-	return matching
-}
-
 type ipAddrNetworkName struct {
 	ipAddr      string
 	networkName string

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	pb "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/proto"
-	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
 	cm "k8s.io/cloud-provider-vsphere/pkg/common/connectionmanager"
 )
 
@@ -244,30 +243,6 @@ func TestExport(t *testing.T) {
 	}
 
 	nm.UnregisterNode(node)
-}
-
-func TestReturnIPsFromSpecificFamily(t *testing.T) {
-	ipFamilies := []string{
-		"10.161.34.192",
-		"fd01:0:101:2609:bdd2:ee20:7bd7:5836",
-		"fe80::98b5:4834:27a8:c58d",
-	}
-
-	ips := returnIPsFromSpecificFamily(vcfg.IPv6Family, ipFamilies)
-	size := len(ips)
-	if size != 1 {
-		t.Errorf("Should only return single IPv6 address. expected: 1, actual: %d", size)
-	} else if !strings.EqualFold(ips[0], "fd01:0:101:2609:bdd2:ee20:7bd7:5836") {
-		t.Errorf("IPv6 does not match. expected: fd01:0:101:2609:bdd2:ee20:7bd7:5836, actual: %s", ips[0])
-	}
-
-	ips = returnIPsFromSpecificFamily(vcfg.IPv4Family, ipFamilies)
-	size = len(ips)
-	if size != 1 {
-		t.Errorf("Should only return single IPv4 address. expected: 1, actual: %d", size)
-	} else if !strings.EqualFold(ips[0], "10.161.34.192") {
-		t.Errorf("IPv6 does not match. expected: 10.161.34.192, actual: %s", ips[0])
-	}
 }
 
 func TestDiscoverNodeIPs(t *testing.T) {


### PR DESCRIPTION
returnIPsFromSpecificFamily function is only used in test

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
minor cleanup

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
