### PR TITLE
Adds implementation for returning zones for nodes.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,8 @@ require (
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.2.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.2.0
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.3.0
-	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023
+	golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
+	golang.org/x/tools v0.1.8 // indirect
 	google.golang.org/grpc v1.38.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -561,6 +561,7 @@ github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
@@ -672,8 +673,9 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
+golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -710,8 +712,9 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210520170846-37e1c6afe023 h1:ADo5wSpq2gqaCGQWzk7S5vd//0iyyLeAratkEoG5dLE=
 golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f h1:OfiFi4JbukWwe3lzw+xunroH1mnC1e2Gy5cxNJApiSY=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -779,8 +782,9 @@ golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
@@ -792,8 +796,9 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -845,8 +850,9 @@ golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjs
 golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.8 h1:P1HhGGuLW4aAclzjtmJdf0mJOjVUZUzOTqkAkWL+l6w=
+golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/cloudprovider/vsphereparavirtual/cloud.go
+++ b/pkg/cloudprovider/vsphereparavirtual/cloud.go
@@ -146,6 +146,12 @@ func (cp *VSphereParavirtual) Initialize(clientBuilder cloudprovider.ControllerC
 		}
 	}
 
+	zones, err := NewZones(clusterNS, kcfg)
+	if err != nil {
+		klog.Errorf("Failed to init Zones: %v", err)
+	}
+	cp.zones = zones
+
 	cp.informMgr.Listen()
 	klog.V(0).Info("Initing vSphere Paravirtual Cloud Provider Succeeded")
 }
@@ -174,7 +180,7 @@ func (cp *VSphereParavirtual) InstancesV2() (cloudprovider.InstancesV2, bool) {
 // is supported, false otherwise.
 func (cp *VSphereParavirtual) Zones() (cloudprovider.Zones, bool) {
 	klog.V(1).Info("Enabling Zones interface on vsphere paravirtual cloud provider")
-	return nil, false
+	return cp.zones, true
 }
 
 // Clusters returns a clusters interface.  Also returns true if the interface

--- a/pkg/cloudprovider/vsphereparavirtual/instances.go
+++ b/pkg/cloudprovider/vsphereparavirtual/instances.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,10 +32,8 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 
-	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmservice"
-	"k8s.io/cloud-provider-vsphere/pkg/util"
-
 	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmservice"
 )
 
 type instances struct {
@@ -68,61 +65,13 @@ func checkError(err error) bool {
 // discoverNodeByProviderID takes a ProviderID and returns a VirtualMachine if one exists, or nil otherwise
 // VirtualMachine not found is not an error
 func (i instances) discoverNodeByProviderID(ctx context.Context, providerID string) (*vmopv1alpha1.VirtualMachine, error) {
-	var discoveredNode *vmopv1alpha1.VirtualMachine = nil
-
-	// Adding Retry here because there is no retry in caller from node controller
-	// https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cloud/node_controller.go#L368
-	err := util.RetryOnError(
-		DiscoverNodeBackoff,
-		checkError,
-		func() error {
-			uuid := GetUUIDFromProviderID(providerID)
-			vms := vmopv1alpha1.VirtualMachineList{}
-			err := i.vmClient.List(ctx, &vms, &client.ListOptions{
-				Namespace: i.namespace,
-			})
-			if err != nil {
-				return err
-			}
-			for i := range vms.Items {
-				vm := vms.Items[i]
-				if uuid == vm.Status.BiosUUID {
-					discoveredNode = &vm
-					break
-				}
-			}
-
-			return nil
-		})
-
-	return discoveredNode, err
+	return discoverNodeByProviderID(ctx, providerID, i.namespace, i.vmClient)
 }
 
 // discoverNodeByName takes a node name and returns a VirtualMachine if one exists, or nil otherwise
 // VirtualMachine not found is not an error
 func (i instances) discoverNodeByName(ctx context.Context, name types.NodeName) (*vmopv1alpha1.VirtualMachine, error) {
-	var discoveredNode *vmopv1alpha1.VirtualMachine = nil
-
-	// Adding Retry here because there is no retry in caller from node controller
-	// https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cloud/node_controller.go#L368
-	err := util.RetryOnError(
-		DiscoverNodeBackoff,
-		checkError,
-		func() error {
-			vmKey := types.NamespacedName{Name: string(name), Namespace: i.namespace}
-			vm := vmopv1alpha1.VirtualMachine{}
-			err := i.vmClient.Get(ctx, vmKey, &vm)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}
-			discoveredNode = &vm
-			return nil
-		})
-
-	return discoveredNode, err
+	return discoverNodeByName(ctx, name, i.namespace, i.vmClient)
 }
 
 // NewInstances returns an implementation of cloudprovider.Instances

--- a/pkg/cloudprovider/vsphereparavirtual/types.go
+++ b/pkg/cloudprovider/vsphereparavirtual/types.go
@@ -33,4 +33,5 @@ type VSphereParavirtual struct {
 	loadBalancer   cloudprovider.LoadBalancer
 	instances      cloudprovider.Instances
 	routes         RoutesProvider
+	zones          cloudprovider.Zones
 }

--- a/pkg/cloudprovider/vsphereparavirtual/vmoperator.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmoperator.go
@@ -1,0 +1,71 @@
+package vsphereparavirtual
+
+import (
+	"context"
+
+	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cloud-provider-vsphere/pkg/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// discoverNodeByProviderID takes a ProviderID and returns a VirtualMachine if one exists, or nil otherwise
+// VirtualMachine not found is not an error
+func discoverNodeByProviderID(ctx context.Context, providerID string, namespace string, vmClient client.Client) (*vmopv1alpha1.VirtualMachine, error) {
+	var discoveredNode *vmopv1alpha1.VirtualMachine = nil
+
+	// Adding Retry here because there is no retry in caller from node controller
+	// https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cloud/node_controller.go#L368
+	err := util.RetryOnError(
+		DiscoverNodeBackoff,
+		checkError,
+		func() error {
+			uuid := GetUUIDFromProviderID(providerID)
+			vms := vmopv1alpha1.VirtualMachineList{}
+			err := vmClient.List(ctx, &vms, &client.ListOptions{
+				Namespace: namespace,
+			})
+			if err != nil {
+				return err
+			}
+			for i := range vms.Items {
+				vm := vms.Items[i]
+				if uuid == vm.Status.BiosUUID {
+					discoveredNode = &vm
+					break
+				}
+			}
+
+			return nil
+		})
+
+	return discoveredNode, err
+}
+
+// discoverNodeByName takes a node name and returns a VirtualMachine if one exists, or nil otherwise
+// VirtualMachine not found is not an error
+func discoverNodeByName(ctx context.Context, name types.NodeName, namespace string, vmClient client.Client) (*vmopv1alpha1.VirtualMachine, error) {
+	var discoveredNode *vmopv1alpha1.VirtualMachine = nil
+
+	// Adding Retry here because there is no retry in caller from node controller
+	// https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cloud/node_controller.go#L368
+	err := util.RetryOnError(
+		DiscoverNodeBackoff,
+		checkError,
+		func() error {
+			vmKey := types.NamespacedName{Name: string(name), Namespace: namespace}
+			vm := vmopv1alpha1.VirtualMachine{}
+			err := vmClient.Get(ctx, vmKey, &vm)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}
+			discoveredNode = &vm
+			return nil
+		})
+
+	return discoveredNode, err
+}

--- a/pkg/cloudprovider/vsphereparavirtual/zone.go
+++ b/pkg/cloudprovider/vsphereparavirtual/zone.go
@@ -1,0 +1,97 @@
+package vsphereparavirtual
+
+import (
+	"context"
+
+	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmservice"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type zones struct {
+	vmClient  client.Client
+	namespace string
+}
+
+func (z zones) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
+	zone := cloudprovider.Zone{}
+	return zone, cloudprovider.NotImplemented
+}
+
+func (z zones) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
+	zone := cloudprovider.Zone{}
+
+	vm, err := z.discoverNodeByProviderID(ctx, providerID)
+	if err != nil {
+		klog.Errorf("Error trying to find vm :  %v", err)
+		return zone, err
+	}
+
+	if vm == nil {
+		klog.V(4).Info("instances.GetZoneByProviderID() InstanceNotFound ", providerID)
+		return zone, cloudprovider.InstanceNotFound
+	}
+
+	if val, ok := vm.Labels["topology.kubernetes.io/zone"]; ok {
+		klog.V(4).Info("retrieved zone", val)
+		zone = cloudprovider.Zone{
+			FailureDomain: val,
+		}
+	}
+
+	return zone, nil
+}
+
+func (z zones) GetZoneByNodeName(ctx context.Context, nodeName types.NodeName) (cloudprovider.Zone, error) {
+	zone := cloudprovider.Zone{}
+
+	vm, err := z.discoverNodeByName(ctx, nodeName)
+	if err != nil {
+		klog.Errorf("Error trying to find vm :  %v", err)
+		return zone, err
+	}
+
+	if vm == nil {
+		klog.V(4).Info("zones.GetZoneByNodeName() InstanceNotFound ", nodeName)
+		return zone, cloudprovider.InstanceNotFound
+	}
+
+	if val, ok := vm.Labels["topology.kubernetes.io/zone"]; ok {
+		klog.V(4).Info("retrieved zone", val)
+		zone = cloudprovider.Zone{
+			FailureDomain: val,
+		}
+	}
+
+	return zone, nil
+}
+
+// discoverNodeByProviderID takes a ProviderID and returns a VirtualMachine if one exists, or nil otherwise
+// VirtualMachine not found is not an error
+func (z zones) discoverNodeByProviderID(ctx context.Context, providerID string) (*vmopv1alpha1.VirtualMachine, error) {
+	return discoverNodeByProviderID(ctx, providerID, z.namespace, z.vmClient)
+}
+
+// discoverNodeByName takes a node name and returns a VirtualMachine if one exists, or nil otherwise
+// VirtualMachine not found is not an error
+func (z zones) discoverNodeByName(ctx context.Context, name types.NodeName) (*vmopv1alpha1.VirtualMachine, error) {
+	return discoverNodeByName(ctx, name, z.namespace, z.vmClient)
+}
+
+// NewZones returns an implementation of cloudprovider.Instances
+func NewZones(namespace string, kcfg *rest.Config) (cloudprovider.Zones, error) {
+	vmClient, err := vmservice.GetVmopClient(kcfg)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &zones{
+		vmClient:  vmClient,
+		namespace: namespace,
+	}, nil
+}

--- a/pkg/cloudprovider/vsphereparavirtual/zone_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/zone_test.go
@@ -1,0 +1,175 @@
+package vsphereparavirtual
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	vmopv1alpha1 "github.com/vmware-tanzu/vm-operator-api/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/cloud-provider-vsphere/pkg/util"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	vmName     = types.NodeName("test-vm")
+	fakeVMName = types.NodeName("fake-vm")
+	vmuuid     = "421960e7-3041-f44a-4b3f-ed99748c12d0"
+	providerid = "vsphere://" + vmuuid
+)
+
+func TestNewZones(t *testing.T) {
+	testCases := []struct {
+		name        string
+		testEnv     *envtest.Environment
+		expectedErr error
+		testVM      *vmopv1alpha1.VirtualMachine
+	}{
+		{
+			name:        "NewZone: when everything is ok",
+			testEnv:     &envtest.Environment{},
+			testVM:      createTestVMWithZone(string(vmName), testClusterNameSpace),
+			expectedErr: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg, err := testCase.testEnv.Start()
+			assert.NoError(t, err)
+			//initVMopClient(testCase.testVM)
+			_, err = NewZones(testClusterNameSpace, cfg)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectedErr, err)
+
+			err = testCase.testEnv.Stop()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestZonesByProviderID(t *testing.T) {
+	testCases := []struct {
+		name           string
+		testEnv        *envtest.Environment
+		expectedResult string
+		expectedErr    error
+		testVM         *vmopv1alpha1.VirtualMachine
+	}{
+		{
+			name:           "TestZonesByProviderID should return true",
+			testVM:         createTestVMWithZoneID(string(vmName), testClusterNameSpace, vmuuid),
+			expectedResult: "zone-a",
+			expectedErr:    nil,
+		},
+		{
+			name:           "TestZonesByProviderID should return error",
+			testVM:         createTestVMWithZoneID(string(vmName), testClusterNameSpace, "fakeuuid"),
+			expectedResult: "",
+			expectedErr:    cloudprovider.InstanceNotFound,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			zone, _ := initVMopClient(testCase.testVM)
+			z, err := zone.GetZoneByProviderID(ctx, providerid)
+
+			if testCase.expectedErr != nil {
+				assert.Equal(t, cloudprovider.InstanceNotFound, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, testCase.expectedResult, z.FailureDomain)
+		})
+	}
+}
+
+func TestZonesByNodeName(t *testing.T) {
+	testCases := []struct {
+		name           string
+		testEnv        *envtest.Environment
+		expectedResult string
+		expectedErr    error
+		testVM         *vmopv1alpha1.VirtualMachine
+		vmName         types.NodeName
+	}{
+		{
+			name:           "TestZonesByNodeName should return true",
+			testVM:         createTestVMWithZoneID(string(vmName), testClusterNameSpace, vmuuid),
+			vmName:         vmName,
+			expectedResult: "zone-a",
+			expectedErr:    nil,
+		},
+		{
+			name:           "TestZonesByNodeName should return error",
+			testVM:         createTestVMWithZoneID(string(vmName), testClusterNameSpace, "fakeuuid"),
+			vmName:         fakeVMName,
+			expectedResult: "",
+			expectedErr:    cloudprovider.InstanceNotFound,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			zone, _ := initVMopClient(testCase.testVM)
+			z, err := zone.GetZoneByNodeName(ctx, testCase.vmName)
+
+			if testCase.expectedErr != nil {
+				assert.Equal(t, cloudprovider.InstanceNotFound, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, testCase.expectedResult, z.FailureDomain)
+		})
+	}
+}
+
+func initVMopClient(testVM *vmopv1alpha1.VirtualMachine) (zones, *util.FakeClientWrapper) {
+	scheme := runtime.NewScheme()
+	_ = vmopv1alpha1.AddToScheme(scheme)
+	fc := fakeClient.NewFakeClientWithScheme(scheme, testVM)
+	fcw := util.NewFakeClientWrapper(fc)
+	zone := zones{
+		vmClient:  fcw,
+		namespace: testClusterNameSpace,
+	}
+	return zone, fcw
+}
+
+func createTestVMWithZone(name, namespace string) *vmopv1alpha1.VirtualMachine {
+	labels := make(map[string]string)
+	labels["topology.kubernetes.io/zone"] = "zone-a"
+	return &vmopv1alpha1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+	}
+}
+
+func createTestVMWithZoneID(name, namespace, biosUUID string) *vmopv1alpha1.VirtualMachine {
+	labels := make(map[string]string)
+	labels["topology.kubernetes.io/zone"] = "zone-a"
+	return &vmopv1alpha1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Status: vmopv1alpha1.VirtualMachineStatus{
+			BiosUUID: biosUUID,
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This change implements zone interface when provider is run in paravirtual mode

In paravirtual mode we rely on the label `topology.kubernetes.io/zone` on the virtualmachine object to determine the faultdomain for zones.

The value in the label is set as failure domain and returned in the zones instance

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #552

**Testing**
verified that the nodes are labelled by kubelet as expected.

> kubectl --kubeconfig gc-kubeconfig get nodes np-cluster-control-plane-bhprk -o yaml
apiVersion: v1
kind: Node
metadata:
  annotations:
    cluster.x-k8s.io/cluster-name: np-cluster
    cluster.x-k8s.io/cluster-namespace: test-ns
    cluster.x-k8s.io/machine: np-cluster-control-plane-bhprk
    cluster.x-k8s.io/owner-kind: KubeadmControlPlane
    cluster.x-k8s.io/owner-name: np-cluster-control-plane
    csi.volume.kubernetes.io/nodeid: '{"csi.vsphere.vmware.com":"np-cluster-control-plane-bhprk"}'
    kubeadm.alpha.kubernetes.io/cri-socket: /run/containerd/containerd.sock
    node.alpha.kubernetes.io/ttl: "0"
    volumes.kubernetes.io/controller-managed-attach-detach: "true"
  creationTimestamp: "2021-12-15T21:10:10Z"
  labels:
    beta.kubernetes.io/arch: amd64
    beta.kubernetes.io/os: linux
    failure-domain.beta.kubernetes.io/zone: cone  <-----------
    kubernetes.io/arch: amd64
    kubernetes.io/hostname: np-cluster-control-plane-bhprk
    kubernetes.io/os: linux
    node-role.kubernetes.io/control-plane: ""
    node-role.kubernetes.io/master: ""
    node.kubernetes.io/exclude-from-external-load-balancers: ""
    run.tanzu.vmware.com/kubernetesDistributionVersion: v1.21.6_vmware.1-tkg.1.b3d708a
    topology.kubernetes.io/zone: cone <----------------
  name: np-cluster-control-plane-bhprk

