### PR TITLE
Exclude subnets for node ip selection

### DIFF
--- a/pkg/cloudprovider/vsphere/config/config_ini_legacy.go
+++ b/pkg/cloudprovider/vsphere/config/config_ini_legacy.go
@@ -35,10 +35,12 @@ func (cci *CPIConfigINI) CreateConfig() *CPIConfig {
 	cfg := &CPIConfig{
 		*cci.CommonConfigINI.CreateConfig(),
 		Nodes{
-			InternalNetworkSubnetCIDR: cci.Nodes.InternalNetworkSubnetCIDR,
-			ExternalNetworkSubnetCIDR: cci.Nodes.ExternalNetworkSubnetCIDR,
-			InternalVMNetworkName:     cci.Nodes.InternalVMNetworkName,
-			ExternalVMNetworkName:     cci.Nodes.ExternalVMNetworkName,
+			InternalNetworkSubnetCIDR:        cci.Nodes.InternalNetworkSubnetCIDR,
+			ExternalNetworkSubnetCIDR:        cci.Nodes.ExternalNetworkSubnetCIDR,
+			InternalVMNetworkName:            cci.Nodes.InternalVMNetworkName,
+			ExternalVMNetworkName:            cci.Nodes.ExternalVMNetworkName,
+			ExcludeInternalNetworkSubnetCIDR: cci.Nodes.ExcludeInternalNetworkSubnetCIDR,
+			ExcludeExternalNetworkSubnetCIDR: cci.Nodes.ExcludeExternalNetworkSubnetCIDR,
 		},
 	}
 

--- a/pkg/cloudprovider/vsphere/config/config_yaml.go
+++ b/pkg/cloudprovider/vsphere/config/config_yaml.go
@@ -36,10 +36,12 @@ func (ccy *CPIConfigYAML) CreateConfig() *CPIConfig {
 	cfg := &CPIConfig{
 		*ccy.CommonConfigYAML.CreateConfig(),
 		Nodes{
-			InternalNetworkSubnetCIDR: ccy.Nodes.InternalNetworkSubnetCIDR,
-			ExternalNetworkSubnetCIDR: ccy.Nodes.ExternalNetworkSubnetCIDR,
-			InternalVMNetworkName:     ccy.Nodes.InternalVMNetworkName,
-			ExternalVMNetworkName:     ccy.Nodes.ExternalVMNetworkName,
+			InternalNetworkSubnetCIDR:        ccy.Nodes.InternalNetworkSubnetCIDR,
+			ExternalNetworkSubnetCIDR:        ccy.Nodes.ExternalNetworkSubnetCIDR,
+			InternalVMNetworkName:            ccy.Nodes.InternalVMNetworkName,
+			ExternalVMNetworkName:            ccy.Nodes.ExternalVMNetworkName,
+			ExcludeInternalNetworkSubnetCIDR: ccy.Nodes.ExcludeInternalNetworkSubnetCIDR,
+			ExcludeExternalNetworkSubnetCIDR: ccy.Nodes.ExcludeExternalNetworkSubnetCIDR,
 		},
 	}
 

--- a/pkg/cloudprovider/vsphere/config/config_yaml_test.go
+++ b/pkg/cloudprovider/vsphere/config/config_yaml_test.go
@@ -57,6 +57,22 @@ nodes:
   externalVmNetworkName: External/Outbound Traffic
 `
 
+const excludeSubnetCidrYAMLConfig = `
+global:
+  server: 0.0.0.0
+  port: 443
+  user: user
+  password: password
+  insecureFlag: true
+  datacenters:
+    - us-west
+  caFile: /some/path/to/a/ca.pem
+
+nodes:
+  excludeInternalNetworkSubnetCidr: "192.0.2.0/24,fe80::1/128"
+  excludeExternalNetworkSubnetCidr: "192.1.2.0/24,fe80::2/128"
+`
+
 func TestReadYAMLConfigSubnetCidr(t *testing.T) {
 	_, err := ReadCPIConfigYAML(nil)
 	if err == nil {
@@ -97,5 +113,20 @@ func TestReadYAMLConfigNetworkName(t *testing.T) {
 
 	if cfg.Nodes.ExternalVMNetworkName != "External/Outbound Traffic" {
 		t.Errorf("incorrect internal vm network name: %s", cfg.Nodes.ExternalVMNetworkName)
+	}
+}
+
+func TestReadYAMLConfigExcludeSubnetCidr(t *testing.T) {
+	cfg, err := ReadCPIConfigYAML([]byte(excludeSubnetCidrYAMLConfig))
+	if err != nil {
+		t.Fatalf("Should succeed when a valid config is provided: %s", err)
+	}
+
+	if cfg.Nodes.ExcludeInternalNetworkSubnetCIDR != "192.0.2.0/24,fe80::1/128" {
+		t.Errorf("incorrect exclude internal network subnet cidrs: %s", cfg.Nodes.ExcludeInternalNetworkSubnetCIDR)
+	}
+
+	if cfg.Nodes.ExcludeExternalNetworkSubnetCIDR != "192.1.2.0/24,fe80::2/128" {
+		t.Errorf("incorrect exclude external network subnet cidrs: %s", cfg.Nodes.ExcludeExternalNetworkSubnetCIDR)
 	}
 }

--- a/pkg/cloudprovider/vsphere/config/types_common.go
+++ b/pkg/cloudprovider/vsphere/config/types_common.go
@@ -38,6 +38,11 @@ type Nodes struct {
 	// only have a single IP address assigned to it.
 	InternalVMNetworkName string
 	ExternalVMNetworkName string
+	// IP addresses in these subnet ranges will be excluded when selecting
+	// the IP address from the VirtualMachine's VM for use in the
+	// status.addresses fields.
+	ExcludeInternalNetworkSubnetCIDR string
+	ExcludeExternalNetworkSubnetCIDR string
 }
 
 // CPIConfig is used to read and store information (related only to the CPI) from the cloud configuration file

--- a/pkg/cloudprovider/vsphere/config/types_ini_legacy.go
+++ b/pkg/cloudprovider/vsphere/config/types_ini_legacy.go
@@ -37,6 +37,11 @@ type NodesINI struct {
 	// only have a single IP address assigned to it.
 	InternalVMNetworkName string `gcfg:"internal-vm-network-name"`
 	ExternalVMNetworkName string `gcfg:"external-vm-network-name"`
+	// IP addresses in these subnet ranges will be excluded when selecting
+	// the IP address from the VirtualMachine's VM for use in the
+	// status.addresses fields.
+	ExcludeInternalNetworkSubnetCIDR string `gcfg:"exclude-internal-network-subnet-cidr"`
+	ExcludeExternalNetworkSubnetCIDR string `gcfg:"exclude-external-network-subnet-cidr"`
 }
 
 // CPIConfigINI is the INI representation

--- a/pkg/cloudprovider/vsphere/config/types_yaml.go
+++ b/pkg/cloudprovider/vsphere/config/types_yaml.go
@@ -41,6 +41,11 @@ type NodesYAML struct {
 	// only have a single IP address assigned to it.
 	InternalVMNetworkName string `yaml:"internalVmNetworkName"`
 	ExternalVMNetworkName string `yaml:"externalVmNetworkName"`
+	// IP addresses in these subnet ranges will be excluded when selecting
+	// the IP address from the VirtualMachine's VM for use in the
+	// status.addresses fields.
+	ExcludeInternalNetworkSubnetCIDR string `yaml:"excludeInternalNetworkSubnetCidr"`
+	ExcludeExternalNetworkSubnetCIDR string `yaml:"excludeExternalNetworkSubnetCidr"`
 }
 
 // CPIConfigYAML is the YAML representation

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -222,6 +222,8 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 
 	var internalNetworkSubnets []*net.IPNet
 	var externalNetworkSubnets []*net.IPNet
+	var excludeInternalNetworkSubnets []*net.IPNet
+	var excludeExternalNetworkSubnets []*net.IPNet
 	var internalVMNetworkName string
 	var externalVMNetworkName string
 
@@ -231,6 +233,14 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 			return err
 		}
 		externalNetworkSubnets, err = parseCIDRs(nm.cfg.Nodes.ExternalNetworkSubnetCIDR)
+		if err != nil {
+			return err
+		}
+		excludeInternalNetworkSubnets, err = parseCIDRs(nm.cfg.Nodes.ExcludeInternalNetworkSubnetCIDR)
+		if err != nil {
+			return err
+		}
+		excludeExternalNetworkSubnets, err = parseCIDRs(nm.cfg.Nodes.ExcludeExternalNetworkSubnetCIDR)
 		if err != nil {
 			return err
 		}
@@ -278,6 +288,8 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 			ipFamily,
 			internalNetworkSubnets,
 			externalNetworkSubnets,
+			excludeInternalNetworkSubnets,
+			excludeExternalNetworkSubnets,
 			internalVMNetworkName,
 			externalVMNetworkName,
 		)
@@ -344,9 +356,15 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 // the first ipAddrNetworkName of the desired family is returned as both the
 // internal and external matches.
 //
+// ipAddrNetworkNames that are contained in the excludeInternalNetworkSubnets
+// will never be returned as an internal address, and similarly addresses
+// contained in the exludedExternalNetworkSubnets will never be returned
+// as an external address - no matter the method of disovery described above.
+//
 // If either of these IPs cannot be discovered, nil will be returned instead.
 func discoverIPs(ipAddrNetworkNames []*ipAddrNetworkName, ipFamily string,
-	internalNetworkSubnets, externalNetworkSubnets []*net.IPNet,
+	internalNetworkSubnets, externalNetworkSubnets,
+	excludeInternalNetworkSubnets, excludeExternalNetworkSubnets []*net.IPNet,
 	internalVMNetworkName, externalVMNetworkName string) (internal *ipAddrNetworkName, external *ipAddrNetworkName) {
 
 	ipFamilyMatches := collectMatchesForIPFamily(ipAddrNetworkNames, ipFamily)
@@ -354,25 +372,28 @@ func discoverIPs(ipAddrNetworkNames []*ipAddrNetworkName, ipFamily string,
 	var discoveredInternal *ipAddrNetworkName
 	var discoveredExternal *ipAddrNetworkName
 
-	if len(ipFamilyMatches) != 0 {
-		discoveredInternal = findSubnetMatch(ipFamilyMatches, internalNetworkSubnets)
+	filteredInternalMatches := filterSubnetExclusions(ipFamilyMatches, excludeInternalNetworkSubnets)
+	filteredExternalMatches := filterSubnetExclusions(ipFamilyMatches, excludeExternalNetworkSubnets)
+
+	if len(filteredInternalMatches) > 0 || len(filteredExternalMatches) > 0 {
+		discoveredInternal = findSubnetMatch(filteredInternalMatches, internalNetworkSubnets)
 		if discoveredInternal != nil {
 			klog.V(2).Infof("Adding Internal IP by AddressMatching: %s", discoveredInternal.ipAddr)
 		}
-		discoveredExternal = findSubnetMatch(ipFamilyMatches, externalNetworkSubnets)
+		discoveredExternal = findSubnetMatch(filteredExternalMatches, externalNetworkSubnets)
 		if discoveredExternal != nil {
 			klog.V(2).Infof("Adding External IP by AddressMatching: %s", discoveredExternal.ipAddr)
 		}
 
 		if discoveredInternal == nil && internalVMNetworkName != "" {
-			discoveredInternal = findNetworkNameMatch(ipFamilyMatches, internalVMNetworkName)
+			discoveredInternal = findNetworkNameMatch(filteredInternalMatches, internalVMNetworkName)
 			if discoveredInternal != nil {
 				klog.V(2).Infof("Adding Internal IP by NetworkName: %s", discoveredInternal.ipAddr)
 			}
 		}
 
 		if discoveredExternal == nil && externalVMNetworkName != "" {
-			discoveredExternal = findNetworkNameMatch(ipFamilyMatches, externalVMNetworkName)
+			discoveredExternal = findNetworkNameMatch(filteredExternalMatches, externalVMNetworkName)
 			if discoveredExternal != nil {
 				klog.V(2).Infof("Adding External IP by NetworkName: %s", discoveredExternal.ipAddr)
 			}
@@ -382,10 +403,16 @@ func discoverIPs(ipAddrNetworkNames []*ipAddrNetworkName, ipFamily string,
 		// address selection behavior which is to only support a single address and
 		// return the first one found
 		if discoveredInternal == nil && discoveredExternal == nil {
-			klog.V(5).Info("Default address selection. Single NIC, Single IP Address")
-			klog.V(2).Infof("Adding IP: %s", ipFamilyMatches[0].ipAddr)
-			discoveredInternal = ipFamilyMatches[0]
-			discoveredExternal = ipFamilyMatches[0]
+			klog.V(5).Info("Default address selection.")
+			if len(filteredInternalMatches) > 0 {
+				klog.V(2).Infof("Adding Internal IP: %s", filteredInternalMatches[0].ipAddr)
+				discoveredInternal = filteredInternalMatches[0]
+			}
+
+			if len(filteredExternalMatches) > 0 {
+				klog.V(2).Infof("Adding External IP: %s", filteredExternalMatches[0].ipAddr)
+				discoveredExternal = filteredExternalMatches[0]
+			}
 		} else {
 			// At least one of the Internal or External addresses has been found.
 			// Minimally the Internal needs to exist for the node to function correctly.
@@ -532,6 +559,18 @@ func excludeLocalhostIPs(ipAddrNetworkNames []*ipAddrNetworkName) []*ipAddrNetwo
 			klog.V(4).Infof("IP is local only or there was an error. ip=%q err=%v", i.ipAddr, err)
 		}
 		return err == nil
+	})
+}
+
+func filterSubnetExclusions(ipAddrNetworkNames []*ipAddrNetworkName, exlusionSubnets []*net.IPNet) []*ipAddrNetworkName {
+	return filter(ipAddrNetworkNames, func(i *ipAddrNetworkName) bool {
+		for _, exlusionSubnet := range exlusionSubnets {
+			if exlusionSubnet.Contains(i.ip()) {
+				klog.V(4).Infof("IP is excluded %q because it is contained in exlusion subnet %q", i.ipAddr, exlusionSubnet.String())
+				return false
+			}
+		}
+		return true
 	})
 }
 

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -1316,6 +1316,42 @@ func TestDiscoverNodeIPs(t *testing.T) {
 			},
 		},
 		{
+			testName: "ByDefaultSelection_itDoesNotSelectIPsFromtheExclusionCIDRList",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4", "ipv6"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						ExcludeInternalNetworkSubnetCIDR: "172.15.108.11/32,fd00:cccc::1/128,fd00:cccc::2/128",
+						ExcludeExternalNetworkSubnetCIDR: "172.15.108.11/32,172.15.108.12/32,fd00:cccc::1/128",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "net_a",
+						IpAddress: []string{
+							"172.15.108.11",
+							"172.15.108.12",
+							"172.15.108.13",
+							"fd00:cccc::1",
+						},
+					},
+					{
+						Network: "net_b",
+						IpAddress: []string{
+							"fd00:cccc::2",
+							"fd00:cccc::3",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "172.15.108.12"},
+				{Type: "ExternalIP", Address: "172.15.108.13"},
+				{Type: "InternalIP", Address: "fd00:cccc::3"},
+				{Type: "ExternalIP", Address: "fd00:cccc::2"},
+			},
+		},
+		{
 			testName: "ByDefaultSelection_DualStackIPv6Primary_itReturnsIPv6AddrsFirst",
 			setup: testSetup{
 				ipFamilyPriority: []string{"ipv6", "ipv4"},
@@ -1376,6 +1412,139 @@ func TestDiscoverNodeIPs(t *testing.T) {
 				{Type: "InternalIP", Address: "172.15.108.11"},
 				{Type: "ExternalIP", Address: "172.15.108.12"},
 			},
+		},
+		{
+			testName: "BySubnet_itDoesNotSelectIPsFromtheExclusionCIDRList",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4", "ipv6"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalNetworkSubnetCIDR: "172.15.0.0/16,fd00:cccc::0/32",
+						ExternalNetworkSubnetCIDR: "173.15.0.0/16,fd01:cccc::0/32",
+
+						ExcludeInternalNetworkSubnetCIDR: "172.15.108.11/32,fd00:cccc::1/128,fd00:cccc::2/128",
+						ExcludeExternalNetworkSubnetCIDR: "173.15.108.11/32,173.15.108.12/32,fd01:cccc::1/128",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"172.15.108.11",
+							"172.15.108.12",
+							"172.15.108.13",
+							"fd00:cccc::1",
+							"fd00:cccc::2",
+							"fd00:cccc::3",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"173.15.108.11",
+							"173.15.108.12",
+							"173.15.108.13",
+							"fd01:cccc::1",
+							"fd01:cccc::2",
+							"fd01:cccc::3",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "172.15.108.12"},
+				{Type: "ExternalIP", Address: "173.15.108.13"},
+				{Type: "InternalIP", Address: "fd00:cccc::3"},
+				{Type: "ExternalIP", Address: "fd01:cccc::2"},
+			},
+		},
+		{
+			testName: "ByNetworkName_itDoesNotSelectIPsFromtheExclusionCIDRList",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv4", "ipv6"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						InternalVMNetworkName:            "internal_net",
+						ExternalVMNetworkName:            "external_net",
+						ExcludeInternalNetworkSubnetCIDR: "172.15.108.11/32,fd00:cccc::1/128,fd00:cccc::2/128",
+						ExcludeExternalNetworkSubnetCIDR: "173.15.108.11/32,173.15.108.12/32,fd01:cccc::1/128",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"172.15.108.11",
+							"172.15.108.12",
+							"172.15.108.13",
+							"fd00:cccc::1",
+							"fd00:cccc::2",
+							"fd00:cccc::3",
+						},
+					},
+					{
+						Network: "external_net",
+						IpAddress: []string{
+							"173.15.108.11",
+							"173.15.108.12",
+							"173.15.108.13",
+							"fd01:cccc::1",
+							"fd01:cccc::2",
+							"fd01:cccc::3",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "172.15.108.12"},
+				{Type: "ExternalIP", Address: "173.15.108.13"},
+				{Type: "InternalIP", Address: "fd00:cccc::3"},
+				{Type: "ExternalIP", Address: "fd01:cccc::2"},
+			},
+		},
+		{
+			testName: "Dualstack_ExcludingSubnets_whenNoIPv4AddrIsDiscovered",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv6", "ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						ExcludeInternalNetworkSubnetCIDR: "172.15.108.11/8",
+						ExcludeExternalNetworkSubnetCIDR: "172.15.108.11/8",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"172.15.108.11",
+							"fd00:cccc::1",
+						},
+					},
+				},
+			},
+			expectedErrorSubstring: "unable to find suitable IP address for node",
+		},
+		{
+			testName: "Dualstack_ExcludingSubnets_whenNoIPv6AddrIsDiscovered",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv6", "ipv4"},
+				cpiConfig: &ccfg.CPIConfig{
+					Nodes: ccfg.Nodes{
+						ExcludeInternalNetworkSubnetCIDR: "fd00:cccc::1/16",
+						ExcludeExternalNetworkSubnetCIDR: "fd00:cccc::1/16",
+					},
+				},
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "internal_net",
+						IpAddress: []string{
+							"172.15.108.11",
+							"fd00:cccc::1",
+						},
+					},
+				},
+			},
+			expectedErrorSubstring: "unable to find suitable IP address for node",
 		},
 		{
 			testName: "DualStack_whenNoIPsOfOneFamilyAreDiscovered",


### PR DESCRIPTION
Adds ability to configure subnets describing what ranges shall be
excluded from node ip selection. External subnet exclusions and internal
subnet exlusions are separately configureable.

Signed-off-by: Tyler Schultz <tschultz@vmware.com>
Co-authored-by: Aidan Obley <aobley@vmware.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This should be generally useful. The case I'm interested in is avoiding the kube-vip assigned IP. In my use case,
I know the kube-vip IP. but I don't know up front the subnets that IPs should be selected from.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ability to exclude subnets for internal/external node ip selection
```
