### PR TITLE
add documentation for cloud config Nodes values

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -344,22 +344,22 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 //
 // The returned ipAddrNetworkNames will match the given ipFamily.
 //
+// ipAddrNetworkNames that are contained in the excludeInternalNetworkSubnets
+// will never be returned as an internal address, and similarly addresses
+// contained in the exludedExternalNetworkSubnets will never be returned
+// as an external address - no matter the method of discovery described below.
+//
 // The returned ipAddrNetworkNames will be selected first by attempting to
 // match the given internalNetworkSubnets and externalNetworkSubnets. Subnet
 // matching has the highest precedence.
 //
 // If subnet matches are not found, or if subnets are not provided, then an
-// attempt is made to select ipAddrNetworkNames that match the givent network
+// attempt is made to select ipAddrNetworkNames that match the given network
 // names. Network name matching has the second highest precedence.
 //
 // If ipAddrNetworkNames are not found by subnet nor network name matching, then
 // the first ipAddrNetworkName of the desired family is returned as both the
 // internal and external matches.
-//
-// ipAddrNetworkNames that are contained in the excludeInternalNetworkSubnets
-// will never be returned as an internal address, and similarly addresses
-// contained in the exludedExternalNetworkSubnets will never be returned
-// as an external address - no matter the method of disovery described above.
 //
 // If either of these IPs cannot be discovered, nil will be returned instead.
 func discoverIPs(ipAddrNetworkNames []*ipAddrNetworkName, ipFamily string,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR is a follow up to #556. This PR documents the behavior of the exclude-internal-network-subnet-cidr
and exclude-external-network-subnet-cidr config variables introduced in the previous PR.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
