### PR TITLE
Return an error if multiple VMs with the same hostname was found

### DIFF
--- a/pkg/common/vclib/custom_errors.go
+++ b/pkg/common/vclib/custom_errors.go
@@ -25,6 +25,7 @@ const (
 	DiskNotFoundErrMsg             = "No vSphere disk ID/Name found"
 	InvalidVolumeOptionsErrMsg     = "VolumeOptions verification failed"
 	NoVMFoundErrMsg                = "No VM found"
+	MultipleVMsFoundErrMsg         = "Multiple VMs found"
 	NoZoneRegionFoundErrMsg        = "Unable to find the Zone/Region pair"
 	NoDatastoreFoundErrMsg         = "Datastore not found"
 	NoDatacenterFoundErrMsg        = "Datacenter not found"
@@ -38,6 +39,7 @@ var (
 	ErrNoDiskIDFound            = errors.New(DiskNotFoundErrMsg)
 	ErrInvalidVolumeOptions     = errors.New(InvalidVolumeOptionsErrMsg)
 	ErrNoVMFound                = errors.New(NoVMFoundErrMsg)
+	ErrMultipleVMsFound         = errors.New(MultipleVMsFoundErrMsg)
 	ErrNoZoneRegionFound        = errors.New(NoZoneRegionFoundErrMsg)
 	ErrNoDatastoreFound         = errors.New(NoDatastoreFoundErrMsg)
 	ErrNoDatacenterFound        = errors.New(NoDatacenterFoundErrMsg)

--- a/pkg/common/vclib/datacenter.go
+++ b/pkg/common/vclib/datacenter.go
@@ -98,16 +98,20 @@ func (dc *Datacenter) GetVMByIP(ctx context.Context, ipAddy string) (*VirtualMac
 func (dc *Datacenter) GetVMByDNSName(ctx context.Context, dnsName string) (*VirtualMachine, error) {
 	s := object.NewSearchIndex(dc.Client())
 	dnsName = strings.ToLower(strings.TrimSpace(dnsName))
-	svm, err := s.FindByDnsName(ctx, dc.Datacenter, dnsName, true)
+	svms, err := s.FindAllByDnsName(ctx, dc.Datacenter, dnsName, true)
 	if err != nil {
 		klog.Errorf("Failed to find VM by DNS Name. VM DNS Name: %s, err: %+v", dnsName, err)
 		return nil, err
 	}
-	if svm == nil {
+	if len(svms) == 0 {
 		klog.Errorf("Unable to find VM by DNS Name. VM DNS Name: %s", dnsName)
 		return nil, ErrNoVMFound
 	}
-	virtualMachine := VirtualMachine{svm.(*object.VirtualMachine), dc}
+	if len(svms) > 1 {
+		klog.Errorf("Multiple vms found VM by DNS Name. DNS Name: %s", dnsName)
+		return nil, ErrMultipleVMsFound
+	}
+	virtualMachine := VirtualMachine{svms[0].(*object.VirtualMachine), dc}
 	return &virtualMachine, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In case if multiple VMs with the same hostname exists
within the same scope, picking the wrong VM is quite possible,
which might lead to hard-diagnosable issues with
Nodes initialization, or even to set up incorrect values (ProviderID, addresses) on a Node object.

For avoid ambiguity `FindByDnsName` call was replaced to `FindAllByDnsName`,
`GetVMByDNSName` function now returns an error in case if
multiple VMs with the same HostName was found.

**Special notes for your reviewer**:
--
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added check for multiple VMs with the same hostname during initial node discovery. In case if multiple VMs with the same hostname exists this would be considered as an error.
```
