### PR TITLE
Wrong vCenter IP in kubernetes-on-vsphere-with-kubeadm.md secrets example

### DIFF
--- a/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
+++ b/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
@@ -556,7 +556,7 @@ In the example `vsphere.conf` above, there are two configured [Kubernetes secret
 
 An example [Secrets YAML](https://github.com/kubernetes/cloud-provider-vsphere/raw/master/manifests/controller-manager/vccm-secret.yaml) can be used for reference when creating your own `secrets`. If the example secret YAML is used, update the secret name to use a `<unique secret name>`, the vCenter IP address in the keys of `stringData`, and the `username` and `password` for each key.
 
-The secret for the vCenter at `1.1.1.1` might look like the following:
+The secret for the vCenter at `10.0.0.1` might look like the following:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The example text and the example yaml didn't share the same IP address for vCenter

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
