### PR TITLE
Backport node ip exclusion to 1.22 branch

### DIFF
--- a/pkg/cloudprovider/vsphere/config/config_ini_legacy.go
+++ b/pkg/cloudprovider/vsphere/config/config_ini_legacy.go
@@ -35,10 +35,12 @@ func (cci *CPIConfigINI) CreateConfig() *CPIConfig {
 	cfg := &CPIConfig{
 		*cci.CommonConfigINI.CreateConfig(),
 		Nodes{
-			InternalNetworkSubnetCIDR: cci.Nodes.InternalNetworkSubnetCIDR,
-			ExternalNetworkSubnetCIDR: cci.Nodes.ExternalNetworkSubnetCIDR,
-			InternalVMNetworkName:     cci.Nodes.InternalVMNetworkName,
-			ExternalVMNetworkName:     cci.Nodes.ExternalVMNetworkName,
+			InternalNetworkSubnetCIDR:        cci.Nodes.InternalNetworkSubnetCIDR,
+			ExternalNetworkSubnetCIDR:        cci.Nodes.ExternalNetworkSubnetCIDR,
+			InternalVMNetworkName:            cci.Nodes.InternalVMNetworkName,
+			ExternalVMNetworkName:            cci.Nodes.ExternalVMNetworkName,
+			ExcludeInternalNetworkSubnetCIDR: cci.Nodes.ExcludeInternalNetworkSubnetCIDR,
+			ExcludeExternalNetworkSubnetCIDR: cci.Nodes.ExcludeExternalNetworkSubnetCIDR,
 		},
 	}
 

--- a/pkg/cloudprovider/vsphere/config/config_yaml.go
+++ b/pkg/cloudprovider/vsphere/config/config_yaml.go
@@ -36,10 +36,12 @@ func (ccy *CPIConfigYAML) CreateConfig() *CPIConfig {
 	cfg := &CPIConfig{
 		*ccy.CommonConfigYAML.CreateConfig(),
 		Nodes{
-			InternalNetworkSubnetCIDR: ccy.Nodes.InternalNetworkSubnetCIDR,
-			ExternalNetworkSubnetCIDR: ccy.Nodes.ExternalNetworkSubnetCIDR,
-			InternalVMNetworkName:     ccy.Nodes.InternalVMNetworkName,
-			ExternalVMNetworkName:     ccy.Nodes.ExternalVMNetworkName,
+			InternalNetworkSubnetCIDR:        ccy.Nodes.InternalNetworkSubnetCIDR,
+			ExternalNetworkSubnetCIDR:        ccy.Nodes.ExternalNetworkSubnetCIDR,
+			InternalVMNetworkName:            ccy.Nodes.InternalVMNetworkName,
+			ExternalVMNetworkName:            ccy.Nodes.ExternalVMNetworkName,
+			ExcludeInternalNetworkSubnetCIDR: ccy.Nodes.ExcludeInternalNetworkSubnetCIDR,
+			ExcludeExternalNetworkSubnetCIDR: ccy.Nodes.ExcludeExternalNetworkSubnetCIDR,
 		},
 	}
 

--- a/pkg/cloudprovider/vsphere/config/config_yaml_test.go
+++ b/pkg/cloudprovider/vsphere/config/config_yaml_test.go
@@ -57,6 +57,22 @@ nodes:
   externalVmNetworkName: External/Outbound Traffic
 `
 
+const excludeSubnetCidrYAMLConfig = `
+global:
+  server: 0.0.0.0
+  port: 443
+  user: user
+  password: password
+  insecureFlag: true
+  datacenters:
+    - us-west
+  caFile: /some/path/to/a/ca.pem
+
+nodes:
+  excludeInternalNetworkSubnetCidr: "192.0.2.0/24,fe80::1/128"
+  excludeExternalNetworkSubnetCidr: "192.1.2.0/24,fe80::2/128"
+`
+
 func TestReadYAMLConfigSubnetCidr(t *testing.T) {
 	_, err := ReadCPIConfigYAML(nil)
 	if err == nil {
@@ -97,5 +113,20 @@ func TestReadYAMLConfigNetworkName(t *testing.T) {
 
 	if cfg.Nodes.ExternalVMNetworkName != "External/Outbound Traffic" {
 		t.Errorf("incorrect internal vm network name: %s", cfg.Nodes.ExternalVMNetworkName)
+	}
+}
+
+func TestReadYAMLConfigExcludeSubnetCidr(t *testing.T) {
+	cfg, err := ReadCPIConfigYAML([]byte(excludeSubnetCidrYAMLConfig))
+	if err != nil {
+		t.Fatalf("Should succeed when a valid config is provided: %s", err)
+	}
+
+	if cfg.Nodes.ExcludeInternalNetworkSubnetCIDR != "192.0.2.0/24,fe80::1/128" {
+		t.Errorf("incorrect exclude internal network subnet cidrs: %s", cfg.Nodes.ExcludeInternalNetworkSubnetCIDR)
+	}
+
+	if cfg.Nodes.ExcludeExternalNetworkSubnetCIDR != "192.1.2.0/24,fe80::2/128" {
+		t.Errorf("incorrect exclude external network subnet cidrs: %s", cfg.Nodes.ExcludeExternalNetworkSubnetCIDR)
 	}
 }

--- a/pkg/cloudprovider/vsphere/config/types_common.go
+++ b/pkg/cloudprovider/vsphere/config/types_common.go
@@ -38,6 +38,11 @@ type Nodes struct {
 	// only have a single IP address assigned to it.
 	InternalVMNetworkName string
 	ExternalVMNetworkName string
+	// IP addresses in these subnet ranges will be excluded when selecting
+	// the IP address from the VirtualMachine's VM for use in the
+	// status.addresses fields.
+	ExcludeInternalNetworkSubnetCIDR string
+	ExcludeExternalNetworkSubnetCIDR string
 }
 
 // CPIConfig is used to read and store information (related only to the CPI) from the cloud configuration file

--- a/pkg/cloudprovider/vsphere/config/types_ini_legacy.go
+++ b/pkg/cloudprovider/vsphere/config/types_ini_legacy.go
@@ -37,6 +37,11 @@ type NodesINI struct {
 	// only have a single IP address assigned to it.
 	InternalVMNetworkName string `gcfg:"internal-vm-network-name"`
 	ExternalVMNetworkName string `gcfg:"external-vm-network-name"`
+	// IP addresses in these subnet ranges will be excluded when selecting
+	// the IP address from the VirtualMachine's VM for use in the
+	// status.addresses fields.
+	ExcludeInternalNetworkSubnetCIDR string `gcfg:"exclude-internal-network-subnet-cidr"`
+	ExcludeExternalNetworkSubnetCIDR string `gcfg:"exclude-external-network-subnet-cidr"`
 }
 
 // CPIConfigINI is the INI representation

--- a/pkg/cloudprovider/vsphere/config/types_yaml.go
+++ b/pkg/cloudprovider/vsphere/config/types_yaml.go
@@ -41,6 +41,11 @@ type NodesYAML struct {
 	// only have a single IP address assigned to it.
 	InternalVMNetworkName string `yaml:"internalVmNetworkName"`
 	ExternalVMNetworkName string `yaml:"externalVmNetworkName"`
+	// IP addresses in these subnet ranges will be excluded when selecting
+	// the IP address from the VirtualMachine's VM for use in the
+	// status.addresses fields.
+	ExcludeInternalNetworkSubnetCIDR string `yaml:"excludeInternalNetworkSubnetCidr"`
+	ExcludeExternalNetworkSubnetCIDR string `yaml:"excludeExternalNetworkSubnetCidr"`
 }
 
 // CPIConfigYAML is the YAML representation


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR backports these 2 PRs from the master branch
https://github.com/kubernetes/cloud-provider-vsphere/pull/556
https://github.com/kubernetes/cloud-provider-vsphere/pull/559

Adds ability to configure subnets describing what ranges shall be
excluded from node ip selection. External subnet exclusions and internal
subnet exlusions are separately configureable.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This should be generally useful. The case I'm interested in is avoiding the kube-vip assigned IP. In my use case,
I know the kube-vip IP. but I don't know up front the subnets that IPs should be selected from.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ability to exclude subnets for internal/external node ip selection
```
