### PR TITLE
Patch priorityClassName: system-node-critical in CPI daemonset

### DIFF
--- a/charts/vsphere-cpi/templates/daemonset.yaml
+++ b/charts/vsphere-cpi/templates/daemonset.yaml
@@ -66,6 +66,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       hostNetwork: true
       dnsPolicy: {{ .Values.daemonset.dnsPolicy }}
+      priorityClassName: system-node-critical
       containers:
       - name: {{ template "cpi.name" . }}
         image: {{ .Values.daemonset.image }}:{{ .Values.daemonset.tag }}

--- a/releases/v1.18/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.18/vsphere-cloud-controller-manager.yaml
@@ -232,6 +232,7 @@ spec:
       securityContext:
         runAsUser: 1001
       serviceAccountName: cloud-controller-manager
+      priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
           image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.18.0

--- a/releases/v1.19/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.19/vsphere-cloud-controller-manager.yaml
@@ -232,6 +232,7 @@ spec:
       securityContext:
         runAsUser: 1001
       serviceAccountName: cloud-controller-manager
+      priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
           image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.19.0

--- a/releases/v1.2/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.2/vsphere-cloud-controller-manager.yaml
@@ -201,6 +201,7 @@ spec:
         effect: NoSchedule
         operator: Exists
       serviceAccountName: cloud-controller-manager
+      priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
           image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1

--- a/releases/v1.20/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.20/vsphere-cloud-controller-manager.yaml
@@ -232,6 +232,7 @@ spec:
       securityContext:
         runAsUser: 1001
       serviceAccountName: cloud-controller-manager
+      priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
           image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.20.0

--- a/releases/v1.21/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.21/vsphere-cloud-controller-manager.yaml
@@ -232,6 +232,7 @@ spec:
       securityContext:
         runAsUser: 1001
       serviceAccountName: cloud-controller-manager
+      priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
           image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.21.1

--- a/releases/v1.22/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.22/vsphere-cloud-controller-manager.yaml
@@ -232,6 +232,7 @@ spec:
       securityContext:
         runAsUser: 1001
       serviceAccountName: cloud-controller-manager
+      priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
           image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.22.3


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongliuharold@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add `priorityClassName: system-node-critical` to avoid cpi pod evicted when there is high load on the control plane node

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #525


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add `priorityClassName: system-node-critical` on cpi pod
```
