### PR TITLE
[Cherry-Pick] Deprecate pod priority annotation in cpi deployment

### DIFF
--- a/charts/vsphere-cpi/templates/daemonset.yaml
+++ b/charts/vsphere-cpi/templates/daemonset.yaml
@@ -9,7 +9,6 @@ metadata:
     tier: control-plane
   namespace: {{ .Release.Namespace }}
   annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
     {{- if .Values.daemonset.annotations }}
     {{- toYaml .Values.daemonset.annotations | nindent 4 }}
     {{- end }}

--- a/docs/book/tutorials/disable-node-deletion.yaml
+++ b/docs/book/tutorials/disable-node-deletion.yaml
@@ -202,8 +202,6 @@ metadata:
     component: cloud-controller-manager
     tier: control-plane
   namespace: kube-system
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
   selector:
     matchLabels:
@@ -232,6 +230,7 @@ spec:
       securityContext:
         runAsUser: 1001
       serviceAccountName: cloud-controller-manager
+      priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
           image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.23.0-alpha.1

--- a/releases/v1.18/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.18/vsphere-cloud-controller-manager.yaml
@@ -202,8 +202,6 @@ metadata:
     component: cloud-controller-manager
     tier: control-plane
   namespace: kube-system
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
   selector:
     matchLabels:

--- a/releases/v1.19/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.19/vsphere-cloud-controller-manager.yaml
@@ -202,8 +202,6 @@ metadata:
     component: cloud-controller-manager
     tier: control-plane
   namespace: kube-system
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
   selector:
     matchLabels:

--- a/releases/v1.20/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.20/vsphere-cloud-controller-manager.yaml
@@ -202,8 +202,6 @@ metadata:
     component: cloud-controller-manager
     tier: control-plane
   namespace: kube-system
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
   selector:
     matchLabels:

--- a/releases/v1.21/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.21/vsphere-cloud-controller-manager.yaml
@@ -202,8 +202,6 @@ metadata:
     component: cloud-controller-manager
     tier: control-plane
   namespace: kube-system
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
   selector:
     matchLabels:

--- a/releases/v1.22/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.22/vsphere-cloud-controller-manager.yaml
@@ -202,8 +202,6 @@ metadata:
     component: cloud-controller-manager
     tier: control-plane
   namespace: kube-system
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
   selector:
     matchLabels:

--- a/releases/v1.23/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.23/vsphere-cloud-controller-manager.yaml
@@ -202,8 +202,6 @@ metadata:
     component: cloud-controller-manager
     tier: control-plane
   namespace: kube-system
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
 spec:
   selector:
     matchLabels:
@@ -232,6 +230,7 @@ spec:
       securityContext:
         runAsUser: 1001
       serviceAccountName: cloud-controller-manager
+      priorityClassName: system-node-critical
       containers:
         - name: vsphere-cloud-controller-manager
           image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.23.0-alpha.1


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Since the priority annotation has been removed from k8s 1.12+ and we have already adopt the priority class in this PR: #569, deprecate all the pod priority annotations in CPI manifest.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: follow up fixes #525

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Deprecate `scheduler.alpha.kubernetes.io/critical-pod` annotation in cpi manifest.
```
