### PR TITLE
Refactor unit-test and  test-cover in MAKEFILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,10 +216,15 @@ export PKGS_WITH_TESTS := $(sort $(shell find ./pkg -name "*_test.go" -type f -e
 endif
 TEST_FLAGS ?= -v
 .PHONY: unit build-unit-tests
+KUBE_BUILDER_VERSION = 2.3.1
+KUBE_BUILDER = kubebuilder_${KUBE_BUILDER_VERSION}_${GOOS}_${GOARCH}
+KUBE_BUILDER_DIR = "/usr/local/kubebuilder/$(KUBE_BUILDER)"
 unit unit-test:
-	curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${GOOS}_${GOARCH}.tar.gz | tar -xz -C /tmp/
-	mv /tmp/kubebuilder_2.3.1_${GOOS}_${GOARCH} /usr/local/kubebuilder
-	export PATH=$PATH:/usr/local/kubebuilder/bin
+	@if [ ! -d $(KUBE_BUILDER_DIR) ]; then \
+	curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBE_BUILDER_VERSION}/${KUBE_BUILDER}.tar.gz | tar -xz -C /tmp/ ;\
+	mv /tmp/${KUBE_BUILDER} /usr/local/kubebuilder; \
+	export PATH=$PATH:/usr/local/kubebuilder/bin; \
+	fi
 	env -u VSPHERE_SERVER -u VSPHERE_PASSWORD -u VSPHERE_USER go test $(TEST_FLAGS) -tags=unit $(PKGS_WITH_TESTS)
 build-unit-tests:
 	$(foreach pkg,$(PKGS_WITH_TESTS),go test $(TEST_FLAGS) -c -tags=unit $(pkg); )
@@ -230,8 +235,8 @@ test: unit
 build-tests: build-unit-tests
 
 .PHONY: test-cover
-test-cover:  ## Run tests with code coverage and code generate reports
-	go test -v -coverprofile=coverage.out ./...
+test-cover: TEST_FLAGS += -coverprofile=coverage.out ## Run tests with code coverage and code generate reports
+test-cover: test
 	go tool cover -func=coverage.out -o coverage.txt
 	go tool cover -html=coverage.out -o coverage.html
 


### PR DESCRIPTION
Signed-off-by: Chen Lin <linch@vmware.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We need to install kubebuilder before running test-cover. Refactor unit-test and put unit-test as dependency for test-cover.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Run test-cover job on ProwJob, output file: [build-log.txt](https://github.com/kubernetes/cloud-provider-vsphere/files/7954884/build-log.txt)
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
