### PR TITLE
[Cherry-Pick] Add test coverage for 1.23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,7 @@ zz_generated.openapi.go
 
 # binaries
 /vsphere-cloud-controller-manager
+
+# Output of the go coverage tool
+*.out
+coverage.*

--- a/Makefile
+++ b/Makefile
@@ -216,10 +216,15 @@ export PKGS_WITH_TESTS := $(sort $(shell find ./pkg -name "*_test.go" -type f -e
 endif
 TEST_FLAGS ?= -v
 .PHONY: unit build-unit-tests
+KUBE_BUILDER_VERSION = 2.3.1
+KUBE_BUILDER = kubebuilder_${KUBE_BUILDER_VERSION}_${GOOS}_${GOARCH}
+KUBE_BUILDER_DIR = "/usr/local/kubebuilder/$(KUBE_BUILDER)"
 unit unit-test:
-	curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.1/kubebuilder_2.3.1_${GOOS}_${GOARCH}.tar.gz | tar -xz -C /tmp/
-	mv /tmp/kubebuilder_2.3.1_${GOOS}_${GOARCH} /usr/local/kubebuilder
-	export PATH=$PATH:/usr/local/kubebuilder/bin
+	@if [ ! -d $(KUBE_BUILDER_DIR) ]; then \
+	curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBE_BUILDER_VERSION}/${KUBE_BUILDER}.tar.gz | tar -xz -C /tmp/ ;\
+	mv /tmp/${KUBE_BUILDER} /usr/local/kubebuilder; \
+	export PATH=$PATH:/usr/local/kubebuilder/bin; \
+	fi
 	env -u VSPHERE_SERVER -u VSPHERE_PASSWORD -u VSPHERE_USER go test $(TEST_FLAGS) -tags=unit $(PKGS_WITH_TESTS)
 build-unit-tests:
 	$(foreach pkg,$(PKGS_WITH_TESTS),go test $(TEST_FLAGS) -c -tags=unit $(pkg); )
@@ -230,8 +235,8 @@ test: unit
 build-tests: build-unit-tests
 
 .PHONY: test-cover
-test-cover:  ## Run tests with code coverage and code generate reports
-	go test -v -coverprofile=coverage.out ./...
+test-cover: TEST_FLAGS += -coverprofile=coverage.out ## Run tests with code coverage and code generate reports
+test-cover: test
 	go tool cover -func=coverage.out -o coverage.txt
 	go tool cover -html=coverage.out -o coverage.html
 

--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,11 @@ build-unit-tests:
 test: unit
 build-tests: build-unit-tests
 
-.PHONY: cover
-cover: TEST_FLAGS += -cover
-cover: test
+.PHONY: test-cover
+test-cover:  ## Run tests with code coverage and code generate reports
+	go test -v -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out -o coverage.txt
+	go tool cover -html=coverage.out -o coverage.html
 
 tools: $(TOOLING_BINARIES) ## Build tooling binaries
 .PHONY: $(TOOLING_BINARIES)

--- a/scripts/ci-test-coverage.sh
+++ b/scripts/ci-test-coverage.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+cd "${REPO_ROOT}" && \
+	make test-cover

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -22,12 +24,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/test/framework"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We want a pipeline to calculate test coverage for unit tests in release 1.23
Cherry-pick changes from:
https://github.com/kubernetes/cloud-provider-vsphere/pull/577
https://github.com/kubernetes/cloud-provider-vsphere/pull/570
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #565

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
