### PR TITLE
Update cluster and node selector labels for paravirutal mode

### DIFF
--- a/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice.go
@@ -39,9 +39,9 @@ import (
 
 const (
 	// ClusterSelectorKey expects key/value pair {ClusterSelectorKey: <cluster name>} for target nodes: ClusterSelectorKey
-	ClusterSelectorKey = "capw.vmware.com/cluster.name"
+	ClusterSelectorKey = "capv.vmware.com/cluster.name"
 	// NodeSelectorKey expects key/value pair {NodeSelectorKey: NodeRole} for target nodes: NodeSelectorKey
-	NodeSelectorKey = "capw.vmware.com/cluster.role"
+	NodeSelectorKey = "capv.vmware.com/cluster.role"
 
 	// NodeRole is set by capw, we are targeting worker vms
 	NodeRole = "node"


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch updates the cluster and node selector for the paravirtual mode for the CPI.

**Which issue this PR fixes**: fixes n/a

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Updates the cluster and node selectors for paravirtual mode
```
