### PR TITLE
[Cherrypick 1.23] Return error when VM's info returned from VC doesn't contains IP address

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -207,6 +207,11 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		return errors.New("VM Guest hostname is empty")
 	}
 
+	if len(oVM.Guest.Net) == 0 {
+		klog.V(4).Infof("oVM.Guest.Net is empty, skipping node discovery. This could be cauesd by vmtool not reporting correct IP address")
+		return errors.New("VM GuestNicInfo is empty")
+	}
+
 	tenantRef := vmDI.VcServer
 	if vmDI.TenantRef != "" {
 		tenantRef = vmDI.TenantRef
@@ -281,6 +286,12 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 	ipAddrNetworkNames := toIPAddrNetworkNames(nonVNICDevices)
 	nonLocalhostIPs := excludeLocalhostIPs(ipAddrNetworkNames)
 
+	if len(nonLocalhostIPs) == 0 {
+		klog.V(4).Infof("nonLocalhostIPs is empty")
+		klog.V(4).Infof("oVM.Guest.Net=%v", oVM.Guest.Net)
+		return fmt.Errorf("unable to find suitable IP address for node after filtering out localhost IPs")
+	}
+
 	for _, ipFamily := range ipFamilies {
 		klog.V(6).Infof("ipFamily: %q nonLocalhostIPs: %q", ipFamily, nonLocalhostIPs)
 		discoveredInternal, discoveredExternal := discoverIPs(
@@ -311,6 +322,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 
 		if len(oVM.Guest.Net) > 0 {
 			if discoveredInternal == nil && discoveredExternal == nil {
+				klog.V(4).Infof("oVM.Guest.Net=%v", oVM.Guest.Net)
 				return fmt.Errorf("unable to find suitable IP address for node %s with IP family %s", nodeID, ipFamilies)
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry pick the change https://github.com/kubernetes/cloud-provider-vsphere/pull/585
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
