### PR TITLE
Add missing logic to pass RemoteAuth when constructing Config

### DIFF
--- a/pkg/nsxt/config/config_ini_legacy.go
+++ b/pkg/nsxt/config/config_ini_legacy.go
@@ -36,6 +36,7 @@ func (nci *NsxtConfigINI) CreateConfig() *Config {
 	cfg.Password = nci.NSXT.Password
 	cfg.Host = nci.NSXT.Host
 	cfg.InsecureFlag = nci.NSXT.InsecureFlag
+	cfg.RemoteAuth = nci.NSXT.RemoteAuth
 	cfg.VMCAccessToken = nci.NSXT.VMCAccessToken
 	cfg.VMCAuthHost = nci.NSXT.VMCAuthHost
 	cfg.ClientAuthCertFile = nci.NSXT.ClientAuthCertFile

--- a/pkg/nsxt/config/config_ini_legacy_test.go
+++ b/pkg/nsxt/config/config_ini_legacy_test.go
@@ -152,7 +152,7 @@ func TestINIValidateSecretConfig(t *testing.T) {
 	}
 }
 
-func TestReadINIConfig(t *testing.T) {
+func TestReadRawConfigINI(t *testing.T) {
 	contents := `
 [NSXT]
 user = admin
@@ -191,4 +191,45 @@ secret-namespace = secret-ns
 	assertEquals("NSXT.ca-file", config.NSXT.CAFile, "ca-file")
 	assertEquals("NSXT.secret-name", config.NSXT.SecretName, "secret-name")
 	assertEquals("NSXT.secret-namespace", config.NSXT.SecretNamespace, "secret-ns")
+}
+
+func TestReadConfigINI(t *testing.T) {
+	contents := `
+[NSXT]
+user = admin
+password = secret
+host = nsxt-server
+insecure-flag = true
+remote-auth = true
+vmc-access-token = vmc-token
+vmc-auth-host = vmc-host
+client-auth-cert-file = client-cert-file
+client-auth-key-file = client-key-file
+ca-file = ca-file
+secret-name = secret-name
+secret-namespace = secret-ns
+	`
+	config, err := ReadConfigINI([]byte(contents))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	assertEquals := func(name, left, right string) {
+		if left != right {
+			t.Errorf("%s %s != %s", name, left, right)
+		}
+	}
+	assertEquals("NSXT.user", config.User, "admin")
+	assertEquals("NSXT.password", config.Password, "secret")
+	assertEquals("NSXT.host", config.Host, "nsxt-server")
+	assert.Equal(t, true, config.InsecureFlag)
+	assert.Equal(t, true, config.RemoteAuth)
+	assertEquals("NSXT.vmc-access-token", config.VMCAccessToken, "vmc-token")
+	assertEquals("NSXT.vmc-auth-host", config.VMCAuthHost, "vmc-host")
+	assertEquals("NSXT.client-auth-cert-file", config.ClientAuthCertFile, "client-cert-file")
+	assertEquals("NSXT.client-auth-key-file", config.ClientAuthKeyFile, "client-key-file")
+	assertEquals("NSXT.ca-file", config.CAFile, "ca-file")
+	assertEquals("NSXT.secret-name", config.SecretName, "secret-name")
+	assertEquals("NSXT.secret-namespace", config.SecretNamespace, "secret-ns")
 }

--- a/pkg/nsxt/config/config_yaml.go
+++ b/pkg/nsxt/config/config_yaml.go
@@ -37,6 +37,7 @@ func (ncy *NsxtConfigYAML) CreateConfig() *Config {
 	cfg.Password = ncy.NSXT.Password
 	cfg.Host = ncy.NSXT.Host
 	cfg.InsecureFlag = ncy.NSXT.InsecureFlag
+	cfg.RemoteAuth = ncy.NSXT.RemoteAuth
 	cfg.VMCAccessToken = ncy.NSXT.VMCAccessToken
 	cfg.VMCAuthHost = ncy.NSXT.VMCAuthHost
 	cfg.ClientAuthCertFile = ncy.NSXT.ClientAuthCertFile

--- a/pkg/nsxt/config/config_yaml_test.go
+++ b/pkg/nsxt/config/config_yaml_test.go
@@ -154,7 +154,7 @@ func TestYAMLValidateSecretConfig(t *testing.T) {
 	}
 }
 
-func TestReadYAMLConfig(t *testing.T) {
+func TestReadRawConfigYAML(t *testing.T) {
 	contents := `
 nsxt:
   user: admin
@@ -193,4 +193,45 @@ nsxt:
 	assertEquals("NSXT.caFile", config.NSXT.CAFile, "ca-file")
 	assertEquals("NSXT.secretName", config.NSXT.SecretName, "secret-name")
 	assertEquals("NSXT.secretNamespace", config.NSXT.SecretNamespace, "secret-ns")
+}
+
+func TestReadConfigYAML(t *testing.T) {
+	contents := `
+nsxt:
+  user: admin
+  password: secret
+  host: nsxt-server
+  insecureFlag: true
+  remoteAuth: true
+  vmcAccessToken: vmc-token
+  vmcAuthHost: vmc-host
+  clientAuthCertFile: client-cert-file
+  clientAuthKeyFile: client-key-file
+  caFile: ca-file
+  secretName: secret-name
+  secretNamespace: secret-ns
+`
+	config, err := ReadConfigYAML([]byte(contents))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	assertEquals := func(name, left, right string) {
+		if left != right {
+			t.Errorf("%s %s != %s", name, left, right)
+		}
+	}
+	assertEquals("NSXT.user", config.User, "admin")
+	assertEquals("NSXT.password", config.Password, "secret")
+	assertEquals("NSXT.host", config.Host, "nsxt-server")
+	assert.Equal(t, true, config.InsecureFlag)
+	assert.Equal(t, true, config.RemoteAuth)
+	assertEquals("NSXT.vmcAccessToken", config.VMCAccessToken, "vmc-token")
+	assertEquals("NSXT.vmcAuthHost", config.VMCAuthHost, "vmc-host")
+	assertEquals("NSXT.clientAuthCertFile", config.ClientAuthCertFile, "client-cert-file")
+	assertEquals("NSXT.clientAuthKeyFile", config.ClientAuthKeyFile, "client-key-file")
+	assertEquals("NSXT.caFile", config.CAFile, "ca-file")
+	assertEquals("NSXT.secretName", config.SecretName, "secret-name")
+	assertEquals("NSXT.secretNamespace", config.SecretNamespace, "secret-ns")
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add missing logic to pass RemoteAuth when constructing Config
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://github.com/kubernetes/cloud-provider-vsphere/issues/588

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix logic to correctly read and pass along value `nsxt.RemoteAuth` in config.
```
