### PR TITLE
Fixed broken link

### DIFF
--- a/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
+++ b/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
@@ -600,7 +600,7 @@ stringData:
 
 ### Zones and Regions for Pod and Volume Placement - CPI
 
-Kubernetes allows you to place Pods and Persistent Volumes on specific parts of the underlying infrastructure, e.g. different DataCenters or different vCenters, using the concept of Zones and Regions. However, to use placement controls, the required configuration steps needs to be put in place at Kubernetes deployment time, and require additional settings in the vSphere.conf of both the CPI and CSI. For more information on how to implement zones/regions support, [there is a zones/regions tutorial on how to do it here](https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/book/tutorials/deploying_cpi_and_csi_with_multi_dc_vc_aka_zones.md).
+Kubernetes allows you to place Pods and Persistent Volumes on specific parts of the underlying infrastructure, e.g. different DataCenters or different vCenters, using the concept of Zones and Regions. However, to use placement controls, the required configuration steps needs to be put in place at Kubernetes deployment time, and require additional settings in the vSphere.conf of both the CPI and CSI. For more information on how to implement zones/regions support, [there is a zones/regions tutorial on how to do it here](https://cloud-provider-vsphere.sigs.k8s.io/tutorials/deploying_cpi_with_multi_dc_vc_aka_zones.html).
 
 If you are not interested in K8s object placement, this section can be ignored, and you can proceed with the remaining CPI setup steps.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In the `Zones and Regions for Pod and Volume Placement - CPI` section, there was a link to a "zones/regions tutorial" that sent the user to a nonexistent Markdown file (https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/book/tutorials/deploying_cpi_and_csi_with_multi_dc_vc_aka_zones.md). I have replaced that broken link with a link to the most similar tutorial I could find in the docs: [Deploying the vSphere CPI and CSI in a Multi-vCenter OR Multi-Datacenter Environment using Zones](https://cloud-provider-vsphere.sigs.k8s.io/tutorials/deploying_cpi_with_multi_dc_vc_aka_zones.html).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #593 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixes broken link in "Zones and Regions for Pod and Volume Placement - CPI" tutorial to another tutorial, "Deploying the vSphere CPI and CSI in a Multi-vCenter OR Multi-Datacenter Environment using Zones"
```
