### PR TITLE
Back port fixes to 1.20

### DIFF
--- a/hack/check-format.sh
+++ b/hack/check-format.sh
@@ -42,6 +42,7 @@ rm -f "${out}" && touch "${out}"
 
 # Run goimports on all the sources.
 go get golang.org/x/tools/cmd/goimports
+go install golang.org/x/tools/cmd/goimports
 cmd=$(go list -f \{\{\.Target\}\} golang.org/x/tools/cmd/goimports)
 flags="-e -w"
 [ -z "${PROW_JOB_ID-}" ] || flags="-d ${flags}"

--- a/hack/check-lint.sh
+++ b/hack/check-lint.sh
@@ -23,6 +23,7 @@ set -o pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 go get golang.org/x/lint/golint
+go install golang.org/x/lint/golint
 
 CMD=$(go list -f \{\{\.Target\}\} golang.org/x/lint/golint)
 

--- a/hack/check-staticcheck.sh
+++ b/hack/check-staticcheck.sh
@@ -23,6 +23,7 @@ set -o pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 go get honnef.co/go/tools/cmd/staticcheck
+go install honnef.co/go/tools/cmd/staticcheck
 CMD=$(go list -f \{\{\.Target\}\} honnef.co/go/tools/cmd/staticcheck)
 
 # re-enable SA1019 when we upgrade to Go 1.14

--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -51,12 +51,6 @@ var _ cloudprovider.Instances = &instances{}
 func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) ([]v1.NodeAddress, error) {
 	klog.V(4).Info("instances.NodeAddresses() called with ", string(nodeName))
 
-	// Check if node has been discovered already
-	if node, ok := i.nodeManager.nodeNameMap[string(nodeName)]; ok {
-		klog.V(2).Info("instances.NodeAddresses() CACHED with ", string(nodeName))
-		return node.NodeAddresses, nil
-	}
-
 	if err := i.nodeManager.DiscoverNode(string(nodeName), cm.FindVMByName); err == nil {
 		if i.nodeManager.nodeNameMap[string(nodeName)] == nil {
 			klog.Errorf("DiscoverNode succeeded, but CACHE missed for node=%s. If this is a Linux VM, hostnames are case sensitive. Make sure they match.", string(nodeName))
@@ -76,12 +70,7 @@ func (i *instances) NodeAddresses(ctx context.Context, nodeName types.NodeName) 
 func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
 	klog.V(4).Info("instances.NodeAddressesByProviderID() called with ", providerID)
 
-	// Check if node has been discovered already
 	uid := GetUUIDFromProviderID(providerID)
-	if node, ok := i.nodeManager.nodeUUIDMap[uid]; ok {
-		klog.V(2).Info("instances.NodeAddressesByProviderID() CACHED with ", uid)
-		return node.NodeAddresses, nil
-	}
 
 	if err := i.nodeManager.DiscoverNode(uid, cm.FindVMByUUID); err == nil {
 		klog.V(2).Info("instances.NodeAddressesByProviderID() FOUND with ", uid)

--- a/pkg/cloudprovider/vsphere/instances.go
+++ b/pkg/cloudprovider/vsphere/instances.go
@@ -34,7 +34,7 @@ import (
 var (
 	// ErrNotFound is returned by NodeAddresses, NodeAddressesByProviderID,
 	// and InstanceID when a node cannot be found.
-	ErrNodeNotFound = errors.New("Node not found")
+	ErrNodeNotFound = errors.New("node not found")
 )
 
 func newInstances(nodeManager *NodeManager) cloudprovider.Instances {

--- a/pkg/cloudprovider/vsphere/instances_test.go
+++ b/pkg/cloudprovider/vsphere/instances_test.go
@@ -80,7 +80,7 @@ func TestInstance(t *testing.T) {
 	instances := newInstances(&nm.NodeManager)
 
 	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
-	name := vm.Name
+	name := strings.ToLower(vm.Name)
 	vm.Guest.HostName = name
 	vm.Guest.Net = []vimtypes.GuestNicInfo{
 		{

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -43,7 +43,7 @@ var (
 
 	// ErrDatacenterNotFound is returned when the configured datacenter cannot
 	// be found.
-	ErrDatacenterNotFound = errors.New("Datacenter not found")
+	ErrDatacenterNotFound = errors.New("datacenter not found")
 
 	// ErrVMNotFound is returned when the specified VM cannot be found.
 	ErrVMNotFound = errors.New("VM not found")
@@ -103,6 +103,19 @@ func (nm *NodeManager) removeNode(uuid string, node *v1.Node) {
 	klog.V(4).Info("removeNode NodeName: ", node.GetName(), ", UID: ", uuid)
 	delete(nm.nodeRegUUIDMap, uuid)
 	nm.nodeRegInfoLock.Unlock()
+
+	nm.nodeInfoLock.Lock()
+	klog.V(4).Info("removeNode from UUID and Name cache. NodeName: ", node.GetName(), ", UID: ", uuid)
+	// in case of a race condition that node with same name create happens before delete event,
+	// delete the node based on uuid
+	name := nm.getNodeNameByUUID(uuid)
+	if name != "" {
+		delete(nm.nodeNameMap, name)
+	} else {
+		klog.V(4).Info("node name: ", node.GetName(), " has a different uuid. Skip deleting this node from cache.")
+	}
+	delete(nm.nodeUUIDMap, uuid)
+	nm.nodeInfoLock.Unlock()
 }
 
 func (nm *NodeManager) shakeOutNodeIDLookup(ctx context.Context, nodeID string, searchBy cm.FindVM) (*cm.VMDiscoveryInfo, error) {
@@ -181,6 +194,10 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 	if err != nil {
 		klog.Errorf("shakeOutNodeIDLookup failed. Err=%v", err)
 		return err
+	}
+
+	if vmDI.UUID == "" {
+		return errors.New("discovered VM UUID is empty")
 	}
 
 	var oVM mo.VirtualMachine
@@ -540,4 +557,14 @@ func (nm *NodeManager) FindNodeInfo(UUID string) (*NodeInfo, error) {
 
 	klog.V(4).Infof("FindNodeInfo( %s ) FOUND", UUIDlower)
 	return nodeInfo, nil
+}
+
+func (nm *NodeManager) getNodeNameByUUID(UUID string) string {
+	for k, v := range nm.nodeNameMap {
+		if v.UUID == UUID {
+			return k
+		}
+
+	}
+	return ""
 }

--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -199,6 +199,11 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		return errors.New("VM Guest hostname is empty")
 	}
 
+	if len(oVM.Guest.Net) == 0 {
+		klog.V(4).Infof("oVM.Guest.Net is empty, skipping node discovery. This could be cauesd by vmtool not reporting correct IP address")
+		return errors.New("VM GuestNicInfo is empty")
+	}
+
 	tenantRef := vmDI.VcServer
 	if vmDI.TenantRef != "" {
 		tenantRef = vmDI.TenantRef
@@ -359,6 +364,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 
 	if len(oVM.Guest.Net) > 0 {
 		if !foundInternal && !foundExternal {
+			klog.V(4).Infof("oVM.Guest.Net=%v", oVM.Guest.Net)
 			return fmt.Errorf("unable to find suitable IP address for node %s with IP family %s", nodeID, ipFamily)
 		}
 	}

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -79,11 +79,11 @@ func TestRegUnregNode(t *testing.T) {
 
 	nm.UnregisterNode(node)
 
-	if len(nm.nodeNameMap) != 1 {
-		t.Errorf("Failed: nodeNameMap should be a length of  1")
+	if len(nm.nodeNameMap) != 0 {
+		t.Errorf("Failed: nodeNameMap should be a length of  0")
 	}
-	if len(nm.nodeUUIDMap) != 1 {
-		t.Errorf("Failed: nodeUUIDMap should be a length of  1")
+	if len(nm.nodeUUIDMap) != 0 {
+		t.Errorf("Failed: nodeUUIDMap should be a length of  0")
 	}
 	if len(nm.nodeRegUUIDMap) != 0 {
 		t.Errorf("Failed: nodeRegUUIDMap should be a length of 0")

--- a/pkg/cloudprovider/vsphereparavirtual/instances.go
+++ b/pkg/cloudprovider/vsphereparavirtual/instances.go
@@ -18,6 +18,7 @@ package vsphereparavirtual
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -55,6 +56,10 @@ var DiscoverNodeBackoff = wait.Backoff{
 	Duration: 50 * time.Millisecond,
 	Jitter:   1.0,
 }
+
+var (
+	errBiosUUIDEmpty = errors.New("discovered Bios UUID is empty")
+)
 
 func checkError(err error) bool {
 	return err != nil
@@ -195,6 +200,10 @@ func (i *instances) InstanceID(ctx context.Context, nodeName types.NodeName) (st
 	if vm == nil {
 		klog.V(4).Info("instances.InstanceID() InstanceNotFound ", nodeName)
 		return "", cloudprovider.InstanceNotFound
+	}
+
+	if vm.Status.BiosUUID == "" {
+		return "", errBiosUUIDEmpty
 	}
 
 	klog.V(4).Infof("instances.InstanceID() called to get vm: %v uuid: %v", nodeName, vm.Status.BiosUUID)

--- a/pkg/cloudprovider/vsphereparavirtual/instances_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/instances_test.go
@@ -137,6 +137,12 @@ func TestInstanceID(t *testing.T) {
 			expectedInstanceID: "",
 			expectedErr:        cloudprovider.InstanceNotFound,
 		},
+		{
+			name:               "cannot find virtualmachine with empty bios uuid",
+			testVM:             createTestVM(string(testVMName), testClusterNameSpace, ""),
+			expectedInstanceID: "",
+			expectedErr:        errBiosUUIDEmpty,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/releases/v1.20/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.20/vsphere-cloud-controller-manager.yaml
@@ -1,0 +1,253 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  labels:
+    vsphere-cpi-infra: service-account
+    component: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-cloud-secret
+  labels:
+    vsphere-cpi-infra: secret
+    component: cloud-controller-manager
+  namespace: kube-system
+  # NOTE: this is just an example configuration, update with real values based on your environment
+stringData:
+  10.0.0.1.username: "<ENTER_YOUR_VCENTER_USERNAME>"
+  10.0.0.1.password: "<ENTER_YOUR_VCENTER_PASSWORD>"
+  1.2.3.4.username: "<ENTER_YOUR_VCENTER_USERNAME>"
+  1.2.3.4.password: "<ENTER_YOUR_VCENTER_PASSWORD>"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vsphere-cloud-config
+  labels:
+    vsphere-cpi-infra: config
+    component: cloud-controller-manager
+  namespace: kube-system
+data:
+  # NOTE: this is just an example configuration, update with real values based on your environment
+  vsphere.conf: |
+    # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+    global:
+      port: 443
+      # set insecureFlag to true if the vCenter uses a self-signed cert
+      insecureFlag: true
+      # settings for using k8s secret
+      secretName: vsphere-cloud-secret
+      secretNamespace: kube-system
+
+    # vcenter section
+    vcenter:
+      your-vcenter-name-here:
+        server: 10.0.0.1
+        user: use-your-vcenter-user-here
+        password: use-your-vcenter-password-here
+        datacenters:
+          - hrwest
+          - hreast
+      could-be-a-tenant-label:
+        server: 1.2.3.4
+        datacenters:
+          - mytenantdc
+        secretName: cpi-engineering-secret
+        secretNamespace: kube-system
+
+    # labels for regions and zones
+    labels:
+      region: k8s-region
+      zone: k8s-zone
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: servicecatalog.k8s.io:apiserver-authentication-reader
+  labels:
+    vsphere-cpi-infra: role-binding
+    component: cloud-controller-manager
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+  - apiGroup: ""
+    kind: User
+    name: cloud-controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    vsphere-cpi-infra: cluster-role-binding
+    component: cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:cloud-controller-manager
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+  - kind: User
+    name: cloud-controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:cloud-controller-manager
+  labels:
+    vsphere-cpi-infra: role
+    component: cloud-controller-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vsphere-cloud-controller-manager
+  labels:
+    component: cloud-controller-manager
+    tier: control-plane
+  namespace: kube-system
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+spec:
+  selector:
+    matchLabels:
+      name: vsphere-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: vsphere-cloud-controller-manager
+        component: cloud-controller-manager
+        tier: control-plane
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+          operator: Exists
+        - key: node.kubernetes.io/not-ready
+          effect: NoSchedule
+          operator: Exists
+      securityContext:
+        runAsUser: 1001
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: vsphere-cloud-controller-manager
+          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.20.1
+          args:
+            - --cloud-provider=vsphere
+            - --v=2
+            - --cloud-config=/etc/cloud/vsphere.conf
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+      hostNetwork: true
+      volumes:
+        - name: vsphere-config-volume
+          configMap:
+            name: vsphere-cloud-config


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Back port the empty uuid check, and empty IP address check when discovering node.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Backport
* Return error when VM's info returned from VC doesn't contains IP address https://github.com/kubernetes/cloud-provider-vsphere/pull/585
* For paravirtual, empty ProviderUUID appears for node https://github.com/kubernetes/cloud-provider-vsphere/pull/546
* Remove cached node based on UUID when unregister node https://github.com/kubernetes/cloud-provider-vsphere/pull/540
* Do not use the cached node addresses when NodeAddresses is invoked. https://github.com/kubernetes/cloud-provider-vsphere/pull/541
```
