### PR TITLE
Fix the error wrapping

### DIFF
--- a/pkg/cloudprovider/vsphereparavirtual/controllers/routablepod/ippool/ippool_controller_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/controllers/routablepod/ippool/ippool_controller_test.go
@@ -148,16 +148,16 @@ func TestProcessIPPoolCreateOrUpdate(t *testing.T) {
 			c, cs := newController()
 
 			if _, err := c.ippoolclientset.NsxV1alpha1().IPPools(testClusterNS).Create(context.Background(), &testIPPool, metav1.CreateOptions{}); err != nil {
-				t.Errorf("failed to create test ippool %s: %w", testIPPool.Name, err)
+				t.Errorf("failed to create test ippool %s: %v", testIPPool.Name, err)
 			}
 
 			if err := c.processIPPoolCreateOrUpdate(&testIPPool); err != nil {
-				t.Errorf("failed to processIPPoolCreateOrUpdate %v: %w", testIPPool, err)
+				t.Errorf("failed to processIPPoolCreateOrUpdate %v: %v", testIPPool, err)
 			}
 
 			for _, n := range tc.nodes {
 				if _, err := c.kubeclientset.CoreV1().Nodes().Create(context.Background(), &n, metav1.CreateOptions{}); err != nil {
-					t.Errorf("failed to create test node %s: %w", n.Name, err)
+					t.Errorf("failed to create test node %s: %v", n.Name, err)
 				}
 			}
 

--- a/pkg/cloudprovider/vsphereparavirtual/controllers/routablepod/node/node_controller_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/controllers/routablepod/node/node_controller_test.go
@@ -131,12 +131,12 @@ func TestProcessNodeCreateOrUpdate(t *testing.T) {
 			// create nodes and run process processNodeCreateOrUpdate
 			for _, n := range tc.nodes {
 				if err := ippc.processNodeCreateOrUpdate(&n); err != nil {
-					t.Errorf("failed to create test node %s: %w", n.Name, err)
+					t.Errorf("failed to create test node %s: %v", n.Name, err)
 				}
 			}
 			for _, n := range tc.nodesUpdate {
 				if err := ippc.processNodeCreateOrUpdate(&n); err != nil {
-					t.Errorf("failed to create test node %s: %w", n.Name, err)
+					t.Errorf("failed to create test node %s: %v", n.Name, err)
 				}
 			}
 
@@ -231,14 +231,14 @@ func TestProcessNodeDelete(t *testing.T) {
 			if tc.ippoolExist {
 				// pre create test nodes
 				if _, err := createIPPool(ippcs, tc.nodes); err != nil {
-					t.Errorf("failed to create ippool %w", err)
+					t.Errorf("failed to create ippool %v", err)
 				}
 			}
 
 			// delete node
 			for _, n := range tc.nodesToBeDeleted {
 				if err := ippc.processNodeDelete(n.Name); err != nil {
-					t.Errorf("failed to create test node %s: %w", n.Name, err)
+					t.Errorf("failed to create test node %s: %v", n.Name, err)
 				}
 			}
 

--- a/pkg/common/vclib/pbm.go
+++ b/pkg/common/vclib/pbm.go
@@ -63,7 +63,7 @@ func (pbmClient *PbmClient) IsDatastoreCompatible(ctx context.Context, storagePo
 		klog.Errorf("Error occurred for CheckRequirements call. err %+v", err)
 		return false, "", err
 	}
-	if compatibilityResult != nil && len(compatibilityResult) > 0 {
+	if len(compatibilityResult) > 0 {
 		compatibleHubs := compatibilityResult.CompatibleDatastores()
 		if len(compatibleHubs) > 0 {
 			return true, "", nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In golang 1.18, test.Errorf doesn't allow using `%w` to wrap error. Instead we need to use `%v`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
