### PR TITLE
Do not restart the CPI pod on the config file's Chmod events.

### DIFF
--- a/cmd/vsphere-cloud-controller-manager/main.go
+++ b/cmd/vsphere-cloud-controller-manager/main.go
@@ -229,8 +229,12 @@ func initializeWatch(_ *appconfig.CompletedConfig, cloudConfigPath string) (watc
 			case err := <-watch.Errors:
 				klog.Warningf("watcher receives err: %v\n", err)
 			case event := <-watch.Events:
-				klog.Fatalf("config map %s has been updated, restarting pod, received event %v\n", cloudConfigPath, event)
-				stopCh <- struct{}{}
+				if event.Op != fsnotify.Chmod {
+					klog.Fatalf("config map %s has been updated, restarting pod, received event %v\n", cloudConfigPath, event)
+					stopCh <- struct{}{}
+				} else {
+					klog.V(5).Infof("watcher receives %s on the cloud config\n", event.Op.String())
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix CPI pod keeps crashing when installed using helm, caused by the Chmod events on the cloud config file.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Do not restart the CPI pod on the config file's Chmod events.
```
