### PR TITLE
Add E2E tests, when recreate a VM, new node should have correct info.

### DIFF
--- a/test/e2e/cpi_vm_test.go
+++ b/test/e2e/cpi_vm_test.go
@@ -11,8 +11,12 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
 )
+
+const machineNamespace = "default"
 
 // getWorkerNode retrieves the worker node object for the E2E testing using workload cluster's clientset
 func getWorkerNode() (*corev1.Node, error) {
@@ -21,6 +25,29 @@ func getWorkerNode() (*corev1.Node, error) {
 		return nil, err
 	}
 	return getFirstWorkerNodeFromList(nodes)
+}
+
+// getWorkerNode retrieves the CAPV machine object with name from the boostrap cluster
+func getWorkerMachine(name string) (*v1beta1.Machine, error) {
+	machine := &v1beta1.Machine{}
+	if err := proxy.GetClient().Get(ctx, k8stypes.NamespacedName{
+		Name:      name,
+		Namespace: machineNamespace,
+	}, machine); err != nil {
+		return nil, err
+	}
+	return machine, err
+}
+
+// deleteWorkerMachine deletes the CAPV machine object with name from the boostrap cluster
+func deleteWorkerMachine(name string) error {
+	machine := &v1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: machineNamespace,
+		},
+	}
+	return proxy.GetClient().Delete(ctx, machine)
 }
 
 // getFirstWorkerNodeFromList searches the first worker node that forms the cluster.
@@ -56,8 +83,8 @@ func getInternalIPFromNode(node *corev1.Node) (string, error) {
 	return "", errors.New("internal IP not found")
 }
 
-// getProviderIPFromNode returns the provider ID of node
-func getProviderIPFromNode(node *corev1.Node) string {
+// getProviderIDFromNode returns the provider ID of node
+func getProviderIDFromNode(node *corev1.Node) string {
 	return node.Spec.ProviderID
 }
 
@@ -117,19 +144,18 @@ func WaitForVMPowerState(name string, targetState types.VirtualMachinePowerState
 	}
 }
 
-var _ = Describe("Recreating VMs", func() {
-	It("should result in new nodes", func() {
-		// TODO(fhan)
-	})
-})
-
 /*
 	Restart a worker node, then assert that the external, internal IP and
 	the provider ID for the node should not change.
-*/
-var _ = Describe("Restarting VMs", func() {
 
+	Delete the worker machine object in the boostrap cluster, after a while CAPV should create a new machine
+	associated with a new VM. The new node should have correct info.
+*/
+var _ = Describe("Restarting and recreating VMs", func() {
+
+	var originalWorkerNodeName string
 	var workerNode *corev1.Node
+	var workerMachine *v1beta1.Machine
 	var workerVM *object.VirtualMachine
 
 	BeforeEach(func() {
@@ -138,15 +164,31 @@ var _ = Describe("Restarting VMs", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			klog.Infof("The worker node for testing is %s\n", workerNode.Name)
+			originalWorkerNodeName = workerNode.Name
+		})
+
+		By("Get the machine object in bootstrap cluster", func() {
+			workerMachine, err = getWorkerMachine(workerNode.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(workerMachine).ToNot(BeNil())
 		})
 
 		By("Get corresponding VM object for node", func() {
 			workerVM, err = getWorkerVM(workerNode.Name)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(workerVM).ToNot(BeNil())
 		})
 	})
 
 	It("should pertain the original node when VM restarts", func() {
+
+		Eventually(func() bool {
+			workerNode, err = getWorkerNode()
+			if err != nil {
+				return false
+			}
+			return DoesNodeHasReadiness(workerNode, corev1.ConditionTrue)
+		}, 10*time.Minute).Should(BeTrue())
 
 		By("Read the externalIP, internalIP and providerID of VM")
 		externalIP, err := getExternalIPFromNode(workerNode)
@@ -155,8 +197,7 @@ var _ = Describe("Restarting VMs", func() {
 		internalIP, err := getInternalIPFromNode(workerNode)
 		Expect(err).ToNot(HaveOccurred())
 
-		providerID := getProviderIPFromNode(workerNode)
-		Expect(DoesNodeHasReadiness(workerNode, corev1.ConditionTrue)).To(BeTrue())
+		providerID := getProviderIDFromNode(workerNode)
 
 		By("Shutdown VM "+workerVM.Name(), func() {
 			task, err := workerVM.PowerOff(ctx)
@@ -199,10 +240,58 @@ var _ = Describe("Restarting VMs", func() {
 
 				Expect(newExternalIP).To(Equal(externalIP))
 				Expect(newInternalIP).To(Equal(internalIP))
-				Expect(getProviderIPFromNode(workerNode)).To(Equal(providerID))
+				Expect(getProviderIDFromNode(workerNode)).To(Equal(providerID))
 
 				return nil
 			}).Should(Succeed())
 		})
+	})
+
+	It("should result in new node when recreating VM", func() {
+
+		Eventually(func() bool {
+			workerNode, err = getWorkerNode()
+			if err != nil {
+				return false
+			}
+			return DoesNodeHasReadiness(workerNode, corev1.ConditionTrue)
+		}, 10*time.Minute).Should(BeTrue())
+
+		By("Read the providerID of VM")
+		providerID := getProviderIDFromNode(workerNode)
+
+		By("Delete machine object", func() {
+			err := deleteWorkerMachine(workerNode.Name)
+			Expect(err).To(BeNil(), "cannot delete machine object")
+		})
+
+		By("Eventually original node will be gone")
+		Eventually(func() bool {
+			_, err = getWorkerNode()
+			return err != nil && err.Error() == "worker node not found"
+		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
+
+		By("Eventually new node will be created")
+		var newExternalIP, newInternalIP string
+		Eventually(func() error {
+			if workerNode, err = getWorkerNode(); err != nil {
+				return err
+			}
+			if newExternalIP, err = getExternalIPFromNode(workerNode); err != nil {
+				return err
+			}
+			if newInternalIP, err = getInternalIPFromNode(workerNode); err != nil {
+				return err
+			}
+			return nil
+		}, 10*time.Minute, 5*time.Second).Should(Succeed())
+
+		By("New node will be created with correct info, different from old one")
+		Expect(newExternalIP).ToNot(BeEmpty())
+		Expect(newInternalIP).ToNot(BeEmpty())
+		Expect(getProviderIDFromNode(workerNode)).ToNot(BeEmpty())
+
+		Expect(workerNode.Name).ToNot(Equal(originalWorkerNodeName), "name still the same")
+		Expect(getProviderIDFromNode(workerNode)).ToNot(Equal(providerID), "providerID still the same")
 	})
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -229,7 +230,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	By("Remove old vsphere-cpi", func() {
 		Eventually(func() error {
 			return removeOldCPI(workloadClientset)
-		}).Should(BeNil())
+		}, 2*time.Minute).Should(BeNil())
 	})
 
 	By("Install new vsphere-cpi with helm on workload cluster", func() {
@@ -347,6 +348,8 @@ func newCPIInstallValues() map[string]interface{} {
 			"username":   e2eConfig.GetVariable("VSPHERE_USERNAME"),
 			"password":   e2eConfig.GetVariable("VSPHERE_PASSWORD"),
 			"datacenter": e2eConfig.GetVariable("VSPHERE_DATACENTER"),
+			"region":     "",
+			"zone":       "",
 		},
 		"daemonset": map[string]interface{}{
 			"image": image,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 This PR adds a test case for CPI E2E test.

Delete the worker machine object in the boostrap cluster, after a while CAPV should create a new machine
associated with a new VM. The new node should have correct info that is different from the original node.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/kubernetes/cloud-provider-vsphere/issues/621

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
