### PR TITLE
Document the least required vCenter permissions for CPV

### DIFF
--- a/docs/book/vcp_roles.md
+++ b/docs/book/vcp_roles.md
@@ -1,0 +1,18 @@
+# Minimal required privilege for vCenters
+
+## Introduction
+
+This article documents the minimal required permissions required for the vSphere user designated to the vSphere Cloud Provider.
+
+Please refer [vSphere Documentation Center](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.security.doc/GUID-18071E9A-EED1-4968-8D51-E0B4F526FDA3.html) to find out
+how to create a `Custom Role`, `User`, and `Role Assignment`.
+
+## Environment
+
+* VMware vCenter Server 7.0.0 build-18369597
+* vSphere Cloud Controller Manager version v1.18.1_vmware.1
+
+## Required permission
+
+The vSphere Cloud Controller Manager requires the Read permission on the parent entities of the node VMs such as folder, host, datacenter, datastore folder, datastore cluster, etc.
+The role `ReadOnly: See details of objects, but not make changes` should be associated with the vSphere user for CPV.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Document the least required vCenter permissions for CPV

Validate if https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/vcp-roles.md#overview still applies for the current version of CPV.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/kubernetes/cloud-provider-vsphere/issues/623

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
