### PR TITLE
CredentialsManager accepts alternate Secret format

### DIFF
--- a/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
+++ b/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
@@ -569,6 +569,23 @@ stringData:
   10.0.0.1.password: "password"
 ```
 
+This is a second Secret example, this time showing an alternative format. This alternative format allows for IPv6 server addresses. This format requires server_{id}, username_{id} and password_{id} entries, where the entries have a common suffix per server:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cpi-engineering-secret
+  namespace: kube-system
+stringData:
+  server_prod: fd01::102
+  username_prod: "administrator@vsphere.local"
+  password_prod: "password"
+  server_test: 10.0.0.2
+  username_test: "developer@vsphere.local"
+  password_test: "sekret"
+```
+
 Then to create the secret, run the following command replacing the name of the YAML file with the one you have used:
 
 ```bash

--- a/pkg/common/credentialmanager/consts_and_errors.go
+++ b/pkg/common/credentialmanager/consts_and_errors.go
@@ -20,6 +20,12 @@ import (
 	"errors"
 )
 
+const (
+	usernamePrefix = "username_"
+	passwordPrefix = "password_"
+	serverPrefix   = "server_"
+)
+
 // Errors
 var (
 	// ErrCredentialsNotFound is returned when no credentials are configured.
@@ -30,4 +36,7 @@ var (
 
 	// ErrUnknownSecretKey is returned when the supplied key does not return a secret.
 	ErrUnknownSecretKey = errors.New("Unknown secret key")
+
+	// ErrIncompleteCredentialSet is returned when the credentials do not contain all required values
+	ErrIncompleteCredentialSet = errors.New("Credentials did not have all required values")
 )

--- a/releases/README.md
+++ b/releases/README.md
@@ -40,6 +40,16 @@ stringData:
   10.0.0.1.password: "<ENTER_YOUR_VCENTER_PASSWORD>"
   1.2.3.4.username: "<ENTER_YOUR_VCENTER_USERNAME>"
   1.2.3.4.password: "<ENTER_YOUR_VCENTER_PASSWORD>"
+
+  # NOTE: the following entries show an alternative format.
+  # This format is amenable to IPv6 addresses. the server_{id}, username_{id},
+  # and password_{id} require common id suffixes per server.
+  server_prod:   fd00::1
+  username_prod: "<ENTER_YOUR_VCENTER_USERNAME>"
+  password_prod: "<ENTER_YOUR_VCENTER_PASSWORD>"
+  server_test:   1.2.3.5
+  username_test: "<ENTER_YOUR_VCENTER_USERNAME>"
+  password_test: "<ENTER_YOUR_VCENTER_PASSWORD>"
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
**What this PR does / why we need it**:

This change was made because the legacy Secret format is not compatible
with IPv6 server addresses. The legacy format uses the server address in
the Secret key and because IPv6 addresses contain colons, errors
occur.

This change continues to support the legacy Secret format.

This change adds the ability to add Secrets in the following format:

```yaml
---
apiVersion: v1
kind: Secret
metadata:
  name: vsphere-cloud-secret
  namespace: kube-system
data:
  10.96.96.96.username: "dXNlcg=="
  10.96.96.96.password: "cGFzcw=="

  username_0: "dXNlcg=="
  password_0: "cGFzcw=="
  server_0: "ZmQwMDo6MQo="

  username_foo: "dXNlcg=="
  password_foo: "cGFzcw=="
  server_foo: "ZmQwMDo6Mgo="
```

The username_, password_, server_ keys should be supplied with matching suffixes.

Co-authored-by: Aidan Obley <aobley@vmware.com>


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

#640 

**Special notes for your reviewer**:


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
VSphere config secret allows an alternative format that allows for IPv6 server addresses
```
