### PR TITLE
Use full resource path for ipclaim and ipaddress in e2e CI.

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -24,8 +24,8 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 on_exit() {
   # release IPClaim
   echo "Releasing IP claims"
-  kubectl --kubeconfig="${KUBECONFIG}" delete ipclaim "${IPCLAIM_NAME}" || true
-  kubectl --kubeconfig="${KUBECONFIG}" delete ipclaim "${WORKLOAD_IPCLAIM_NAME}" || true
+  kubectl --kubeconfig="${KUBECONFIG}" delete "$(append_api_group ipclaim)" "${IPCLAIM_NAME}" || true
+  kubectl --kubeconfig="${KUBECONFIG}" delete "$(append_api_group ipclaim)" "${WORKLOAD_IPCLAIM_NAME}" || true
 
   # kill the VPN
   docker kill vpn
@@ -60,6 +60,11 @@ docker logs vpn
 # Sleep to allow vpn container to start running
 sleep 30
 
+function append_api_group() {
+  resource=$1
+  echo "${resource}.ipam.metal3.io"
+}
+
 # Retrieve an IP to be used as the kube-vip IP
 KUBECONFIG="/root/ipam-conf/capv-services.conf"
 
@@ -67,8 +72,8 @@ function acquire_ip_for_management_cluster_cp() {
   IPCLAIM_NAME="ip-claim-$(openssl rand -hex 20)"
   sed "s/IPCLAIM_NAME/${IPCLAIM_NAME}/" "${REPO_ROOT}/hack/ipclaim-template.yaml" | kubectl --kubeconfig=${KUBECONFIG} create -f -
 
-  IPADDRESS_NAME=$(kubectl --kubeconfig=${KUBECONFIG} get ipclaim "${IPCLAIM_NAME}" -o=jsonpath='{@.status.address.name}')
-  CONTROL_PLANE_ENDPOINT_IP=$(kubectl --kubeconfig=${KUBECONFIG} get ipaddresses "${IPADDRESS_NAME}" -o=jsonpath='{@.spec.address}')
+  IPADDRESS_NAME=$(kubectl --kubeconfig=${KUBECONFIG} get "$(append_api_group ipclaim)" "${IPCLAIM_NAME}" -o=jsonpath='{@.status.address.name}')
+  CONTROL_PLANE_ENDPOINT_IP=$(kubectl --kubeconfig=${KUBECONFIG} get "$(append_api_group ipaddresses)" "${IPADDRESS_NAME}" -o=jsonpath='{@.spec.address}')
   export CONTROL_PLANE_ENDPOINT_IP
   echo "Acquired Control Plane IP: $CONTROL_PLANE_ENDPOINT_IP"
 }
@@ -77,8 +82,8 @@ function acquire_ip_for_workload_cluster_cp() {
   WORKLOAD_IPCLAIM_NAME="workload-ip-claim-$(openssl rand -hex 20)"
   sed "s/IPCLAIM_NAME/${WORKLOAD_IPCLAIM_NAME}/" "${REPO_ROOT}/hack/ipclaim-template.yaml" | kubectl --kubeconfig=${KUBECONFIG} create -f -
 
-  WORKLOAD_IPADDRESS_NAME=$(kubectl --kubeconfig=${KUBECONFIG} get ipclaim "${WORKLOAD_IPCLAIM_NAME}" -o=jsonpath='{@.status.address.name}')
-  WORKLOAD_CONTROL_PLANE_ENDPOINT_IP=$(kubectl --kubeconfig=${KUBECONFIG} get ipaddresses "${WORKLOAD_IPADDRESS_NAME}" -o=jsonpath='{@.spec.address}')
+  WORKLOAD_IPADDRESS_NAME=$(kubectl --kubeconfig=${KUBECONFIG} get "$(append_api_group ipclaim)" "${WORKLOAD_IPCLAIM_NAME}" -o=jsonpath='{@.status.address.name}')
+  WORKLOAD_CONTROL_PLANE_ENDPOINT_IP=$(kubectl --kubeconfig=${KUBECONFIG} get "$(append_api_group ipaddresses)" "${WORKLOAD_IPADDRESS_NAME}" -o=jsonpath='{@.spec.address}')
   export WORKLOAD_CONTROL_PLANE_ENDPOINT_IP
   echo "Acquired Workload Cluster Control Plane IP: $WORKLOAD_CONTROL_PLANE_ENDPOINT_IP"
 }

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -127,16 +127,14 @@ function login() {
   fi
 }
 
-function docker_tag_exists() {
-    curl --silent -f -lSL "https://index.docker.io/v1/repositories/$1/tags/$2" > /dev/null
-}
-
 function push_images() {
   [ "${CPI_IMAGE_NAME}" ] || fatal "CPI_IMAGE_NAME not set"
 
   login
 
-  if docker_tag_exists "${CPI_IMAGE_NAME}" "${VERSION}"; then
+  existing_tags=$(gcloud container images list-tags --filter="tags:${VERSION}" --format=json "${CPI_IMAGE_NAME}")
+
+  if [[ "$existing_tags" != "[]" ]]; then
     echo "${CPI_IMAGE_NAME}:${VERSION} already exists, skip pushing"
   else
     echo "pushing ${CPI_IMAGE_NAME}:${VERSION}"

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -137,7 +137,7 @@ providers:
           - sourcePath: "../data/metadata.yaml"
 
 variables:
-  KUBERNETES_VERSION: "v1.20.1"
+  KUBERNETES_VERSION: "v1.23.5"
   CNI: "./data/cni/calico/calico.yaml"
   EXP_CLUSTER_RESOURCE_SET: "true"
   CONTROL_PLANE_MACHINE_COUNT: 1
@@ -145,19 +145,19 @@ variables:
   IP_FAMILY: "IPv4"
   CLUSTER_CLASS_NAME: "quick-start"
   # Following CAPV variables should be set before testing
-  VSPHERE_TLS_THUMBPRINT: "9E:7F:01:3B:13:CF:B2:93:16:2C:31:6A:03:6A:D1:5D:C7:79:D8:DE"
+  VSPHERE_TLS_THUMBPRINT: "AA:70:F9:CF:5A:5F:CF:6C:81:15:E0:A1:88:B9:E9:2B:DC:19:0E:D0"
   VSPHERE_DATACENTER:  "SDDC-Datacenter"
   VSPHERE_FOLDER: "clusterapi"
   VSPHERE_RESOURCE_POOL: "clusterapi"
   VSPHERE_DATASTORE: "WorkloadDatastore"
   VSPHERE_STORAGE_POLICY: "Cluster API vSphere Storage Policy"
   VSPHERE_NETWORK: "sddc-cgw-network-6"
-  VSPHERE_TEMPLATE: "ubuntu-1804-kube-v1.20.1"
+  VSPHERE_TEMPLATE: "ubuntu-2004-kube-v1.23.5"
   VSPHERE_INSECURE: "true"
+  VSPHERE_INSECURE_CSI: "true"
   INIT_WITH_BINARY_V1ALPHA3: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.3.25/clusterctl-{OS}-{ARCH}"
   INIT_WITH_BINARY_V1ALPHA4: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-{OS}-{ARCH}"
-  INIT_WITH_KUBERNETES_VERSION: "v1.20.1"
-  VSPHERE_INSECURE_CSI: "true"
+  INIT_WITH_KUBERNETES_VERSION: "v1.23.5"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   NODE_DRAIN_TIMEOUT: "60s"
   CLUSTER_TOPOLOGY: "true"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Use full resource path for IPClaim and IPAddress in the CPI e2e CI, to avoid CR name conflicts with other group such as MetalLB or Calico



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use full resource path for ipclaim and ipaddress in e2e CI.
```
