### PR TITLE
Don't trigger helm chart release to each release branch. Since not en…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - release-**
     paths:
       - "charts/**"
 


### PR DESCRIPTION
…ough permission

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Tried release helm chart with each patch release, but it will fail because enough permission to push to gh-pages branch from each of the release branch. Have to use the master branch
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
