### PR TITLE
Check for vm state using mof when VM can't be found by using uuid

### DIFF
--- a/pkg/common/vclib/virtualmachine.go
+++ b/pkg/common/vclib/virtualmachine.go
@@ -429,3 +429,26 @@ func (vm *VirtualMachine) RenewVM(client *vim25.Client) VirtualMachine {
 	newVM := object.NewVirtualMachine(client, vm.VirtualMachine.Reference())
 	return VirtualMachine{VirtualMachine: newVM, Datacenter: &dc}
 }
+
+func (vm *VirtualMachine) Exists(ctx context.Context) (bool, error) {
+	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{"summary.runtime.powerState"})
+	if err != nil {
+		klog.Errorf("Failed to get VM Managed object with property summary. err: +%v", err)
+		return false, err
+	}
+	// We check for VMs which are still available in vcenter and has not been terminated/removed from
+	// disk and hence we consider PoweredOn,PoweredOff and Suspended as alive states.
+	aliveStates := []types.VirtualMachinePowerState{
+
+		types.VirtualMachinePowerStatePoweredOff,
+		types.VirtualMachinePowerStatePoweredOn,
+		types.VirtualMachinePowerStateSuspended,
+	}
+	currentState := vmMoList[0].Summary.Runtime.PowerState
+	for _, state := range aliveStates {
+		if state == currentState {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/common/vclib/virtualmachine.go
+++ b/pkg/common/vclib/virtualmachine.go
@@ -430,6 +430,7 @@ func (vm *VirtualMachine) RenewVM(client *vim25.Client) VirtualMachine {
 	return VirtualMachine{VirtualMachine: newVM, Datacenter: &dc}
 }
 
+// Exists chech whether VM exist by searching by managed object reference
 func (vm *VirtualMachine) Exists(ctx context.Context) (bool, error) {
 	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{"summary.runtime.powerState"})
 	if err != nil {
@@ -439,7 +440,6 @@ func (vm *VirtualMachine) Exists(ctx context.Context) (bool, error) {
 	// We check for VMs which are still available in vcenter and has not been terminated/removed from
 	// disk and hence we consider PoweredOn,PoweredOff and Suspended as alive states.
 	aliveStates := []types.VirtualMachinePowerState{
-
 		types.VirtualMachinePowerStatePoweredOff,
 		types.VirtualMachinePowerStatePoweredOn,
 		types.VirtualMachinePowerStateSuspended,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When Node VM is inaccessible for any reason, but VM is still present in the VC inventory, CPI shouldn't delete the Node.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/kubernetes/cloud-provider-vsphere/issues/642

**Special notes for your reviewer**:
Not sure how to mimic the scenario with govc simulator that FindByUUID will not return the vm

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Try not to delete VM when vm is inaccessible for any reason, but VM is still present in the VC inventory
```
