### PR TITLE
[Cherrypick 1.24]Add new legacy flag and skip deleting vm if it's in accessible state

### DIFF
--- a/cmd/vsphere-cloud-controller-manager/main.go
+++ b/cmd/vsphere-cloud-controller-manager/main.go
@@ -20,6 +20,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	goflag "flag"
 	"fmt"
 	"math/rand"
@@ -82,6 +83,12 @@ func main() {
 	namedFlagSets := ccmOptions.Flags(app.ControllerNames(app.DefaultInitFuncConstructors), app.ControllersDisabledByDefault.List())
 	verflag.AddFlags(namedFlagSets.FlagSet("global"))
 	globalflag.AddGlobalFlags(namedFlagSets.FlagSet("global"), command.Name())
+
+	if flag.CommandLine.Lookup("is-legacy-paravirtual") != nil {
+		// hoist this flag from the global flagset to preserve the commandline until
+		// the legcay paravirtual mode is removed.
+		globalflag.Register(namedFlagSets.FlagSet("generic"), "is-legacy-paravirtual")
+	}
 
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)

--- a/pkg/cloudprovider/vsphereparavirtual/cloud.go
+++ b/pkg/cloudprovider/vsphereparavirtual/cloud.go
@@ -18,6 +18,7 @@ package vsphereparavirtual
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -29,6 +30,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/controllers/routablepod"
+	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmservice"
 	cpcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
 	k8s "k8s.io/cloud-provider-vsphere/pkg/common/kubernetes"
 )
@@ -79,6 +81,8 @@ func init() {
 
 		return newVSphereParavirtual(&cfg)
 	})
+
+	flag.BoolVar(&vmservice.IsLegacy, "is-legacy-paravirtual", false, "If true, machine label selector will start with capw.vmware.com. By default, it's false, machine label selector will start with capv.vmware.com.")
 }
 
 // Creates new Controller node interface and returns

--- a/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
-
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,6 +41,11 @@ const (
 	ClusterSelectorKey = "capv.vmware.com/cluster.name"
 	// NodeSelectorKey expects key/value pair {NodeSelectorKey: NodeRole} for target nodes: NodeSelectorKey
 	NodeSelectorKey = "capv.vmware.com/cluster.role"
+
+	// LegacyClusterSelectorKey expects key/value pair {LegacyClusterSelectorKey: <cluster name>} for target nodes: LegacyClusterSelectorKey
+	LegacyClusterSelectorKey = "capw.vmware.com/cluster.name"
+	// LegacyNodeSelectorKey expects key/value pair {LegacyNodeSelectorKey: NodeRole} for target nodes: LegacyNodeSelectorKey
+	LegacyNodeSelectorKey = "capw.vmware.com/cluster.role"
 
 	// NodeRole is set by capw, we are targeting worker vms
 	NodeRole = "node"
@@ -75,6 +79,12 @@ var (
 	ErrDeleteVMService     = errors.New("failed to delete VirtualMachineService")
 	ErrVMServiceIPNotFound = errors.New("VirtualMachineService IP not found")
 	ErrNodePortNotFound    = errors.New("NodePort not found")
+)
+
+var (
+	// IsLegacy indicates whether legacy paravirtual mode is enabled
+	// Default to false
+	IsLegacy bool
 )
 
 // GetVmopClient gets a vm-operator-api client
@@ -312,6 +322,13 @@ func (s *vmService) lbServiceToVMService(service *v1.Service, clusterName string
 		// When service has spec.LoadBalancerSourceRanges specified,
 		// pass it to the corresponding VirtualMachineService
 		LoadBalancerSourceRanges: service.Spec.LoadBalancerSourceRanges,
+	}
+
+	if IsLegacy {
+		vmServiceSpec.Selector = map[string]string{
+			LegacyClusterSelectorKey: clusterName,
+			LegacyNodeSelectorKey:    NodeRole,
+		}
 	}
 
 	label := map[string]string{

--- a/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice_test.go
@@ -184,6 +184,28 @@ func TestCreateVMService(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestCreateVMServiceWithLegacySelector(t *testing.T) {
+	testK8sService, vms, _ := initTest()
+	ports, _ := findPorts(testK8sService)
+	expectedSpec := vmopv1alpha1.VirtualMachineServiceSpec{
+		Type:  vmopv1alpha1.VirtualMachineServiceTypeLoadBalancer,
+		Ports: ports,
+		Selector: map[string]string{
+			LegacyClusterSelectorKey: testClustername,
+			LegacyNodeSelectorKey:    NodeRole,
+		},
+	}
+
+	IsLegacy = true
+	vmServiceObj, err := vms.Create(context.Background(), testK8sService, testClustername)
+	assert.NoError(t, err)
+	assert.Equal(t, (*vmServiceObj).Spec, expectedSpec)
+
+	err = vms.Delete(context.Background(), testK8sService, testClustername)
+	assert.NoError(t, err)
+	IsLegacy = false
+}
+
 func TestCreateVMService_ZeroNodeport(t *testing.T) {
 	_, vms, _ := initTest()
 	k8sService := &v1.Service{

--- a/pkg/common/vclib/virtualmachine.go
+++ b/pkg/common/vclib/virtualmachine.go
@@ -429,3 +429,26 @@ func (vm *VirtualMachine) RenewVM(client *vim25.Client) VirtualMachine {
 	newVM := object.NewVirtualMachine(client, vm.VirtualMachine.Reference())
 	return VirtualMachine{VirtualMachine: newVM, Datacenter: &dc}
 }
+
+// Exists chech whether VM exist by searching by managed object reference
+func (vm *VirtualMachine) Exists(ctx context.Context) (bool, error) {
+	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{"summary.runtime.powerState"})
+	if err != nil {
+		klog.Errorf("Failed to get VM Managed object with property summary. err: +%v", err)
+		return false, err
+	}
+	// We check for VMs which are still available in vcenter and has not been terminated/removed from
+	// disk and hence we consider PoweredOn,PoweredOff and Suspended as alive states.
+	aliveStates := []types.VirtualMachinePowerState{
+		types.VirtualMachinePowerStatePoweredOff,
+		types.VirtualMachinePowerStatePoweredOn,
+		types.VirtualMachinePowerStateSuspended,
+	}
+	currentState := vmMoList[0].Summary.Runtime.PowerState
+	for _, state := range aliveStates {
+		if state == currentState {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cherry pick two PRs
https://github.com/kubernetes/cloud-provider-vsphere/pull/653
https://github.com/kubernetes/cloud-provider-vsphere/pull/650
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
