### PR TITLE
Bump golang version in go.mod to go 1.19

### DIFF
--- a/cluster/images/controller-manager/Dockerfile
+++ b/cluster/images/controller-manager/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.18.6
+ARG GOLANG_IMAGE=golang:1.19.2
 
 # The distroless image on which the CPI manager image is built.
 #

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-vsphere
 
-go 1.18
+go 1.19
 
 require (
 	github.com/fsnotify/fsnotify v1.5.4

--- a/hack/images/ci/Dockerfile
+++ b/hack/images/ci/Dockerfile
@@ -3,7 +3,7 @@
 ################################################################################
 # The golang image is used to create the project's module and build caches
 # and is also the image on which this image is based.
-ARG GOLANG_IMAGE=golang:1.18.6
+ARG GOLANG_IMAGE=golang:1.19.2
 
 # The image from which the Terraform project used to turn up a K8s cluster is
 # copied, as well as several programs.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,8 +1,30 @@
 module tools
 
-go 1.18
+go 1.19
 
 require (
 	github.com/onsi/ginkgo v1.16.4
 	sigs.k8s.io/kind v0.7.0
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 // indirect
+	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/mattn/go-isatty v0.0.11 // indirect
+	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pelletier/go-toml v1.6.0 // indirect
+	github.com/pkg/errors v0.9.0 // indirect
+	github.com/spf13/cobra v0.0.5 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.0.0-20210112080510-489259a85091 // indirect
+	golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2 // indirect
+	k8s.io/apimachinery v0.17.0 // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module k8s.io/cloud-provider-vsphere/test/e2e
 
-go 1.18
+go 1.19
 
 require (
 	github.com/onsi/ginkgo v1.16.5


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Follow up for #658 
Upstream is using golang 1.19 now https://github.com/kubernetes/cloud-provider/blob/release-1.25/go.mod

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update golang version to 1.19
```
