### PR TITLE
Load vSphere Credentials by SecretsDirectory

### DIFF
--- a/pkg/common/connectionmanager/connectionmanager.go
+++ b/pkg/common/connectionmanager/connectionmanager.go
@@ -58,8 +58,6 @@ func NewConnectionManager(cfg *vcfg.Config, informMgr *k8s.InformerManager, clie
 		return connMgr
 	}
 
-
-
 	klog.V(2).Info("Initializing generic CO")
 	credMgr := cm.NewCredentialManager("", "", "", nil)
 	connMgr.credentialManagers[vcfg.DefaultCredentialManager] = credMgr

--- a/pkg/common/connectionmanager/connectionmanager.go
+++ b/pkg/common/connectionmanager/connectionmanager.go
@@ -42,6 +42,13 @@ func NewConnectionManager(cfg *vcfg.Config, informMgr *k8s.InformerManager, clie
 		informerManagers:   make(map[string]*k8s.InformerManager),
 	}
 
+	if cfg.Global.SecretsDirectory != "" {
+		klog.V(2).Info("Initializing for generic CO with secrets")
+		credMgr, _ := connMgr.createManagersPerTenant("", "", cfg.Global.SecretsDirectory, nil)
+		connMgr.credentialManagers[vcfg.DefaultCredentialManager] = credMgr
+
+		return connMgr
+	}
 	if informMgr != nil {
 		klog.V(2).Info("Initializing with K8s SecretLister")
 		credMgr := cm.NewCredentialManager(cfg.Global.SecretName, cfg.Global.SecretNamespace, "", informMgr.GetSecretLister())
@@ -51,13 +58,7 @@ func NewConnectionManager(cfg *vcfg.Config, informMgr *k8s.InformerManager, clie
 		return connMgr
 	}
 
-	if cfg.Global.SecretsDirectory != "" {
-		klog.V(2).Info("Initializing for generic CO with secrets")
-		credMgr, _ := connMgr.createManagersPerTenant("", "", cfg.Global.SecretsDirectory, nil)
-		connMgr.credentialManagers[vcfg.DefaultCredentialManager] = credMgr
 
-		return connMgr
-	}
 
 	klog.V(2).Info("Initializing generic CO")
 	credMgr := cm.NewCredentialManager("", "", "", nil)

--- a/pkg/common/credentialmanager/credentialmanager.go
+++ b/pkg/common/credentialmanager/credentialmanager.go
@@ -199,13 +199,13 @@ func parseConfig(data map[string][]byte, config map[string]*Credential) error {
 			if _, ok := config[vcServer]; !ok {
 				config[vcServer] = &Credential{}
 			}
-			config[vcServer].Password = string(credentialValue)
+			config[vcServer].Password = strings.Split(string(credentialValue), "\n")[0]
 		} else if strings.HasSuffix(credentialKey, "username") {
 			vcServer := strings.Split(credentialKey, ".username")[0]
 			if _, ok := config[vcServer]; !ok {
 				config[vcServer] = &Credential{}
 			}
-			config[vcServer].User = string(credentialValue)
+			config[vcServer].User = strings.Split(string(credentialValue), "\n")[0]
 		} else {
 			unknownKeys[credentialKey] = credentialValue
 		}

--- a/pkg/common/credentialmanager/credentialmanager.go
+++ b/pkg/common/credentialmanager/credentialmanager.go
@@ -199,13 +199,13 @@ func parseConfig(data map[string][]byte, config map[string]*Credential) error {
 			if _, ok := config[vcServer]; !ok {
 				config[vcServer] = &Credential{}
 			}
-			config[vcServer].Password = strings.Split(string(credentialValue), "\n")[0]
+			config[vcServer].Password = strings.TrimSuffix(string(credentialValue), "\n")
 		} else if strings.HasSuffix(credentialKey, "username") {
 			vcServer := strings.Split(credentialKey, ".username")[0]
 			if _, ok := config[vcServer]; !ok {
 				config[vcServer] = &Credential{}
 			}
-			config[vcServer].User = strings.Split(string(credentialValue), "\n")[0]
+			config[vcServer].User = strings.TrimSuffix(string(credentialValue), "\n")
 		} else {
 			unknownKeys[credentialKey] = credentialValue
 		}
@@ -241,13 +241,11 @@ func parseConfig(data map[string][]byte, config map[string]*Credential) error {
 					return ErrCredentialMissing
 				}
 				config[string(serverName)].User = string(username)
-
 				if password, ok = data[passwordKey]; !ok {
 					klog.Errorf("%s is missing for server %s", passwordKey, serverName)
 					return ErrCredentialMissing
 				}
 				config[string(serverName)].Password = string(password)
-
 				delete(unknownKeys, passwordKey)
 				delete(unknownKeys, usernameKey)
 				delete(unknownKeys, serverKey)

--- a/pkg/common/credentialmanager/credentialmanager_test.go
+++ b/pkg/common/credentialmanager/credentialmanager_test.go
@@ -306,6 +306,20 @@ func TestParseSecretConfig(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			testName: "Valid username and password with suffix '\\n'(Load from files in SecretDirectory)",
+			data: map[string][]byte{
+				"10.20.30.40.username": []byte(testUsername+"\n"),
+				"10.20.30.40.password": []byte(testPassword+"\n"),
+			},
+			config: map[string]*Credential{
+				testIP: {
+					User:     testUsername,
+					Password: testPassword,
+				},
+			},
+			expectedError: nil,
+		},
+		{
 			testName: "Invalid username key with valid password key",
 			data: map[string][]byte{
 				"10.20.30.40.usernam":  []byte(testUsername),

--- a/pkg/common/credentialmanager/credentialmanager_test.go
+++ b/pkg/common/credentialmanager/credentialmanager_test.go
@@ -308,8 +308,8 @@ func TestParseSecretConfig(t *testing.T) {
 		{
 			testName: "Valid username and password with suffix '\\n'(Load from files in SecretDirectory)",
 			data: map[string][]byte{
-				"10.20.30.40.username": []byte(testUsername+"\n"),
-				"10.20.30.40.password": []byte(testPassword+"\n"),
+				"10.20.30.40.username": []byte(testUsername + "\n"),
+				"10.20.30.40.password": []byte(testPassword + "\n"),
 			},
 			config: map[string]*Credential{
 				testIP: {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
TKGi needs SecretsDirectory for vSphere Credentials, but vSphere CPI only reads vSphere Credentials by Secrets.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
