### PR TITLE
Update the KEP link for cloud-controller-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains the [Kubernetes cloud-controller-manager](https://kuber
 
 This project replaces the deprecated in-tree vSphere cloud provider located within the [Kubernetes repository](https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/legacy-cloud-providers/vsphere). If you want to create issues or pull requests for the in-tree cloud provider, please go to the [Kubernetes repository](https://github.com/kubernetes/kubernetes).
 
-There is ongoing work for refactoring cloud providers out of the upstream repository. For more details, please check [this KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20180530-cloud-controller-manager.md).
+There is ongoing work for refactoring cloud providers out of the upstream repository. For more details, please check [this KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/2392-cloud-controller-manager/README.md).
 
 ## Compatibility with Kubernetes
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The commit[1] has changed the URL of the KEP.
This updates the link for catching it.

[1]: https://github.com/kubernetes/enhancements/commit/6d7b4ba80ccae674a34f63b61398529d34a3926c

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
