### PR TITLE
Delete node if VM's MOR not found

### DIFF
--- a/pkg/common/vclib/virtualmachine.go
+++ b/pkg/common/vclib/virtualmachine.go
@@ -434,6 +434,10 @@ func (vm *VirtualMachine) RenewVM(client *vim25.Client) VirtualMachine {
 func (vm *VirtualMachine) Exists(ctx context.Context) (bool, error) {
 	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*VirtualMachine{vm}, []string{"summary.runtime.powerState"})
 	if err != nil {
+		if IsManagedObjectNotFoundError(err) {
+			klog.Errorf("VM's ManagedObject is not found, assume it's already deleted, err: +%v", err)
+			return false, nil
+		}
 		klog.Errorf("Failed to get VM Managed object with property summary. err: +%v", err)
 		return false, err
 	}

--- a/test/e2e/cpi_vm_test.go
+++ b/test/e2e/cpi_vm_test.go
@@ -307,9 +307,6 @@ var _ = Describe("Restarting, recreating and deleting VMs", func() {
 			return DoesNodeHasReadiness(workerNode, corev1.ConditionTrue)
 		}, 10*time.Minute).Should(BeTrue())
 
-		By("Read the providerID of VM")
-		providerID := getProviderIDFromNode(workerNode)
-
 		By("Powering off machine object")
 		task, err := workerVM.PowerOff(ctx)
 		Expect(err).ToNot(HaveOccurred(), "cannot power off vm")
@@ -317,7 +314,7 @@ var _ = Describe("Restarting, recreating and deleting VMs", func() {
 		err = task.Wait(ctx)
 		Expect(err).ToNot(HaveOccurred(), "cannot wait for vm to power off")
 
-		By("Delete machine object")
+		By("Delete VM fron VC")
 		task, err = workerVM.Destroy(ctx)
 		Expect(err).ToNot(HaveOccurred(), "cannot destroy vm")
 
@@ -329,28 +326,5 @@ var _ = Describe("Restarting, recreating and deleting VMs", func() {
 			_, err = getWorkerNode()
 			return err != nil && err.Error() == "worker node not found"
 		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
-
-		By("Eventually new node will be created")
-		var newExternalIP, newInternalIP string
-		Eventually(func() error {
-			if workerNode, err = getWorkerNode(); err != nil {
-				return err
-			}
-			if newExternalIP, err = getExternalIPFromNode(workerNode); err != nil {
-				return err
-			}
-			if newInternalIP, err = getInternalIPFromNode(workerNode); err != nil {
-				return err
-			}
-			return nil
-		}, 10*time.Minute, 5*time.Second).Should(Succeed())
-
-		By("New node will be created with correct info, different from old one")
-		Expect(newExternalIP).ToNot(BeEmpty())
-		Expect(newInternalIP).ToNot(BeEmpty())
-		Expect(getProviderIDFromNode(workerNode)).ToNot(BeEmpty())
-
-		Expect(workerNode.Name).ToNot(Equal(originalWorkerNodeName), "name still the same")
-		Expect(getProviderIDFromNode(workerNode)).ToNot(Equal(providerID), "providerID still the same")
 	})
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently, due to the fix in https://github.com/kubernetes/cloud-provider-vsphere/pull/650, the node will not be deleted if VM is deleted from VC

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/kubernetes/cloud-provider-vsphere/issues/680

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix the issue that node won't be deleted if VM is deleted from VC
```
