### PR TITLE
Update Dockerfile

### DIFF
--- a/cluster/images/controller-manager/Dockerfile
+++ b/cluster/images/controller-manager/Dockerfile
@@ -14,7 +14,7 @@
 ##                               BUILD ARGS                                   ##
 ################################################################################
 # This build arg allows the specification of a custom Golang image.
-ARG GOLANG_IMAGE=golang:1.19.2
+ARG GOLANG_IMAGE=golang:1.19.5
 
 # The distroless image on which the CPI manager image is built.
 #
@@ -23,7 +23,7 @@ ARG GOLANG_IMAGE=golang:1.19.2
 # the fully-qualified image can be obtained by entering
 # "gcr.io/distroless/static:latest" in a browser and then copying the
 # fully-qualified image from the web page.
-ARG DISTROLESS_IMAGE=gcr.io/distroless/static@sha256:9b60270ec0991bc4f14bda475e8cae75594d8197d0ae58576ace84694aa75d7a
+ARG DISTROLESS_IMAGE=gcr.io/distroless/static@sha256:1e6ae0365c169e23830c155592fc154d02aa90755830e494284c28b124736b73
 
 ################################################################################
 ##                              BUILD STAGE                                   ##


### PR DESCRIPTION
Bump versions to 1.19.5 and distroless 1e6ae0365c

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update versions to latest

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump versions to 1.19.5 and distroless 1e6ae0365c
```
