### PR TITLE
Update registry k8s.gcr.io -> registry.k8s.io

### DIFF
--- a/docs/book/tutorials/k8s-vcp-on-vsphere-with-kubeadm.md
+++ b/docs/book/tutorials/k8s-vcp-on-vsphere-with-kubeadm.md
@@ -198,13 +198,13 @@ Firstly, verify that connectivity to the required `gcr.io` registries is working
 
 ```sh
 $ sudo kubeadm config images pull
-[config/images] Pulled k8s.gcr.io/kube-apiserver:v1.14.2
-[config/images] Pulled k8s.gcr.io/kube-controller-manager:v1.14.2
-[config/images] Pulled k8s.gcr.io/kube-scheduler:v1.14.2
-[config/images] Pulled k8s.gcr.io/kube-proxy:v1.14.2
-[config/images] Pulled k8s.gcr.io/pause:3.1
-[config/images] Pulled k8s.gcr.io/etcd:3.3.10
-[config/images] Pulled k8s.gcr.io/coredns:1.3.1
+[config/images] Pulled registry.k8s.io/kube-apiserver:v1.14.2
+[config/images] Pulled registry.k8s.io/kube-controller-manager:v1.14.2
+[config/images] Pulled registry.k8s.io/kube-scheduler:v1.14.2
+[config/images] Pulled registry.k8s.io/kube-proxy:v1.14.2
+[config/images] Pulled registry.k8s.io/pause:3.1
+[config/images] Pulled registry.k8s.io/etcd:3.3.10
+[config/images] Pulled registry.k8s.io/coredns:1.3.1
 ```
 
 ### On the master node(s) (part b)

--- a/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
+++ b/docs/book/tutorials/kubernetes-on-vsphere-with-kubeadm.md
@@ -45,13 +45,13 @@ quay.io/k8scsi/csi-provisioner:v1.2.2
 quay.io/k8scsi/csi-attacher:v1.1.1
 quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
 quay.io/k8scsi/livenessprobe:v1.1.0
-k8s.gcr.io/kube-apiserver:v1.14.2
-k8s.gcr.io/kube-controller-manager:v1.14.2
-k8s.gcr.io/kube-scheduler:v1.14.2
-k8s.gcr.io/kube-proxy:v1.14.2
-k8s.gcr.io/pause:3.1
-k8s.gcr.io/etcd:3.3.10
-k8s.gcr.io/coredns:1.3.1
+registry.k8s.io/kube-apiserver:v1.14.2
+registry.k8s.io/kube-controller-manager:v1.14.2
+registry.k8s.io/kube-scheduler:v1.14.2
+registry.k8s.io/kube-proxy:v1.14.2
+registry.k8s.io/pause:3.1
+registry.k8s.io/etcd:3.3.10
+registry.k8s.io/coredns:1.3.1
 ```
 
 ### Tools
@@ -303,11 +303,11 @@ networking:
   podSubnet: "10.244.0.0/16"
 etcd:
   local:
-    imageRepository: "k8s.gcr.io"
+    imageRepository: "registry.k8s.io"
     imageTag: "3.3.10"
 dns:
   type: "CoreDNS"
-  imageRepository: "k8s.gcr.io"
+  imageRepository: "registry.k8s.io"
   imageTag: "1.5.0"
 EOF
 ```


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR will update the uses of deprecating `[k8s.gcr.io](http://k8s.gcr.io/)` registry to `[registry.k8s.io](http://registry.k8s.io/)` prior to the planned April freeze.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://github.com/kubernetes/k8s.io/issues/4738

**Special notes for your reviewer**:
Search results: https://cs.k8s.io/?q=k8s.gcr.io&i=nope&files=&excludeFiles=vendor%2F&repos=kubernetes/cloud-provider-vsphere

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
