### PR TITLE
Move credentials from configmap to secret

### DIFF
--- a/charts/vsphere-cpi/templates/configmap.yaml
+++ b/charts/vsphere-cpi/templates/configmap.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.config.enabled | default .Values.global.config.enabled -}}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ .Values.config.name | default "cloud-config" }}
   labels:
@@ -8,7 +8,7 @@ metadata:
     vsphere-cpi-infra: cloud-config
     component: cloud-controller-manager
   namespace: {{ .Release.Namespace }}
-data:
+stringData:
   vsphere.conf: |
     # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
     global:

--- a/charts/vsphere-cpi/templates/daemonset.yaml
+++ b/charts/vsphere-cpi/templates/daemonset.yaml
@@ -83,8 +83,8 @@ spec:
         {{- end }}
       volumes:
         - name: vsphere-config-volume
-          configMap:
-            name: {{ if .Values.config.enabled }}{{- .Values.config.name }}{{- else }}cloud-config{{- end }}
+          secret:
+            secretName: {{ if .Values.config.enabled }}{{- .Values.config.name }}{{- else }}cloud-config{{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
**What this PR does / why we need it**:

Configmap shouldn't contain any sensitive data. Now, the chart renders credentials in the configmap by default, which is a severe security issue.

This PR replaces the config map with a secret.

Alternative fix: https://github.com/kubernetes/cloud-provider-vsphere/pull/703

**Release note**:
```release-note
Use secret instead of configmap for configuration including credentials.
```
