### PR TITLE
Remove credentials from configmap

### DIFF
--- a/charts/vsphere-cpi/templates/configmap.yaml
+++ b/charts/vsphere-cpi/templates/configmap.yaml
@@ -25,10 +25,8 @@ data:
 
     # vcenter section
     vcenter:
-      {{ .Values.config.vcenter }}:
+      {{ .Values.config.vcenter | default .Values.global.config.vcenter }}:
         server: {{ .Values.config.vcenter | default .Values.global.config.vcenter }}
-        user: {{ .Values.config.username | default .Values.global.config.username }}
-        password: {{ .Values.config.password | default .Values.global.config.password }}
         datacenters:
           - {{ .Values.config.datacenter | default .Values.global.config.datacenter }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Configmap shouldn't contain any sensitive data. Now, the chart renders credentials in the configmap by default, which is a severe security issue.

This PR removes the credentials from the config map. This PR is an alternative fix for #702.

The credentials are already mentioned in the global section here. https://github.com/kubernetes/cloud-provider-vsphere/pull/703/files#diff-16a1b86b54e6dcd195f64b3a827a7a6dddfcee85eafcb5ced64a103632d07b97R23

If the user wants to provide username and password instead of creating the secret upfront, it is enough to set `config.secret.create=true`.

**Release note**:
```release-note
Remove credentials from configmap in the helm chart.
```