### PR TITLE
Use dl.k8s.io instead of hardcoded GCS URIs

### DIFF
--- a/hack/ensure-kubectl.sh
+++ b/hack/ensure-kubectl.sh
@@ -31,7 +31,7 @@ verify_kubectl_version() {
         mkdir -p "${GOPATH_BIN}"
       fi
       echo 'kubectl not found, installing'
-      curl -sLo "${GOPATH_BIN}/kubectl" https://storage.googleapis.com/kubernetes-release/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
+      curl -sLo "${GOPATH_BIN}/kubectl" https://dl.k8s.io/release/${MINIMUM_KUBECTL_VERSION}/bin/linux/amd64/kubectl
       chmod +x "${GOPATH_BIN}/kubectl"
     else
       echo "Missing required binary in path: kubectl"


### PR DESCRIPTION
**What this PR does / why we need it**:

The `storage.googleapis.com/kubernetes-release` URL is a hard coded path to a GCS bucket location. To allow redirecting and spreading the load across multiple hosting locations, the `dl.k8s.io` URL has been introduced.

**Which issue this PR fixes**:

Related PRs:

- https://github.com/kubernetes-sigs/image-builder/pull/656
- https://github.com/kubernetes-sigs/cluster-api/pull/4958

**Special notes for your reviewer**:

N/A

**Release note**:

```release-note
NONE
```
