### PR TITLE
Fix error verification to work on Go 1.19 and 1.20

### DIFF
--- a/pkg/common/vclib/connection_test.go
+++ b/pkg/common/vclib/connection_test.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
 	"k8s.io/cloud-provider-vsphere/pkg/common/vclib/fixtures"
 )
@@ -188,7 +190,8 @@ func verifyWrappedX509UnkownAuthorityErr(t *testing.T, err error) {
 	if !ok {
 		t.Fatalf("Expected to receive an url.Error, got '%s' (%#v)", err.Error(), err)
 	}
-	x509Err, ok := urlErr.Err.(x509.UnknownAuthorityError)
+	x509Err := &x509.UnknownAuthorityError{}
+	ok = errors.As(urlErr.Err, x509Err)
 	if !ok {
 		t.Fatalf("Expected to receive a wrapped x509.UnknownAuthorityError, got: '%s' (%#v)", urlErr.Error(), urlErr)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Go 1.20 introduces a new tls.CertificateValidationError that wraps the x509.UnknownAuthorityError. Instead of casting to the UnknownAuthorityError directly, search the error chain for it.

Fixing this allows for code compatibility with Go 1.19 and Go 1.20.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This was discovered in a test for upgrading the OpenShift fork of this repository to Go 1.20. You can see the originating [PR](https://github.com/openshift/cloud-provider-vsphere/pull/37) that surfaced the issue

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
