### PR TITLE
Fix tls thumbprint parameter in the helm chart

### DIFF
--- a/charts/vsphere-cpi/templates/configmap.yaml
+++ b/charts/vsphere-cpi/templates/configmap.yaml
@@ -13,8 +13,8 @@ data:
     # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
     global:
       port: 443
-      {{- if .Values.config.tlsThumbprint }}
-      tlsThumbprint: {{- .Values.config.tlsThumbprint }}
+      {{- if .Values.config.thumbprint }}
+      thumbprint: {{ .Values.config.thumbprint }}
       {{- else }}
       # set insecure-flag to true if the vCenter uses a self-signed cert
       insecureFlag: true

--- a/charts/vsphere-cpi/values.yaml
+++ b/charts/vsphere-cpi/values.yaml
@@ -15,7 +15,7 @@ config:
   datacenter: "dc"
   region: "k8s-region"
   zone: "k8s-zone"
-  tlsThumbprint: ""
+  thumbprint: ""
 
   secret:
     # Specifies whether Secret should be created from config values


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes helm chart for tls thumbprint parameter. The current chart is wrong.

**Special notes for your reviewer**:
The controller respects `thumbprint`, not `tlsThumbprint`.

https://github.com/kubernetes/cloud-provider-vsphere/blob/a7af18bcabc6b79b559aff6a8f84b17b9491ac9c/pkg/common/config/config_ini_legacy.go#L47

Since the current parameter doesn't work because of [wrong templating](https://github.com/kubernetes/cloud-provider-vsphere/pull/726#discussion_r1205388077) and the wrong parameter name, I think it is OK to fix the parameter too. I believe there is no one who relies on this feature since it is already broken. 

**Release note**:
```release-note
Fix tls thumbprint parameter in the helm chart
```
