### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -21,7 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	klog "k8s.io/klog/v2"
@@ -50,7 +50,7 @@ func ParseConfig(configFile string) (*config.Config, error) {
 		return nil, fmt.Errorf("Can not open config file %s, %v", configFile, err)
 	}
 
-	byConfig, err := ioutil.ReadAll(f)
+	byConfig, err := io.ReadAll(f)
 	if err != nil {
 		klog.Errorf("ReadAll failed: %s", err)
 		return nil, err

--- a/pkg/cli/util.go
+++ b/pkg/cli/util.go
@@ -18,7 +18,6 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -31,7 +30,7 @@ func ReadContent(path string) (string, error) {
 		}
 		return "", err
 	}
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -19,7 +19,6 @@ package vsphere
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -58,7 +57,7 @@ const (
 
 func init() {
 	cloudprovider.RegisterCloudProvider(RegisteredProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
-		byConfig, err := ioutil.ReadAll(config)
+		byConfig, err := io.ReadAll(config)
 		if err != nil {
 			klog.Errorf("ReadAll failed: %s", err)
 			return nil, err

--- a/pkg/cloudprovider/vsphereparavirtual/cloud.go
+++ b/pkg/cloudprovider/vsphereparavirtual/cloud.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -67,7 +66,7 @@ func init() {
 		}
 
 		// read the config file
-		data, err := ioutil.ReadAll(config)
+		data, err := io.ReadAll(config)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read cloud configuration from %q [%v]", config, err)
 		}

--- a/pkg/cloudprovider/vsphereparavirtual/config.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config.go
@@ -18,7 +18,6 @@ package vsphereparavirtual
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net"
 	"os"
 
@@ -60,7 +59,7 @@ type SupervisorEndpoint struct {
 
 func readOwnerRef(path string) (*metav1.OwnerReference, error) {
 	ownerRef := &metav1.OwnerReference{}
-	d, err := ioutil.ReadFile(path)
+	d, err := os.ReadFile(path)
 	if err != nil {
 		return ownerRef, errors.Wrapf(err, "Failed Reading OwnerReference Config file %s", path)
 	}
@@ -96,7 +95,7 @@ func readSupervisorConfig() (*SupervisorEndpoint, error) {
 
 func getNameSpace(svConfigPath string) (string, error) {
 	namespaceFile := svConfigPath + "/" + SupervisorClusterAccessNamespaceFile
-	namespace, err := ioutil.ReadFile(namespaceFile)
+	namespace, err := os.ReadFile(namespaceFile)
 	if err != nil {
 		klog.Errorf("Failed to read namespace from %s: %v", namespaceFile, err)
 		return "", err
@@ -112,7 +111,7 @@ func getRestConfig(svConfigPath string) (*rest.Config, error) {
 	}
 
 	tokenFile := svConfigPath + "/" + SupervisorClusterAccessTokenFile
-	token, err := ioutil.ReadFile(tokenFile)
+	token, err := os.ReadFile(tokenFile)
 
 	if err != nil {
 		klog.Errorf("Failed to read token from %s: %v", tokenFile, err)
@@ -120,7 +119,7 @@ func getRestConfig(svConfigPath string) (*rest.Config, error) {
 	}
 
 	rootCAFile := svConfigPath + "/" + SupervisorClusterAccessCAFile
-	rootCA, err := ioutil.ReadFile(rootCAFile)
+	rootCA, err := os.ReadFile(rootCAFile)
 
 	if err != nil {
 		klog.Errorf("Failed to read ca cert from %s: %v", rootCAFile, err)

--- a/pkg/cloudprovider/vsphereparavirtual/config_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config_test.go
@@ -19,7 +19,6 @@ package vsphereparavirtual
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"testing"
@@ -62,7 +61,7 @@ func TestReadOwnerRef(t *testing.T) {
 	for _, test := range tests {
 
 		if test.fileExists {
-			tmpfile, err := ioutil.TempFile("", "TestReadOwnerRef")
+			tmpfile, err := os.CreateTemp("", "TestReadOwnerRef")
 			if err != nil {
 				t.Errorf("Should be able to create tmpfile: %s", err)
 			}

--- a/pkg/common/credentialmanager/credentialmanager.go
+++ b/pkg/common/credentialmanager/credentialmanager.go
@@ -17,8 +17,8 @@ limitations under the License.
 package credentialmanager
 
 import (
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -109,22 +109,21 @@ func (credentialManager *CredentialManager) updateCredentialsMapFile() error {
 	//take the mounted secrets in the form of files and make it looks like we
 	//parsed it from a k8s secret so we can reuse the SecretCache.parseSecret() func
 	data := make(map[string][]byte)
-
-	files, err := ioutil.ReadDir(credentialManager.SecretsDirectory)
+	entries, err := os.ReadDir(credentialManager.SecretsDirectory)
 	if err != nil {
 		credentialManager.secretsDirectoryParsed = true
 		klog.Warningf("Failed to find secrets directory %s. error: %q", credentialManager.SecretsDirectory, err)
 		return err
 	}
 
-	for _, f := range files {
+	for _, f := range entries {
 		if f.IsDir() {
 			klog.Warningf("Skipping parse of directory: %s", f.Name())
 			continue
 		}
 
 		fullFilePath := credentialManager.SecretsDirectory + "/" + f.Name()
-		contents, err := ioutil.ReadFile(fullFilePath)
+		contents, err := os.ReadFile(fullFilePath)
 		if err != nil {
 			klog.Warningf("Cannot read  file %s. error: %q", fullFilePath, err)
 			continue

--- a/pkg/common/vclib/connection_test.go
+++ b/pkg/common/vclib/connection_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -43,7 +42,7 @@ func createTestServer(
 	serverKeyPath string,
 	handler http.HandlerFunc,
 ) (*httptest.Server, string) {
-	caCertPEM, err := ioutil.ReadFile(caCertPath)
+	caCertPEM, err := os.ReadFile(caCertPath)
 	if err != nil {
 		t.Fatalf("Could not read ca cert from file")
 	}

--- a/pkg/nsxt/connector_manager.go
+++ b/pkg/nsxt/connector_manager.go
@@ -21,8 +21,9 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 
@@ -134,7 +135,7 @@ func getConnectorTLSConfig(insecure bool, clientCertFile string, clientKeyFile s
 	}
 
 	if len(caFile) > 0 {
-		caCert, err := ioutil.ReadFile(caFile)
+		caCert, err := os.ReadFile(caFile)
 		if err != nil {
 			return nil, err
 		}
@@ -173,7 +174,7 @@ func getAPIToken(vmcAuthHost string, vmcAccessToken string) (string, error) {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		b, _ := ioutil.ReadAll(res.Body)
+		b, _ := io.ReadAll(res.Body)
 		return "", fmt.Errorf("Unexpected status code %d trying to get auth token. %s", res.StatusCode, string(b))
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
