### PR TITLE
Improve helm chart to support global values

### DIFF
--- a/charts/vsphere-cpi/templates/configmap.yaml
+++ b/charts/vsphere-cpi/templates/configmap.yaml
@@ -1,8 +1,14 @@
-{{- if .Values.config.enabled | default .Values.global.config.enabled -}}
+{{- $config := .Values.config -}}
+{{- if .Values.global }}
+{{- if .Values.global.config }}
+{{- $config = mergeOverwrite (deepCopy .Values.config) .Values.global.config -}}
+{{- end }}
+{{- end }}
+{{- if $config.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.config.name | default "cloud-config" }}
+  name: {{ $config.name | default "cloud-config" }}
   labels:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: cloud-config
@@ -13,25 +19,25 @@ data:
     # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
     global:
       port: 443
-      {{- if .Values.config.thumbprint }}
-      thumbprint: {{ .Values.config.thumbprint }}
+      {{- if $config.thumbprint }}
+      thumbprint: {{ $config.thumbprint }}
       {{- else }}
       # set insecure-flag to true if the vCenter uses a self-signed cert
       insecureFlag: true
       {{- end }}
       # settings for using k8s secret
-      secretName: {{ .Values.config.secret.name }}
+      secretName: {{ $config.secret.name }}
       secretNamespace: {{ .Release.Namespace }}
 
     # vcenter section
     vcenter:
-      {{ .Values.config.vcenter | default .Values.global.config.vcenter }}:
-        server: {{ .Values.config.vcenter | default .Values.global.config.vcenter }}
+      {{ $config.vcenter }}:
+        server: {{ $config.vcenter }}
         datacenters:
-          - {{ .Values.config.datacenter | default .Values.global.config.datacenter }}
+          - {{ $config.datacenter }}
 
     # labels for regions and zones
     labels:
-      region: {{ .Values.config.region | default .Values.global.config.region }}
-      zone: {{ .Values.config.zone | default .Values.global.config.zone }}
+      region: {{ $config.region }}
+      zone: {{ $config.zone }}
 {{- end -}}

--- a/charts/vsphere-cpi/templates/daemonset.yaml
+++ b/charts/vsphere-cpi/templates/daemonset.yaml
@@ -1,3 +1,9 @@
+{{- $config := .Values.config -}}
+{{- if .Values.global -}}
+{{- if .Values.global.config -}}
+{{- $config = mergeOverwrite (deepCopy .Values.config) .Values.global.config -}}
+{{- end -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -84,7 +90,7 @@ spec:
       volumes:
         - name: vsphere-config-volume
           configMap:
-            name: {{ if .Values.config.enabled }}{{- .Values.config.name }}{{- else }}cloud-config{{- end }}
+            name: {{ if $config.enabled }}{{- $config.name }}{{- else }}cloud-config{{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/vsphere-cpi/templates/secret.yaml
+++ b/charts/vsphere-cpi/templates/secret.yaml
@@ -1,14 +1,20 @@
-{{- if and .Values.config.secret.create .Values.config.enabled | default .Values.global.config.enabled -}}
+{{- $config := .Values.config -}}
+{{- if .Values.global -}}
+{{- if .Values.global.config -}}
+{{- $config = mergeOverwrite (deepCopy .Values.config) .Values.global.config -}}
+{{- end -}}
+{{- end -}}
+{{- if and $config.secret.create $config.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.config.secret.name | default "vsphere-cloud-secret" }}
+  name: {{ $config.secret.name | default "vsphere-cloud-secret" }}
   labels:
     app: {{ template "cpi.name" . }}
     vsphere-cpi-infra: secret
     component: cloud-controller-manager
   namespace: {{ .Release.Namespace }}
 stringData:
-  {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.username: {{ .Values.config.username | default .Values.global.config.username | quote }}
-  {{ .Values.config.vcenter | default .Values.global.config.vcenter }}.password: {{ .Values.config.password | default .Values.global.config.password | quote }}
+  {{ $config.vcenter }}.username: {{ $config.username | quote }}
+  {{ $config.vcenter }}.password: {{ $config.password | quote }}
 {{- end -}}

--- a/charts/vsphere-cpi/values.yaml
+++ b/charts/vsphere-cpi/values.yaml
@@ -2,10 +2,6 @@
 # This is a YAML-formatted file.
 # vSphere CPI values are grouped by component
 
-global:
-  config:
-    enabled: false
-
 config:
   enabled: false
   name: vsphere-cloud-config


### PR DESCRIPTION
### Background

A helm chart can be used as sub chart in another chart. The parent chart can provide values for subcharts explicitly and it doesn't require anything in the subchart. On the other hand, when the parent chart wants to provide a common set of values to all subcharts, it is not easy. The parent chart has to set `.global` and all subcharts have to respect `.global` explicitly. See https://helm.sh/docs/chart_template_guide/subcharts_and_globals/

While developing a helm chart, if you want 
- Your chart should work standalone
- Your chart should respect `.global` if exists

at the same time, there is no proper solution. You need to implement the logic in your chart.

### Why did I open this PR?

Current chart has code pieces as below to achieve this goal. 

```
 .Values.config.region | default .Values.global.config.region
```

**Problems**
- The order is not right in the current chart. Parent chart should be able to overwrite config via `.global`. Therefore, default should be `.config` and `.global.config` should overwrite it if exists.
- Config merge is done for every parameter in templates. It is error-prone and the logic is missing for some configs right now. See `.config.thumbprint ` and `.config.secret.name`.

### Note for reviewers
I tried to find a better solution. It was great if it was possible to do the merge once and use it in every template but there is no such solution. See https://kubernetes.slack.com/archives/C0NH30761/p1686828259395319

**Release note**:
```release-note
Improve helm chart to support global values so that this chart can be used as subchart.
```
