### PR TITLE
Scope secret informers per namespace

### DIFF
--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -122,7 +122,7 @@ func (vs *VSphere) Initialize(clientBuilder cloudprovider.ControllerClientBuilde
 	if err == nil {
 		klog.V(1).Info("Kubernetes Client Init Succeeded")
 
-		vs.informMgr = k8s.NewInformer(client, true)
+		vs.informMgr = k8s.NewInformer(client, vs.cfg.Config.Global.SecretNamespace, vs.nsxtSecretNamespace)
 
 		connMgr := cm.NewConnectionManager(&vs.cfg.Config, vs.informMgr, client)
 		vs.connectionManager = connMgr
@@ -156,7 +156,7 @@ func (vs *VSphere) Initialize(clientBuilder cloudprovider.ControllerClientBuilde
 		}
 		vs.loadbalancer.Initialize(loadbalancer.ClusterName, client, stop)
 	}
-	err = vs.nsxtConnectorMgr.AddSecretListener(vs.informMgr.GetSecretInformer())
+	err = vs.nsxtConnectorMgr.AddSecretListener(vs.informMgr.GetSecretInformer(vs.nsxtSecretNamespace))
 	if err != nil {
 		klog.Warningf("Adding NSXT secret listener failed: %v", err)
 	}
@@ -257,15 +257,21 @@ func buildVSphereFromConfig(cfg *ccfg.CPIConfig, nsxtcfg *ncfg.Config, lbcfg *lc
 		return nil, err
 	}
 
+	nsxtSecretNamespace := v1.NamespaceAll
+	if nsxtcfg != nil {
+		nsxtSecretNamespace = nsxtcfg.SecretNamespace
+	}
+
 	vs := VSphere{
-		cfg:              cfg,
-		cfgLB:            lbcfg,
-		nodeManager:      nm,
-		nsxtConnectorMgr: ncm,
-		loadbalancer:     lb,
-		routes:           routes,
-		instances:        newInstances(nm),
-		zones:            newZones(nm, cfg.Labels.Zone, cfg.Labels.Region),
+		cfg:                 cfg,
+		cfgLB:               lbcfg,
+		nodeManager:         nm,
+		nsxtConnectorMgr:    ncm,
+		nsxtSecretNamespace: nsxtSecretNamespace,
+		loadbalancer:        lb,
+		routes:              routes,
+		instances:           newInstances(nm),
+		zones:               newZones(nm, cfg.Labels.Zone, cfg.Labels.Region),
 	}
 	return &vs, nil
 }

--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -53,10 +53,11 @@ type VSphere struct {
 	*/
 
 	// internal plumbing
-	connectionManager *cm.ConnectionManager
-	nodeManager       *NodeManager
-	informMgr         *k8s.InformerManager
-	nsxtConnectorMgr  *nsxt.ConnectorManager
+	connectionManager   *cm.ConnectionManager
+	nodeManager         *NodeManager
+	informMgr           *k8s.InformerManager
+	nsxtConnectorMgr    *nsxt.ConnectorManager
+	nsxtSecretNamespace string
 }
 
 // NodeInfo is information about a Kubernetes node.

--- a/pkg/cloudprovider/vsphereparavirtual/cloud.go
+++ b/pkg/cloudprovider/vsphereparavirtual/cloud.go
@@ -121,7 +121,7 @@ func (cp *VSphereParavirtual) Initialize(clientBuilder cloudprovider.ControllerC
 	}
 
 	cp.client = client
-	cp.informMgr = k8s.NewInformer(client, true)
+	cp.informMgr = k8s.NewInformer(client)
 	cp.ownerReference = ownerRef
 
 	kcfg, err := getRestConfig(SupervisorClusterConfigPath)

--- a/pkg/common/connectionmanager/connectionmanager.go
+++ b/pkg/common/connectionmanager/connectionmanager.go
@@ -51,7 +51,7 @@ func NewConnectionManager(cfg *vcfg.Config, informMgr *k8s.InformerManager, clie
 	}
 	if informMgr != nil {
 		klog.V(2).Info("Initializing with K8s SecretLister")
-		credMgr := cm.NewCredentialManager(cfg.Global.SecretName, cfg.Global.SecretNamespace, "", informMgr.GetSecretLister())
+		credMgr := cm.NewCredentialManager(cfg.Global.SecretName, cfg.Global.SecretNamespace, "", informMgr.GetSecretLister(cfg.Global.SecretNamespace))
 		connMgr.credentialManagers[vcfg.DefaultCredentialManager] = credMgr
 		connMgr.informerManagers[vcfg.DefaultCredentialManager] = informMgr
 
@@ -116,8 +116,8 @@ func (connMgr *ConnectionManager) createManagersPerTenant(secretName string, sec
 	var informMgr *k8s.InformerManager
 	var lister listerv1.SecretLister
 	if client != nil && secretsDirectory == "" {
-		informMgr = k8s.NewInformer(client, true)
-		lister = informMgr.GetSecretLister()
+		informMgr = k8s.NewInformer(client, secretNamespace)
+		lister = informMgr.GetSecretLister(secretNamespace)
 	}
 
 	credMgr := cm.NewCredentialManager(secretName, secretNamespace, secretsDirectory, lister)

--- a/pkg/common/kubernetes/informers.go
+++ b/pkg/common/kubernetes/informers.go
@@ -65,40 +65,66 @@ func setupSignalHandler() (stopCh <-chan struct{}) {
 }
 
 // NewInformer creates a newk8s client based on a service account
-func NewInformer(client clientset.Interface, singleWatcher bool) *InformerManager {
+func NewInformer(client clientset.Interface, namespaces ...string) *InformerManager {
 	onceForInformer.Do(func() {
 		signalHandler = setupSignalHandler()
 		informerFactory = informers.NewSharedInformerFactory(client, noResyncPeriodFunc())
 	})
 
+	informerFactories := map[string]informers.SharedInformerFactory{
+		defaultInformerFactoryNamespace: informerFactory,
+	}
+
+	for _, ns := range namespaces {
+		informerFactories[ns] = informers.NewSharedInformerFactoryWithOptions(client, noResyncPeriodFunc(), informers.WithNamespace(ns))
+	}
+
 	return &InformerManager{
-		client:          client,
-		stopCh:          signalHandler,
-		informerFactory: informerFactory,
+		client:                      client,
+		stopCh:                      signalHandler,
+		namespacedInformerFactories: informerFactories,
+		namespacedSecretInformer:    make(map[string]informerv1.SecretInformer),
 	}
 }
 
 // GetSecretLister creates a lister to use
-func (im *InformerManager) GetSecretLister() listerv1.SecretLister {
-	if im.secretInformer == nil {
-		im.secretInformer = im.informerFactory.Core().V1().Secrets()
-	}
-
-	return im.secretInformer.Lister()
+func (im *InformerManager) GetSecretLister(namespace string) listerv1.SecretLister {
+	return im.getSecretInformer(namespace).Lister()
 }
 
 // GetSecretInformer gets secret informer
-func (im *InformerManager) GetSecretInformer() informerv1.SecretInformer {
-	if im.secretInformer == nil {
-		im.secretInformer = im.informerFactory.Core().V1().Secrets()
+func (im *InformerManager) GetSecretInformer(namespace string) informerv1.SecretInformer {
+	return im.getSecretInformer(namespace)
+}
+
+func (im *InformerManager) getSecretInformer(namespace string) informerv1.SecretInformer {
+	secretInformer, ok := im.namespacedSecretInformer[namespace]
+	if ok {
+		return secretInformer
 	}
-	return im.secretInformer
+
+	factory, ok := im.namespacedInformerFactories[namespace]
+	if !ok {
+		factory = informers.NewSharedInformerFactoryWithOptions(im.client, noResyncPeriodFunc(), informers.WithNamespace(namespace))
+		im.namespacedInformerFactories[namespace] = factory
+		go factory.Start(im.stopCh)
+	}
+
+	secretInformer = factory.Core().V1().Secrets()
+	im.namespacedSecretInformer[namespace] = secretInformer
+
+	return secretInformer
 }
 
 // AddNodeListener hooks up add, update, delete callbacks
 func (im *InformerManager) AddNodeListener(add, remove func(obj interface{}), update func(oldObj, newObj interface{})) {
 	if im.nodeInformer == nil {
-		im.nodeInformer = im.informerFactory.Core().V1().Nodes().Informer()
+		factory, ok := im.namespacedInformerFactories[defaultInformerFactoryNamespace]
+		if !ok {
+			panic("no default informer factory")
+		}
+
+		im.nodeInformer = factory.Core().V1().Nodes().Informer()
 	}
 
 	im.nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -110,16 +136,27 @@ func (im *InformerManager) AddNodeListener(add, remove func(obj interface{}), up
 
 // GetNodeLister creates a lister to use
 func (im *InformerManager) GetNodeLister() listerv1.NodeLister {
-	return im.informerFactory.Core().V1().Nodes().Lister()
+	factory, ok := im.namespacedInformerFactories[defaultInformerFactoryNamespace]
+	if !ok {
+		panic("no default informer factory")
+	}
+	return factory.Core().V1().Nodes().Lister()
 }
 
 // IsNodeInformerSynced returns whether node informer is synced
 func (im *InformerManager) IsNodeInformerSynced() cache.InformerSynced {
-	return im.informerFactory.Core().V1().Nodes().Informer().HasSynced
+	factory, ok := im.namespacedInformerFactories[defaultInformerFactoryNamespace]
+	if !ok {
+		panic("no default informer factory")
+	}
+
+	return factory.Core().V1().Nodes().Informer().HasSynced
 }
 
 // Listen starts the Informers. Based on client-go informer package, if the Lister has
 // already been initialized, it will not re-init them. Only new non-init Listers will be initialized.
 func (im *InformerManager) Listen() {
-	go im.informerFactory.Start(im.stopCh)
+	for _, factory := range im.namespacedInformerFactories {
+		go factory.Start(im.stopCh)
+	}
 }

--- a/pkg/common/kubernetes/types.go
+++ b/pkg/common/kubernetes/types.go
@@ -23,18 +23,26 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+const (
+	defaultInformerFactoryNamespace = ""
+)
+
 // InformerManager is a service that notifies subscribers about changes
 // to well-defined information in the Kubernetes API server.
 type InformerManager struct {
 	// k8s client
 	client clientset.Interface
-	// main shared informer factory
-	informerFactory informers.SharedInformerFactory
+
+	// namespaced informer factories for resources limited to namespaces.
+	// The main informer factory is for cluster-scoped resources and is under
+	// the key "".
+	namespacedInformerFactories map[string]informers.SharedInformerFactory
+
 	// main signal
 	stopCh (<-chan struct{})
 
-	// secret informer
-	secretInformer v1.SecretInformer
+	// secret informers by namespace
+	namespacedSecretInformer map[string]v1.SecretInformer
 
 	// node informer
 	nodeInformer cache.SharedInformer


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When trying to set up the cloud provider with stricter permissions (not requiring get/list/watch for secrets across all namespaces), I realised that the way that the vSphere provider currently retrieves secrets for credentials requires these wide permissions.

To make the RBAC surface smaller, this PR updates the way we watch secrets to only watch the required namespaces for the secrets from the configuration.

This should be backwards compatible as existing users require get/list/watch on secrets across all namespaces currently.
Future configurations will now be able to specify secret get/list/watch for only the namespaces they need, eg the one containing their credentials for vCenter.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

I have manually tested this but have not updated any unit tests as I wasn't sure where to go for that, any pointers to appropriate tests to update would be appreciated.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Provider no longer requires global secret reader permissions and may be scoped to reading secrets only in required namespaces.
```
