### PR TITLE
Bump govmomi to 0.30.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
 	github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20201118171008-5ca641b0e126
-	github.com/vmware/govmomi v0.30.4
+	github.com/vmware/govmomi v0.30.6
 	github.com/vmware/vsphere-automation-sdk-go/lib v0.7.0
 	github.com/vmware/vsphere-automation-sdk-go/runtime v0.7.0
 	github.com/vmware/vsphere-automation-sdk-go/services/nsxt v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,8 @@ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20201118171008-5ca641b0e126 h1:kDAAVFnTW9YHGuUTMGQoWz9AV7aZo3+wCbtzyenVktI=
 github.com/vmware-tanzu/vm-operator-api v0.1.4-0.20201118171008-5ca641b0e126/go.mod h1:mubK0QMyaA2TbeAmGsu2GVfiqDFppNUAUqoMPoKFgzM=
-github.com/vmware/govmomi v0.30.4 h1:BCKLoTmiBYRuplv3GxKEMBLtBaJm8PA56vo9bddIpYQ=
-github.com/vmware/govmomi v0.30.4/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4r3INMdY=
+github.com/vmware/govmomi v0.30.6 h1:O3tjSwQBy0XwI5uK1/yVIfQ1LP9bAECEDUfifnyGs9U=
+github.com/vmware/govmomi v0.30.6/go.mod h1:epgoslm97rLECMV4D+08ORzUBEU7boFSepKjt7AYVGg=
 github.com/vmware/vsphere-automation-sdk-go/lib v0.7.0 h1:pT+oqJ8FD5eUBQkl+e7LZwwtbwPvW5kDyyGXvt66gOM=
 github.com/vmware/vsphere-automation-sdk-go/lib v0.7.0/go.mod h1:f3+6YVZpNcK2pYyiQ94BoHWmjMj9BnYav0vNFuTiDVM=
 github.com/vmware/vsphere-automation-sdk-go/runtime v0.7.0 h1:pSBxa9Agh6bgW8Hr0A1eQxuwnxGTnuAVox8iQb023hg=

--- a/pkg/common/connectionmanager/list_test.go
+++ b/pkg/common/connectionmanager/list_test.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 	"testing"
 
-	lookup "github.com/vmware/govmomi/lookup/simulator"
+	_ "github.com/vmware/govmomi/lookup/simulator"
 	"github.com/vmware/govmomi/simulator"
-	"github.com/vmware/govmomi/simulator/vpx"
-	sts "github.com/vmware/govmomi/sts/simulator"
+	_ "github.com/vmware/govmomi/sts/simulator"
+	_ "github.com/vmware/govmomi/vapi/simulator"
 
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
 	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
@@ -57,15 +57,11 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc b
 		log.Fatal(err)
 	}
 
+	// Adds vAPI, STS, Lookup Service endpoints to vcsim
+	model.Service.RegisterEndpoints = true
+
 	model.Service.TLS = tlsConfig
 	s := model.Service.NewServer()
-
-	// STS simulator
-	path, handler := sts.New(s.URL, vpx.Setting)
-	model.Service.ServeMux.Handle(path, handler)
-
-	// Lookup Service simulator
-	model.Service.RegisterSDK(lookup.New())
 
 	cfg.Global.InsecureFlag = insecureAllowed
 	cfg.Global.VCenterIP = s.URL.Hostname()

--- a/pkg/common/connectionmanager/list_test.go
+++ b/pkg/common/connectionmanager/list_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/simulator/vpx"
 	sts "github.com/vmware/govmomi/sts/simulator"
-	vapi "github.com/vmware/govmomi/vapi/simulator"
 
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
 	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
@@ -64,10 +63,6 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc b
 	// STS simulator
 	path, handler := sts.New(s.URL, vpx.Setting)
 	model.Service.ServeMux.Handle(path, handler)
-
-	// vAPI simulator
-	vapiPath, handler := vapi.New(s.URL, nil)
-	model.Service.ServeMux.Handle(vapiPath[0], handler)
 
 	// Lookup Service simulator
 	model.Service.RegisterSDK(lookup.New())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Need govmomi fix https://github.com/vmware/govmomi/issues/3174 for validating certificate's tlsthumbprint to work properly

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #https://github.com/kubernetes/cloud-provider-vsphere/issues/736

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Bump govmomi to 0.30.6
```
