### PR TITLE
Simplify vcsim endpoint setup

### DIFF
--- a/pkg/cloudprovider/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/vsphere/vsphere_test.go
@@ -25,11 +25,10 @@ import (
 	"reflect"
 	"testing"
 
-	lookup "github.com/vmware/govmomi/lookup/simulator"
+	_ "github.com/vmware/govmomi/lookup/simulator"
 	"github.com/vmware/govmomi/simulator"
-	"github.com/vmware/govmomi/simulator/vpx"
-	sts "github.com/vmware/govmomi/sts/simulator"
-	vapi "github.com/vmware/govmomi/vapi/simulator"
+	_ "github.com/vmware/govmomi/sts/simulator"
+	_ "github.com/vmware/govmomi/vapi/simulator"
 
 	ccfg "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/config"
 	vcfg "k8s.io/cloud-provider-vsphere/pkg/common/config"
@@ -88,19 +87,11 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc b
 		log.Fatal(err)
 	}
 
+	// Adds vAPI, STS, Lookup Service endpoints to vcsim
+	model.Service.RegisterEndpoints = true
+
 	model.Service.TLS = tlsConfig
 	s := model.Service.NewServer()
-
-	// STS simulator
-	path, handler := sts.New(s.URL, vpx.Setting)
-	model.Service.ServeMux.Handle(path, handler)
-
-	// vAPI simulator
-	vapiPath, handler := vapi.New(s.URL, nil)
-	model.Service.ServeMux.Handle(vapiPath[0], handler)
-
-	// Lookup Service simulator
-	model.Service.RegisterSDK(lookup.New())
 
 	cfg.Global.InsecureFlag = insecureAllowed
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The vcsim 'RegisterEndpoints' flag was added after the initial version of vsphere_test was written. With the flag set, tests only need to import the simulator packages it needs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

See: https://github.com/vmware/govmomi/issues/3178

**Special notes for your reviewer**:

@lubronzhan another option when bumping the govmomi version is the patch below. But this PR will also simplify the code a bit.

```diff
modified   pkg/cloudprovider/vsphere/vsphere_test.go
@@ -96,7 +96,7 @@ func configFromSimWithTLS(tlsConfig *tls.Config, insecureAllowed bool, multiDc b
 	model.Service.ServeMux.Handle(path, handler)
 
 	// vAPI simulator
-	vapiPath, handler := vapi.New(s.URL, nil)
+	vapiPath, handler := vapi.New(s.URL, simulator.Map)
 	model.Service.ServeMux.Handle(vapiPath[0], handler)
 
 	// Lookup Service simulator
```
**Release note**:

```release-note
NONE
```
