### PR TITLE
Correct parsing of guestInfo metadata

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -17,10 +17,13 @@ limitations under the License.
 package vsphere
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"sort"
 	"strings"
@@ -52,14 +55,20 @@ var (
 	ErrVMNotFound = errors.New("VM not found")
 )
 
-type cloudInitConfig struct {
-	Network struct {
+type (
+	networkConfig struct {
 		Ethernets map[string]struct {
 			Name      string   `yaml:"set-name"`
 			Addresses []string `yaml:"addresses"`
 		} `yaml:"ethernets"`
-	} `yaml:"network"`
-}
+	}
+	cloudInitConfig struct {
+		Network networkConfig `yaml:"network"`
+	}
+	encodedCloudInitConfig struct {
+		Network string `yaml:"network"`
+	}
+)
 
 func newNodeManager(cfg *ccfg.CPIConfig, cm *cm.ConnectionManager) *NodeManager {
 	return &NodeManager{
@@ -362,8 +371,10 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		os,
 	)
 
-	nodeInfo := &NodeInfo{tenantRef: tenantRef, dataCenter: vmDI.DataCenter, vm: vmDI.VM, vcServer: vmDI.VcServer,
-		UUID: vmDI.UUID, NodeName: vmDI.NodeName, NodeType: instanceType, NodeAddresses: addrs}
+	nodeInfo := &NodeInfo{
+		tenantRef: tenantRef, dataCenter: vmDI.DataCenter, vm: vmDI.VM, vcServer: vmDI.VcServer,
+		UUID: vmDI.UUID, NodeName: vmDI.NodeName, NodeType: instanceType, NodeAddresses: addrs,
+	}
 	nm.addNodeInfo(nodeInfo)
 
 	return nil
@@ -395,8 +406,8 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 func discoverIPs(ipAddrNetworkNames []*ipAddrNetworkName, ipFamily string,
 	internalNetworkSubnets, externalNetworkSubnets,
 	excludeInternalNetworkSubnets, excludeExternalNetworkSubnets []*net.IPNet,
-	internalVMNetworkName, externalVMNetworkName string) (internal *ipAddrNetworkName, external *ipAddrNetworkName) {
-
+	internalVMNetworkName, externalVMNetworkName string,
+) (internal *ipAddrNetworkName, external *ipAddrNetworkName) {
 	ipFamilyMatches := collectMatchesForIPFamily(ipAddrNetworkNames, ipFamily)
 
 	var discoveredInternal *ipAddrNetworkName
@@ -667,7 +678,6 @@ func (nm *NodeManager) getNodeNameByUUID(UUID string) string {
 		if v.UUID == UUID {
 			return k
 		}
-
 	}
 	return ""
 }
@@ -693,37 +703,92 @@ func guestInfoMetadata(extraConfig []types.BaseOptionValue) (string, string) {
 func sortStaticallyConfiguredAddressesFirst(extraConfig []types.BaseOptionValue, nonLocalhostIPs []*ipAddrNetworkName) ([]*ipAddrNetworkName, error) {
 	guestInfo, encoding := guestInfoMetadata(extraConfig)
 
-	if guestInfo != "" && encoding == "base64" {
-		value, err := base64.StdEncoding.DecodeString(guestInfo)
-		if err != nil {
-			return nil, err
-		}
-
-		guestInfo := &cloudInitConfig{}
-		err = yaml.Unmarshal(value, guestInfo)
-		if err != nil {
-			return nil, err
-		}
-
-		// Map of guestInfo IP -> index that describes the order they appear in the guestInfo
-		guestInfoAddresses := make(map[string]int)
-		for _, eth := range guestInfo.Network.Ethernets {
-			for _, address := range eth.Addresses {
-				ip := net.ParseIP(strings.Split(address, "/")[0])
-				guestInfoAddresses[ip.String()] = len(guestInfoAddresses)
-			}
-		}
-
-		// Sort nonlocalhostIPs by the following comparator for two IP addresses: a and b
-		// if a is statically configured, but b is not then a should be prioritized before b
-		// if b is statically configured, but a is not then a should not be prioritized before b
-		// if a and b are both statically configured, then use the index from the guest info
-		sort.SliceStable(nonLocalhostIPs, func(i, j int) bool {
-			aIndex, aFound := guestInfoAddresses[nonLocalhostIPs[i].ipAddr]
-			bIndex, bFound := guestInfoAddresses[nonLocalhostIPs[j].ipAddr]
-
-			return aFound && !bFound || aFound && bFound && aIndex < bIndex
-		})
+	if guestInfo == "" || encoding != "base64" {
+		return nonLocalhostIPs, nil
 	}
+
+	value, err := base64.StdEncoding.DecodeString(guestInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	ne := struct {
+		NetworkEncoding string `yaml:"network.encoding"`
+	}{}
+	if err := yaml.Unmarshal(value, &ne); err != nil {
+		return nil, err
+	}
+
+	var netConfig networkConfig
+	switch ne.NetworkEncoding {
+	case "base64", "b64":
+		var encNetconfig encodedCloudInitConfig
+		if err := yaml.Unmarshal(value, &encNetconfig); err != nil {
+			return nil, err
+		}
+
+		if value, err = base64.StdEncoding.DecodeString(encNetconfig.Network); err != nil {
+			return nil, err
+		}
+
+		if err := yaml.Unmarshal(value, &netConfig); err != nil {
+			return nil, err
+		}
+	case "gzip+base64", "gz+b64":
+		var encNetconfig encodedCloudInitConfig
+		if err := yaml.Unmarshal(value, &encNetconfig); err != nil {
+			return nil, err
+		}
+
+		gzData, err := base64.StdEncoding.DecodeString(encNetconfig.Network)
+		if err != nil {
+			return nil, err
+		}
+
+		r := bytes.NewReader(gzData)
+		gr, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+
+		if value, err = io.ReadAll(gr); err != nil {
+			return nil, err
+		}
+
+		if err := gr.Close(); err != nil {
+			return nil, err
+		}
+
+		if err := yaml.Unmarshal(value, &netConfig); err != nil {
+			return nil, err
+		}
+	default: // raw data
+		cloudInitCfg := &cloudInitConfig{}
+		if err := yaml.Unmarshal(value, cloudInitCfg); err != nil {
+			return nil, err
+		}
+		netConfig = cloudInitCfg.Network
+	}
+
+	// Map of guestInfo IP -> index that describes the order they appear in the guestInfo
+	guestInfoAddresses := make(map[string]int)
+	for _, eth := range netConfig.Ethernets {
+		for _, address := range eth.Addresses {
+			ip := net.ParseIP(strings.Split(address, "/")[0])
+			guestInfoAddresses[ip.String()] = len(guestInfoAddresses)
+		}
+	}
+
+	// Sort nonlocalhostIPs by the following comparator for two IP addresses: a and b
+	// if a is statically configured, but b is not then a should be prioritized before b
+	// if b is statically configured, but a is not then a should not be prioritized before b
+	// if a and b are both statically configured, then use the index from the guest info
+	sort.SliceStable(nonLocalhostIPs, func(i, j int) bool {
+		aIndex, aFound := guestInfoAddresses[nonLocalhostIPs[i].ipAddr]
+		bIndex, bFound := guestInfoAddresses[nonLocalhostIPs[j].ipAddr]
+
+		return aFound && !bFound || aFound && bFound && aIndex < bIndex
+	})
+
 	return nonLocalhostIPs, nil
 }

--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package vsphere
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -240,7 +242,6 @@ func TestDiscoverNodeIPs(t *testing.T) {
 		expectedIPs            []v1.NodeAddress
 		expectedErrorSubstring string
 	}{
-
 		{
 			testName: "BySubnet",
 			setup: testSetup{
@@ -1761,6 +1762,50 @@ func TestDiscoverNodeIPs(t *testing.T) {
 			},
 		},
 		{
+			testName: "StaticAddresses_IPv6_usesNetworkB64EncodedStaticAddressForExternalInternal",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv6"},
+				guestinfo:        guestInfoEncodedNetconfigWithAddresses("gzip+base64", "fd01:cccc::1/128"),
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "VM Network",
+						IpAddress: []string{
+							"fe80::1",
+							"fd01:1234::1",
+							"fd01:cccc::1",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "fd01:cccc::1"},
+				{Type: "ExternalIP", Address: "fd01:cccc::1"},
+			},
+		},
+		{
+			testName: "StaticAddresses_IPv6_usesNetworkGZB64EncodedStaticAddressForExternalInternal",
+			setup: testSetup{
+				ipFamilyPriority: []string{"ipv6"},
+				guestinfo:        guestInfoEncodedNetconfigWithAddresses("base64", "fd01:cccc::1/128"),
+				cpiConfig:        nil,
+				networks: []vimtypes.GuestNicInfo{
+					{
+						Network: "VM Network",
+						IpAddress: []string{
+							"fe80::1",
+							"fd01:1234::1",
+							"fd01:cccc::1",
+						},
+					},
+				},
+			},
+			expectedIPs: []v1.NodeAddress{
+				{Type: "InternalIP", Address: "fd01:cccc::1"},
+				{Type: "ExternalIP", Address: "fd01:cccc::1"},
+			},
+		},
+		{
 			testName: "StaticAddresses_errorsOnInvalidGuestInfoFormat",
 			setup: testSetup{
 				guestinfo: "not-valid-yaml this should error",
@@ -2094,12 +2139,12 @@ func TestFindNetworkNameMatch(t *testing.T) {
 
 func TestExcludeLocalhostIPs(t *testing.T) {
 	ipAddrNetworkNames := []*ipAddrNetworkName{
-		//doesn't parse
+		// doesn't parse
 		{ipAddr: "garbage"},
-		//unspecified
+		// unspecified
 		{ipAddr: "0.0.0.0"},
 		{ipAddr: "::"},
-		//link local multicast
+		// link local multicast
 		{ipAddr: "224.0.0.1"},
 		{ipAddr: "ff02::1"},
 		// link local unicast
@@ -2164,4 +2209,48 @@ network:
       dhcp4: false
       dhcp6: false`,
 		addresses)
+}
+
+func guestInfoEncodedNetconfigWithAddresses(encoding, addresses string) string {
+	var (
+		networkConfig = []byte(fmt.Sprintf(`version: 2
+ethernets:
+  id0:
+    addresses: [%s]
+    match:
+    macaddress: "00:11:22"
+    set-name: "eth0"
+    wakeonlan: true
+    dhcp4: false
+    dhcp6: false`,
+			addresses))
+
+		encodedNetconfig string
+	)
+
+	switch encoding {
+	case "base64":
+		encodedNetconfig = base64.StdEncoding.EncodeToString(networkConfig)
+	case "gzip+base64":
+		buf := bytes.NewBuffer(nil)
+		gw := gzip.NewWriter(buf)
+		if _, err := gw.Write(networkConfig); err != nil {
+			return err.Error()
+		}
+		if err := gw.Close(); err != nil {
+			return err.Error()
+		}
+		encodedNetconfig = base64.StdEncoding.EncodeToString(buf.Bytes())
+	default:
+		return guestInfoWithAddresses(addresses)
+	}
+
+	return fmt.Sprintf(`instance-id: "tkg-mgmt-vc"
+local-hostname: "tkg-mgmt-vc"
+wait-on-network:
+  ipv4: false
+  ipv6: false
+network.encoding: %s
+network: %s`,
+		encoding, encodedNetconfig)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Proper handling of encoded network for cloud-init in a VM's guestInfo.metadata

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #760 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support for `base64` and `gzip+base64` encoding types in the `network` section of cloud-init config
```
