### PR TITLE
CI: move to new resource pool and folder in VMC and migrate to new IPAM

### DIFF
--- a/hack/ipclaim-template.yaml
+++ b/hack/ipclaim-template.yaml
@@ -1,7 +1,12 @@
-apiVersion: ipam.metal3.io/v1alpha1
-kind: IPClaim
+apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+kind: IPAddressClaim
 metadata:
-  name: IPCLAIM_NAME
+  name: ${IPCLAIM_NAME}
+  annotations:
+    prow.k8s.io/build-id: "${BUILD_ID}"
+    prow.k8s.io/job: "${JOB_NAME}"
 spec:
-  pool:
+  poolRef:
+    apiGroup: ipam.cluster.x-k8s.io
+    kind: InClusterIPPool
     name: capv-e2e-ippool

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -147,8 +147,8 @@ variables:
   # Following CAPV variables should be set before testing
   VSPHERE_TLS_THUMBPRINT: "18:EC:35:60:54:68:92:F6:F8:92:3E:4D:11:A1:0D:13:9C:E9:3E:B6"
   VSPHERE_DATACENTER:  "SDDC-Datacenter"
-  VSPHERE_FOLDER: "clusterapi"
-  VSPHERE_RESOURCE_POOL: "clusterapi"
+  VSPHERE_FOLDER: "cloud-provider-vsphere"
+  VSPHERE_RESOURCE_POOL: "cloud-provider-vsphere"
   VSPHERE_DATASTORE: "WorkloadDatastore"
   VSPHERE_STORAGE_POLICY: "Cluster API vSphere Storage Policy"
   VSPHERE_NETWORK: "sddc-cgw-network-6"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

CAPV maintainer here.
We currently clean up the CI environment a bit.

For better separation we created a new directory and resource pool which then is used exclusively by cloud-provider-vsphere.

This PR:
* changes the configuration to make use of the new folder and resource pool.
* Makes use of the new resources from ipam in-cluster provider in `hack/e2e.sh` to get ip addresses.

This PR should get cherry-picked to all releases where we still run CI, according test-infra this is all release branches >= v1.22:

- release-1.22
- release-1.23
- release-1.24
- release-1.25
- release-1.26
- release-1.27
- release-1.28

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
