### PR TITLE
Allow setting specific useragent identifier

### DIFF
--- a/pkg/common/config/config_yaml.go
+++ b/pkg/common/config/config_yaml.go
@@ -37,6 +37,7 @@ func (ccy *CommonConfigYAML) CreateConfig() *Config {
 		VirtualCenter: make(map[string]*VirtualCenterConfig),
 	}
 
+	cfg.Global.ClusterID = ccy.Global.ClusterID
 	cfg.Global.User = ccy.Global.User
 	cfg.Global.Password = ccy.Global.Password
 	cfg.Global.VCenterIP = ccy.Global.VCenterIP
@@ -88,7 +89,7 @@ func (vccy *VirtualCenterConfigYAML) isSecretInfoProvided() bool {
 }
 
 func (ccy *CommonConfigYAML) validateConfig() error {
-	//Fix default global values
+	// Fix default global values
 	if ccy.Global.RoundTripperCount == 0 {
 		ccy.Global.RoundTripperCount = DefaultRoundTripperCount
 	}

--- a/pkg/common/config/types_common.go
+++ b/pkg/common/config/types_common.go
@@ -53,6 +53,10 @@ type Global struct {
 	// 2) we are not in a k8s env, namely DC/OS, since CSI is CO agnostic
 	// Default: /etc/cloud/credentials
 	SecretsDirectory string
+	// ClusterID defines a cluster unique identifier (eg the CAPV cluster name)
+	// that can be passed on the configuration and can be used to identify connections
+	// to vSphere
+	ClusterID string `yaml:"clusterID"`
 }
 
 // VirtualCenterConfig struct

--- a/pkg/common/config/types_yaml.go
+++ b/pkg/common/config/types_yaml.go
@@ -69,6 +69,10 @@ type GlobalYAML struct {
 	// ipv4 - IPv4 addresses only (Default)
 	// ipv6 - IPv6 addresses only
 	IPFamilyPriority []string `yaml:"ipFamily"`
+	// ClusterID defines a cluster unique identifier (eg the CAPV cluster name)
+	// that can be passed on the configuration and can be used to identify connections
+	// to vSphere
+	ClusterID string `yaml:"clusterID"`
 }
 
 // VirtualCenterConfigYAML contains information used to access a remote vCenter

--- a/pkg/common/connectionmanager/connectionmanager.go
+++ b/pkg/common/connectionmanager/connectionmanager.go
@@ -80,6 +80,7 @@ func generateInstanceMap(cfg *vcfg.Config) map[string]*VSphereInstance {
 			Port:              vcConfig.VCenterPort,
 			CACert:            vcConfig.CAFile,
 			Thumbprint:        vcConfig.Thumbprint,
+			ClusterID:         cfg.Global.ClusterID,
 		}
 		vsphereIns := VSphereInstance{
 			Conn: &vSphereConn,
@@ -111,8 +112,8 @@ func (connMgr *ConnectionManager) InitializeSecretLister() {
 }
 
 func (connMgr *ConnectionManager) createManagersPerTenant(secretName string, secretNamespace string,
-	secretsDirectory string, client clientset.Interface) (*cm.CredentialManager, *k8s.InformerManager) {
-
+	secretsDirectory string, client clientset.Interface,
+) (*cm.CredentialManager, *k8s.InformerManager) {
 	var informMgr *k8s.InformerManager
 	var lister listerv1.SecretLister
 	if client != nil && secretsDirectory == "" {

--- a/pkg/common/vclib/connection_test.go
+++ b/pkg/common/vclib/connection_test.go
@@ -140,8 +140,7 @@ func TestWithVerificationWithoutCaCertOrThumbprint(t *testing.T) {
 func TestWithValidThumbprint(t *testing.T) {
 	handler, verifyConnectionWasMade := getRequestVerifier(t)
 
-	server, thumbprint :=
-		createTestServer(t, fixtures.CaCertPath, fixtures.ServerCertPath, fixtures.ServerKeyPath, handler)
+	server, thumbprint := createTestServer(t, fixtures.CaCertPath, fixtures.ServerCertPath, fixtures.ServerKeyPath, handler)
 	server.StartTLS()
 	u := mustParseUrl(t, server.URL)
 
@@ -182,6 +181,26 @@ func TestInvalidCaCert(t *testing.T) {
 	if msg := err.Error(); !strings.Contains(msg, "invalid certificate") {
 		t.Fatalf("Expected invalid certificate error, got '%s'", msg)
 	}
+}
+
+func TestSpecificCluterID(t *testing.T) {
+	handler, verifyConnectionWasMade := getRequestVerifier(t)
+
+	server, _ := createTestServer(t, fixtures.CaCertPath, fixtures.ServerCertPath, fixtures.ServerKeyPath, handler)
+	server.StartTLS()
+	u := mustParseUrl(t, server.URL)
+
+	connection := &vclib.VSphereConnection{
+		Hostname:  u.Hostname(),
+		Port:      u.Port(),
+		CACert:    fixtures.CaCertPath,
+		ClusterID: "my-amazing-cluster",
+	}
+
+	// Ignoring error here, because we only care about the TLS connection
+	connection.NewClient(context.Background())
+
+	verifyConnectionWasMade()
 }
 
 func verifyWrappedX509UnkownAuthorityErr(t *testing.T, err error) {


### PR DESCRIPTION
**What this PR does / why we need it**: During some scalability tests, we have figured out that having a unique identifier per cluster would make it easier to identify how many connections a cluster is opening to vSphere, and improve this workflow. Also it is good to know exactly what cluster has open connections

**Which issue this PR fixes**: fixes #787 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow specifying new ClusterID on configuration
```
