### PR TITLE
run e2e test suite on latest k8s version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,10 @@ $(TOOLING_BINARIES):
 e2e:
 	make -C $(E2E_DIR) run
 
+.PHONY: e2e-latest-k8s-version
+e2e-latest-k8s-version:
+	make -C $(E2E_DIR) run-on-latest-k8s-version
+
 .PHONY: integration-test
 integration-test: | $(DOCKER_SOCK)
 	$(MAKE) -C test/integration

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -112,4 +112,8 @@ export WORKLOAD_CONTROL_PLANE_ENDPOINT_IP
 GCR_KEY_FILE="${GCR_KEY_FILE:-}"
 login
 
-E2E_ARTIFACTS=${ARTIFACTS} make e2e
+if [ "$#" -eq 1 ] && [ "$1" = "latest-k8s-version" ]; then
+  E2E_ARTIFACTS=${ARTIFACTS} make e2e-latest-k8s-version
+else 
+  E2E_ARTIFACTS=${ARTIFACTS} make e2e
+fi

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -83,3 +83,10 @@ run-e2e-with-dev-image: $(TOOLING_BINARIES) $(E2E_DATA_DIR)
 	$(GINKGO) -v . -- --e2e.config="$(E2E_CONF_FILE_DEV)" --e2e.artifacts-folder="$(E2E_ARTIFACTS)" \
 		--e2e.chart-folder="$(E2E_CHART)" --e2e.skip-resource-cleanup=true \
 		--e2e.version="$(VERSION_DEV)" --e2e.image="$(IMAGE_DEV)"
+
+# run-on-latest-k8s-version runs the E2E tests on the k8s version specified in KUBERNETES_VERSION_LATEST_CI
+run-on-latest-k8s-version: $(TOOLING_BINARIES) $(E2E_DATA_DIR) push-ccm-image
+	$(GINKGO) -v . -- --e2e.config="$(E2E_CONF_FILE)" --e2e.artifacts-folder="$(E2E_ARTIFACTS)" \
+		--e2e.chart-folder="$(E2E_CHART)" --e2e.skip-resource-cleanup=false \
+		--e2e.version="$(VERSION)" --e2e.image="$(IMAGE_DEV)" \
+		--e2e.use-latest-k8s-version=true

--- a/test/e2e/config/vsphere-ci.yaml
+++ b/test/e2e/config/vsphere-ci.yaml
@@ -60,10 +60,17 @@ providers:
     files:
     # Add a cluster template
     - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/main/cluster-template.yaml"
+    - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/main/cluster-template-install-on-bootstrap.yaml"
+    - sourcePath: "../../../test/e2e/data/infrastructure-vsphere/main/clusterclass-quick-start.yaml"
     - sourcePath: "../data/shared/main/v1beta1_provider/metadata.yaml"
 
 variables:
   KUBERNETES_VERSION: "v1.29.0"
+  #! KUBERNETES_VERSION_LATEST_CI can have the following formats:
+  #! * v1.28.0 => will return the same version for convenience
+  #! * stable-1.28 => will return the latest patch release for v1.28, e.g. v1.28.5
+  #! * ci/latest-1.28 => will return the latest built version from the release branch, e.g. v1.28.5-26+72feddd3acde14
+  KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.30"
   KUBERNETES_VERSION_UPGRADE_FROM: "v1.28.0"
   KUBERNETES_VERSION_UPGRADE_TO: "v1.29.0"
   CPI_IMAGE_K8S_VERSION: "v1.29.0"

--- a/test/e2e/cpi_vm_test.go
+++ b/test/e2e/cpi_vm_test.go
@@ -118,7 +118,7 @@ func WaitForWorkerNodeReadiness(readiness corev1.ConditionStatus) func() error {
 		if err != nil {
 			return err
 		}
-		if DoesNodeHasReadiness(node, readiness) {
+		if !DoesNodeHasReadiness(node, readiness) {
 			return errors.New("worker node ready status is not " + string(readiness))
 		}
 		return nil
@@ -213,7 +213,7 @@ var _ = Describe("Restarting, recreating and deleting VMs", func() {
 		Eventually(WaitForVMPowerState(workerVM.Name(), types.VirtualMachinePowerStatePoweredOff))
 
 		By("Wait for node " + workerNode.Name + " to become not ready")
-		Eventually(WaitForWorkerNodeReadiness(corev1.ConditionFalse), 5*time.Minute, 2*time.Second).Should(BeNil())
+		Eventually(WaitForWorkerNodeReadiness(corev1.ConditionUnknown), 5*time.Minute, 2*time.Second).Should(BeNil())
 
 		By("Power on VM "+workerVM.Name(), func() {
 			task, err := workerVM.PowerOn(ctx)

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/klog/v2 v2.120.1
 	sigs.k8s.io/cluster-api v1.6.1
 	sigs.k8s.io/cluster-api/test v1.6.1
+	sigs.k8s.io/controller-runtime v0.16.3
 )
 
 require (
@@ -186,7 +187,6 @@ require (
 	k8s.io/kubectl v0.29.0 // indirect
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661 // indirect
 	oras.land/oras-go v1.2.4 // indirect
-	sigs.k8s.io/controller-runtime v0.16.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kind v0.20.0 // indirect
 	sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 // indirect


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR enables running e2e test suite with a specified k8s version filled in `KUBERNETES_VERSION_LATEST_CI`

- fixed controller-runtime complaints no logger set in the test suite
- fixed wait the node status function incorrect logic

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
user now can run e2e test suite on a specified k8s version by setting KUBERNETES_VERSION_LATEST_CI
```
