### PR TITLE
run dependabot on three latest release branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,12 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
+# #############
+# master branch
+# #############
 # GitHub Actions
-- package-ecosystem: "github-actions"
+- target-branch: master
+  package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "weekly"
@@ -12,7 +16,8 @@ updates:
   labels:
     - "ok-to-test"
 # Main Go module
-- package-ecosystem: "gomod"
+- target-branch: master
+  package-ecosystem: "gomod"
   directory: "/"
   schedule:
     interval: "weekly"
@@ -27,8 +32,9 @@ updates:
     - "ok-to-test"
   open-pull-requests-limit: 10
 ## Update dockerfile
-- package-ecosystem: docker
-  directory: /
+- target-branch: master
+  package-ecosystem: docker
+  directory: "/cluster/images/controller-manager"
   schedule:
     interval: weekly
   commit-message:
@@ -36,7 +42,8 @@ updates:
   labels:
     - "ok-to-test"
 # Test Go module
-- package-ecosystem: "gomod"
+- target-branch: master
+  package-ecosystem: "gomod"
   directory: "/test/e2e"
   schedule:
     interval: "weekly"
@@ -49,3 +56,228 @@ updates:
     prefix: ":seedling:"
   labels:
     - "ok-to-test"
+
+# ################
+# release branch N
+# ################
+# GitHub Actions
+- target-branch: release-1.29
+  package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+# Main Go module
+- target-branch: release-1.29
+  package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+## Update dockerfile
+- target-branch: release-1.29
+  package-ecosystem: docker
+  directory: "/cluster/images/controller-manager"
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+# Test Go module
+- target-branch: release-1.29
+  package-ecosystem: "gomod"
+  directory: "/test/e2e"
+  schedule:
+    interval: "weekly"
+    day: "tuesday"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+
+# ##################
+# release branch N-1
+# ##################
+# GitHub Actions
+- target-branch: release-1.28
+  package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+# Main Go module
+- target-branch: release-1.28
+  package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+## Update dockerfile
+- target-branch: release-1.28
+  package-ecosystem: docker
+  directory: "/cluster/images/controller-manager"
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+# Test Go module
+- target-branch: release-1.28
+  package-ecosystem: "gomod"
+  directory: "/test/e2e"
+  schedule:
+    interval: "weekly"
+    day: "tuesday"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+
+# ##################
+# release branch N-2
+# ##################
+# GitHub Actions
+- target-branch: release-1.27
+  package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+# Main Go module
+- target-branch: release-1.27
+  package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+## Update dockerfile
+- target-branch: release-1.27
+  package-ecosystem: docker
+  directory: "/cluster/images/controller-manager"
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
+# Test Go module
+- target-branch: release-1.27
+  package-ecosystem: "gomod"
+  directory: "/test/e2e"
+  schedule:
+    interval: "weekly"
+    day: "tuesday"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"

--- a/docs/book/tutorials/make_a_new_cpi_release.md
+++ b/docs/book/tutorials/make_a_new_cpi_release.md
@@ -56,3 +56,8 @@ Now we can open up the [release page](https://github.com/kubernetes/cloud-provid
 Press `Publish Release` to publish the release from the existing tag. As soon as you publish the release on GitHub, we can see it under the release tab, which was previously showing just the tag names.
 
 Please go to [post-release-pipeline](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cloud-provider-vsphere-release/) to check the release logs and make sure new image is published in `gcr.io/cloud-provider-vsphere/cpi/release/manager` with the correct version tag.
+
+## Update dependabot config
+
+Dependabot is configured to bump dependencies on the `master` branch as well as the three latest release branches.
+After a release, the list of release branches within `.github/dependabot.yml` needs to be updated to add the newest one and drop the oldest one.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Configures dependabot to run on the latest three
release branches in addition to master. Only
patch bumps will be performed on the release
branches.

Also updates the docker dependabot configuration
to reference /cluster/images/controller-manager
which is where the main Dockerfile is stored.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
Fixes #865

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
