### PR TITLE
[1.27]Cherry pick #904 to fix integration test

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -1,7 +1,5 @@
 all: test
 
-include ../../hack/make/docker.mk
-
 # PROJECT_ROOT may be set externally when this Makefile is invoked with DinD.
 PROJECT_ROOT ?= $(abspath ../..)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Removing include ../../hack/make/docker.mk because of this change kubernetes/test-infra#32203

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
