### PR TITLE
Add hack/tools module to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,18 @@ updates:
     prefix: ":seedling:"
   labels:
     - "ok-to-test"
+# Tools Go module
+- target-branch: master
+  package-ecosystem: "gomod"
+  directory: "/hack/tools"
+  schedule:
+    interval: "weekly"
+    day: "monday"
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+    - "ok-to-test"
+  open-pull-requests-limit: 10
 # ##################
 # release branch N
 # ##################


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds tools module to dependabot config to keep utils up to date

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
