### PR TITLE
add github action to auto sync doc changes to gh-pages

### DIFF
--- a/.github/workflows/auto-sync-gh-pages.yml
+++ b/.github/workflows/auto-sync-gh-pages.yml
@@ -1,0 +1,57 @@
+name: Sync update to gh-pages branch
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+  workflow_dispatch: # Use for manaully trigger to debug
+
+
+permissions:
+  contents: write # Allow to create a release.
+
+jobs:
+  sync-changes-to-gh-pages-branch:
+    runs-on: ubuntu-latest
+    steps:
+      # This step uses Github's checkout-action: https://github.com/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Configure Git for helm release
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Check Latest Release Tag
+        id: check
+        run: |          
+          git fetch --tags
+
+          latest_tag=$(git tag --sort=-creatordate | head -n 1)
+          echo "latest_tag=${latest_tag}" >> $GITHUB_OUTPUT
+          echo "valid=$(./hack/match-release-tag.sh ${latest_tag} >/dev/null 2>&1)" >> $GITHUB_OUTPUT
+
+      - name: Cherry Pick All Related Changes in Master Branch
+        if: ${{ steps.check.outputs.valid }}
+        run: |
+          git checkout gh-pages
+          git checkout -b topic/github-action/update-gh-pages-$(date +'%Y%m%d')
+          git checkout ${{ steps.check.outputs.latest_tag }} README.md index.yaml charts/* releases/* docs/*
+          git add README.md index.yaml charts/* releases/* docs/*
+          git commit -m":book:(docs) cherry-pick docs update from master to gh-pages"
+          git push -u origin topic/github-action/update-gh-pages-$(date +'%Y%m%d')
+
+      - name: Create Pull Request
+        if: ${{ steps.check.outputs.valid }}
+        run: |
+          gh pr create --title ":book:(docs) cherry-pick docs update to gh-pages" \
+            --body "This PR was created by GitHub Actions to update documentation in gh-pages branch" \
+            --base gh-pages --head topic/github-action/update-gh-pages-$(date +'%Y%m%d')
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
