### PR TITLE
Fix the unknown revision error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module k8s.io/cloud-provider-vsphere
 
 go 1.22.4
 
+replace github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels => github.com/vmware-tanzu/vm-operator/pkg/constants/testlabels v1.8.7-0.20240625173706-a93aa9f0bda0
+
 require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/golang/mock v1.6.0

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -4,6 +4,8 @@ go 1.22.0
 
 toolchain go1.22.3
 
+replace sigs.k8s.io/cluster-api-provider-vsphere => sigs.k8s.io/cluster-api-provider-vsphere v1.10.0-rc.1.0.20240521132953-469f652e57ae
+
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1


### PR DESCRIPTION
Goland IDE reports the following error because vm-operator api mod has a dependency on its testlabels. Fix it by specifying the version.

invalid version: unknown revision 000000000000

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
