### PR TITLE
Move DaemonSet affinities and tolerations to values.yaml to make them user manageable.

### DIFF
--- a/charts/vsphere-cpi/templates/daemonset.yaml
+++ b/charts/vsphere-cpi/templates/daemonset.yaml
@@ -40,25 +40,14 @@ spec:
         {{- toYaml .Values.daemonset.podLabels | nindent 8 }}
         {{- end }}
     spec:
+    {{- with .Values.daemonset.tolerations }}
       tolerations:
-      - key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
-        effect: NoSchedule
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
-        operator: Exists
-      - key: node-role.kubernetes.io/control-plane
-        effect: NoSchedule
-        operator: Exists
-      - key: node.kubernetes.io/not-ready
-        effect: NoSchedule
-        operator: Exists
-      - key: CriticalAddonsOnly
-        effect: NoExecute
-        operator: Exists
-      {{- if .Values.daemonset.tolerations }}
-      {{- toYaml .Values.daemonset.tolerations | nindent 6 }}
-      {{- end }}
+{{- toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.daemonset.affinity }}
+      affinity:
+{{- toYaml . | indent 8 }}
+    {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
@@ -91,13 +80,3 @@ spec:
         - name: vsphere-config-volume
           configMap:
             name: {{ if $config.enabled }}{{- $config.name }}{{- else }}cloud-config{{- end }}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists

--- a/charts/vsphere-cpi/templates/daemonset.yaml
+++ b/charts/vsphere-cpi/templates/daemonset.yaml
@@ -40,13 +40,13 @@ spec:
         {{- toYaml .Values.daemonset.podLabels | nindent 8 }}
         {{- end }}
     spec:
-    {{- with .Values.daemonset.tolerations }}
+    {{- if .Values.daemonset.tolerations }}
       tolerations:
-{{- toYaml . | indent 8 }}
+        {{- toYaml .Values.daemonset.tolerations | nindent 8 }}
     {{- end }}
-    {{- with .Values.daemonset.affinity }}
+    {{- if .Values.daemonset.affinity }}
       affinity:
-{{- toYaml . | indent 8 }}
+        {{- toYaml .Values.daemonset.affinity | nindent 8 }}
     {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/charts/vsphere-cpi/values.yaml
+++ b/charts/vsphere-cpi/values.yaml
@@ -82,9 +82,6 @@ daemonset:
     - key: node.cloudprovider.kubernetes.io/uninitialized
       value: "true"
       effect: NoSchedule
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-      operator: Exists
     - key: node-role.kubernetes.io/control-plane
       effect: NoSchedule
       operator: Exists

--- a/charts/vsphere-cpi/values.yaml
+++ b/charts/vsphere-cpi/values.yaml
@@ -77,5 +77,31 @@ daemonset:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
-  ## Allows for the default tolerations to be replaced with user-defined ones
-  tolerations: []
+  ## Allows for the default tolerations to be updated or replaced with user-defined ones
+  tolerations:
+    - key: node.cloudprovider.kubernetes.io/uninitialized
+      value: "true"
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+      operator: Exists
+    - key: node-role.kubernetes.io/control-plane
+      effect: NoSchedule
+      operator: Exists
+    - key: node.kubernetes.io/not-ready
+      effect: NoSchedule
+      operator: Exists
+    - key: CriticalAddonsOnly
+      effect: NoExecute
+      operator: Exists
+  ## Allows for the default affinities to be updated or replaced with user-defined ones
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+        - matchExpressions:
+          - key: node-role.kubernetes.io/master
+            operator: Exists


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

Moves the CPI DaemonSet affinities and tolerations from daemonset.yaml to values.yaml whilst preserving the defaults.

Some environments, in our case RKEv1, apply different node taints and labels for example, ours are:
```
node-role.kubernetes.io/controlplane=true:NoExecute
node-role.kubernetes.io/etcd=true:NoSchedule
```

This change would allow us to easily adjust them.
