### PR TITLE
⚙️  fix post merge image build job failure

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -5,7 +5,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240210-29014a6e3a'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:7621a5a169f39e40ff2d77250f5908e5195bed68e0f2a70644e23ff8ae2fbff6' # v20240718-5ef92b5c36
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240210-29014a6e3a'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:7621a5a169f39e40ff2d77250f5908e5195bed68e0f2a70644e23ff8ae2fbff6' # v20240718-5ef92b5c36
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- update dockerfile golang version to 1.22.5
- this will fix post-merge job fix after https://github.com/kubernetes/cloud-provider-vsphere/pull/1152 upgrading go mod to `1.22.5`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
