### PR TITLE
Removed error logging from config loader

### DIFF
--- a/pkg/common/config/config_ini_legacy_test.go
+++ b/pkg/common/config/config_ini_legacy_test.go
@@ -63,6 +63,27 @@ secret-namespace = "kube-system"
 # port, insecure-flag will be used from Global section.
 `
 
+const missingServerConfigINI = `
+[Global]
+port = 443
+user = user
+password = password
+insecure-flag = true
+datacenters = us-west
+ca-file = /some/path/to/a/ca.pem
+`
+
+const badConfigINI = `
+[Global]]
+server = 0.0.0.0
+port = 443
+user = user
+password = password
+insecure-flag = true
+datacenters = us-west
+ca-file = /some/path/to/a/ca.pem
+`
+
 func TestReadConfigINIGlobal(t *testing.T) {
 	_, err := ReadConfigINI([]byte(""))
 	if err == nil {

--- a/pkg/common/config/config_test.go
+++ b/pkg/common/config/config_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+const invalidFormat = `
+This is just a string that is neither a yaml or ini file
+`
+
+func TestReadConfig(t *testing.T) {
+	mockConfigTestCases := []struct {
+		name          string
+		configData    string
+		expectedError error
+	}{
+		{
+			name:       "Valid YAML",
+			configData: basicConfigYAML,
+		},
+		{
+			name:          "Invalid YAML",
+			configData:    badConfigYAML,
+			expectedError: errors.New("ReadConfig failed.  YAML=[yaml: line 5: mapping values are not allowed in this context], INI=[2:1: expected section header]"),
+		},
+		{
+			name:       "Valid INI",
+			configData: basicConfigINI,
+		},
+		{
+			name:          "Invalid INI",
+			configData:    badConfigINI,
+			expectedError: errors.New("ReadConfig failed.  YAML=[yaml: unmarshal errors:\n  line 2: cannot unmarshal !!seq into config.CommonConfigYAML], INI=[2:9: expected EOL, EOF, or comment]"),
+		},
+		{
+			name:          "Invalid format",
+			configData:    invalidFormat,
+			expectedError: errors.New("ReadConfig failed.  YAML=[yaml: unmarshal errors:\n  line 2: cannot unmarshal !!str `This is...` into config.CommonConfigYAML], INI=[2:1: expected section header]"),
+		},
+		{
+			name:          "Missing vCenter IP YAML",
+			configData:    missingServerConfigYAML,
+			expectedError: errors.New("No Virtual Center hosts defined"),
+		},
+		{
+			name:          "Missing vCenter IP INI",
+			configData:    missingServerConfigINI,
+			expectedError: errors.New("No Virtual Center hosts defined"),
+		},
+	}
+
+	for _, tc := range mockConfigTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			cfg, err := ReadConfig([]byte(tc.configData))
+
+			if tc.expectedError != nil {
+				if err == nil {
+					t.Fatal("ReadConfig was expected to return error")
+				}
+				if err.Error() != tc.expectedError.Error() {
+					t.Fatalf("Expected: %v, got %v", tc.expectedError, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("ReadConfig was not expected to return error: %v", err)
+				}
+
+				if cfg == nil {
+					t.Fatal("ReadConfig did not return a config object")
+				}
+			}
+		})
+	}
+}

--- a/pkg/common/config/config_yaml.go
+++ b/pkg/common/config/config_yaml.go
@@ -227,3 +227,14 @@ func ReadConfigYAML(byConfig []byte) (*Config, error) {
 
 	return cfg.CreateConfig(), nil
 }
+
+func isConfigYaml(byConfig []byte) error {
+	cfg := CommonConfigYAML{
+		Vcenter: make(map[string]*VirtualCenterConfigYAML),
+	}
+
+	if err := yaml.Unmarshal(byConfig, &cfg); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/common/config/config_yaml_test.go
+++ b/pkg/common/config/config_yaml_test.go
@@ -65,6 +65,28 @@ vcenter:
     secretNamespace: kube-system
 `
 
+const missingServerConfigYAML = `
+global:
+  port: 443
+  user: user
+  password: password
+  insecureFlag: true
+  datacenters:
+    - us-west
+  caFile: /some/path/to/a/ca.pem
+`
+
+const badConfigYAML = `
+global:
+  server: 0.0.0.0
+  port: 443
+  user: password: 
+  insecureFlag: true
+  datacenters:
+    - us-west
+  caFile: /some/path/to/a/ca.pem
+`
+
 func TestReadConfigYAMLGlobal(t *testing.T) {
 	_, err := ReadConfigYAML([]byte(""))
 	if err == nil {
@@ -135,5 +157,27 @@ func TestTenantRefsYAML(t *testing.T) {
 	}
 	if !strings.EqualFold(vcConfig3.SecretRef, "kube-system/eu-secret") {
 		t.Errorf("vcConfig3 SecretRef should be kube-system/eu-secret but actual=%s", vcConfig3.SecretRef)
+	}
+}
+
+func TestIsConfigYAML(t *testing.T) {
+	if err := isConfigYaml([]byte(basicConfigYAML)); err != nil {
+		t.Error("YAML config should be valid")
+	}
+
+	if err := isConfigYaml([]byte(basicConfigINI)); err == nil {
+		t.Error("INI config should be invalid")
+	}
+
+	if err := isConfigYaml([]byte(badConfigYAML)); err == nil {
+		t.Error("Bad config YAML config should be invalid")
+	}
+
+	if err := isConfigYaml([]byte(badConfigINI)); err == nil {
+		t.Error("Bad config YAML config should be invalid")
+	}
+
+	if err := isConfigYaml([]byte(invalidFormat)); err == nil {
+		t.Error("Generic text file should be invalid")
 	}
 }

--- a/pkg/common/config/consts_and_errors.go
+++ b/pkg/common/config/consts_and_errors.go
@@ -16,10 +16,6 @@ limitations under the License.
 
 package config
 
-import (
-	"errors"
-)
-
 const (
 	// DefaultRoundTripperCount is the number of allowed round trips
 	// before an error is returned.
@@ -51,19 +47,34 @@ const (
 
 var (
 	// ErrUsernameMissing is returned when the provided username is empty.
-	ErrUsernameMissing = errors.New("Username is missing")
+	ErrUsernameMissing = getError("Username is missing")
 
 	// ErrPasswordMissing is returned when the provided password is empty.
-	ErrPasswordMissing = errors.New("Password is missing")
+	ErrPasswordMissing = getError("Password is missing")
 
 	// ErrInvalidVCenterIP is returned when the provided vCenter IP address is
 	// missing from the provided configuration.
-	ErrInvalidVCenterIP = errors.New("vsphere.conf does not have the VirtualCenter IP address specified")
+	ErrInvalidVCenterIP = getError("vsphere.conf does not have the VirtualCenter IP address specified")
 
 	// ErrMissingVCenter is returned when the provided configuration does not
 	// define any vCenters.
-	ErrMissingVCenter = errors.New("No Virtual Center hosts defined")
+	ErrMissingVCenter = getError("No Virtual Center hosts defined")
 
 	// ErrInvalidIPFamilyType is returned when an invalid IPFamily type is encountered
-	ErrInvalidIPFamilyType = errors.New("Invalid IP Family type")
+	ErrInvalidIPFamilyType = getError("Invalid IP Family type")
 )
+
+// Err error to be used for any config related errors
+type Err struct {
+	Msg string
+}
+
+func (p Err) Error() string {
+	return p.Msg
+}
+
+func getError(msg string) error {
+	return Err{
+		Msg: msg,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Reduces misleading error message that may cause confusion when users glance through the logs

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1224 

**Special notes for your reviewer**:

This PR adds a check to see if byte data is YAML.  If so, it will call the parse yaml like before allowing any errors to be logged.  I believe this is enough to just state the YAML attempt failed and is falling back onto INI config load.

**Release note**:

```
None
```
