### PR TITLE
Implement shared session capability

### DIFF
--- a/docs/book/vc_shared_sessions.md
+++ b/docs/book/vc_shared_sessions.md
@@ -1,0 +1,117 @@
+# vSphere Shared Session capability
+
+One problem that can be found when provisioning a large amount of clusters using
+vSphere Cloud Provider is vCenter session exhaustion. This happens because every
+workload cluster needs to request a new session to vSphere to do proper reconciliation.
+
+vSphere 8.0U3 and up uses a new approach of session management, that allows the
+creation and sharing of the sessions among different clusters.
+
+A cluster admin can implement a rest API that, once called, requests a new vCenter
+session and shares with CPI. This session will not count on the total generated
+sessions of vSphere, and instead will be a child derived session.
+
+This configuration can be applied on vSphere Cloud Provider with the usage of
+the following secret/credentials, instead of vSphere Username/password:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: kube-system
+  name: vsphere-cloud-secret
+stringData:
+  your-vcenter-host.vc-session-manager-url: "https://shared-session-service.tld/session"
+  your-vcenter-host.vc-session-manager-token: "authenticationtoken"
+```
+
+The configuration above will make CPI call the shared session rest API and use the
+provided token to authenticate against vSphere, instead of using a username/password.
+
+The parameter provider at `vc-session-manager-token` is sent as a `Authorization: Bearer` token
+to the session manager, and in case this directive is not configured CPI will send the
+Pod Service Account token instead.
+
+Below is an example implementation of a shared session manager rest API. Starting the
+program below and calling `http://127.0.0.1:18080/session` should return a JSON that is expected
+by CPI using session manager to work:
+
+```shell
+$ curl 127.0.0.1:18080/session
+{"token":"cst-VCT-52f8d061-aace-4506-f4e6-fca78293a93f-....."}
+```
+
+**NOTE**: Below implementation is **NOT PRODUCTION READY** and does not implement
+any kind of authentication!
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "log"
+    "net/http"
+    "net/url"
+
+    "github.com/vmware/govmomi"
+    "github.com/vmware/govmomi/session"
+    "github.com/vmware/govmomi/vim25"
+    "github.com/vmware/govmomi/vim25/soap"
+)
+
+const (
+    vcURL      = "https://my-vc.tld"
+    vcUsername = "Administrator@vsphere.local"
+    vcPassword = "somepassword"
+)
+
+var (
+    userPassword = url.UserPassword(vcUsername, vcPassword)
+)
+
+// SharedSessionResponse is the expected response of CPI when using Shared session manager
+type SharedSessionResponse struct {
+    Token string `json:"token"`
+}
+
+func main() {
+    ctx := context.Background()
+    vcURL, err := soap.ParseURL(vcURL)
+    if err != nil {
+        panic(err)
+    }
+    soapClient := soap.NewClient(vcURL, false)
+    c, err := vim25.NewClient(ctx, soapClient)
+    if err != nil {
+        panic(err)
+    }
+    client := &govmomi.Client{
+        Client:         c,
+        SessionManager: session.NewManager(c),
+    }
+    if err := client.SessionManager.Login(ctx, userPassword); err != nil {
+        panic(err)
+    }
+
+    vcsession := func(w http.ResponseWriter, r *http.Request) {
+        clonedtoken, err := client.SessionManager.AcquireCloneTicket(ctx)
+        if err != nil {
+            w.WriteHeader(http.StatusForbidden)
+            return
+        }
+        token := &SharedSessionResponse{Token: clonedtoken}
+        jsonT, err := json.Marshal(token)
+        if err != nil {
+            w.WriteHeader(http.StatusInternalServerError)
+            return
+        }
+        w.WriteHeader(http.StatusOK)
+        w.Write(jsonT)
+    }
+
+    http.HandleFunc("/session", vcsession)
+    log.Printf("starting webserver on port 18080")
+    http.ListenAndServe(":18080", nil)
+}
+```

--- a/pkg/common/connectionmanager/connectionmanager.go
+++ b/pkg/common/connectionmanager/connectionmanager.go
@@ -161,7 +161,7 @@ func (connMgr *ConnectionManager) Connect(ctx context.Context, vcInstance *VSphe
 		klog.Error("Failed to get credentials from Secret Credential Manager with err:", err)
 		return err
 	}
-	vcInstance.Conn.UpdateCredentials(credentials.User, credentials.Password)
+	vcInstance.Conn.UpdateCredentials(credentials.User, credentials.Password, credentials.VCSessionManagerURL, credentials.VCSessionManagerToken)
 	return vcInstance.Conn.Connect(ctx)
 }
 

--- a/pkg/common/connectionmanager/zones.go
+++ b/pkg/common/connectionmanager/zones.go
@@ -292,7 +292,7 @@ func (cm *ConnectionManager) getDIFromMultiVCorDC(ctx context.Context,
 
 func withTagsClient(ctx context.Context, connection *vclib.VSphereConnection, f func(c *rest.Client) error) error {
 	c := rest.NewClient(connection.Client)
-	if connection.SessionManagerURL != "" && connection.SessionManagerToken != "" {
+	if connection.SessionManagerURL != "" {
 		c.SessionID(connection.Client.SessionCookie().Value)
 		return nil
 	}
@@ -313,7 +313,7 @@ func withTagsClient(ctx context.Context, connection *vclib.VSphereConnection, f 
 
 	defer func() {
 		// When using shared session manager we don't need to logout
-		if connection.SessionManagerURL != "" && connection.SessionManagerToken != "" {
+		if connection.SessionManagerURL != "" {
 			return
 		}
 

--- a/pkg/common/credentialmanager/credentialmanager.go
+++ b/pkg/common/credentialmanager/credentialmanager.go
@@ -303,8 +303,7 @@ func parseConfig(data map[string][]byte, config map[string]*Credential) error {
 	}
 
 	for vcServer, credential := range config {
-		if (credential.User == "" || credential.Password == "") &&
-			(credential.VCSessionManagerURL == "" || credential.VCSessionManagerToken == "") {
+		if (credential.User == "" || credential.Password == "") && credential.VCSessionManagerURL == "" {
 
 			klog.Errorf("Username/Password or shared session manager URL/Token directives are missing for server %s", vcServer)
 			return ErrCredentialMissing

--- a/pkg/common/credentialmanager/credentialmanager_test.go
+++ b/pkg/common/credentialmanager/credentialmanager_test.go
@@ -394,7 +394,7 @@ func TestParseSecretConfig(t *testing.T) {
 					VCSessionManagerURL: "https://something.tld/session",
 				},
 			},
-			expectedError: ErrCredentialMissing,
+			expectedError: nil,
 		},
 		{
 			testName: "Missing session manager url",

--- a/pkg/common/credentialmanager/types.go
+++ b/pkg/common/credentialmanager/types.go
@@ -36,6 +36,9 @@ type SecretCache struct {
 type Credential struct {
 	User     string `gcfg:"user"`
 	Password string `gcfg:"password"`
+	// VC shared session manager directives
+	VCSessionManagerURL   string `gcfg:"vc-session-manager-url"`
+	VCSessionManagerToken string `gcfg:"vc-session-manager-token"`
 }
 
 // CredentialManager is used to manage vCenter credentials stored as

--- a/pkg/common/vclib/connection.go
+++ b/pkg/common/vclib/connection.go
@@ -134,7 +134,7 @@ func (connection *VSphereConnection) login(ctx context.Context, client *vim25.Cl
 	connection.credentialsLock.Lock()
 	defer connection.credentialsLock.Unlock()
 
-	if connection.SessionManagerURL != "" && connection.SessionManagerToken != "" {
+	if connection.SessionManagerURL != "" {
 		token, err := GetSharedToken(ctx, SharedTokenOptions{
 			URL:   connection.SessionManagerURL,
 			Token: connection.SessionManagerToken,

--- a/pkg/common/vclib/connection.go
+++ b/pkg/common/vclib/connection.go
@@ -37,16 +37,18 @@ const (
 
 // VSphereConnection contains information for connecting to vCenter
 type VSphereConnection struct {
-	Client            *vim25.Client
-	Username          string
-	Password          string
-	Hostname          string
-	Port              string
-	CACert            string
-	Thumbprint        string
-	Insecure          bool
-	RoundTripperCount uint
-	credentialsLock   sync.Mutex
+	Client              *vim25.Client
+	Username            string
+	Password            string
+	Hostname            string
+	Port                string
+	CACert              string
+	Thumbprint          string
+	Insecure            bool
+	SessionManagerURL   string
+	SessionManagerToken string
+	RoundTripperCount   uint
+	credentialsLock     sync.Mutex
 }
 
 var (
@@ -132,6 +134,22 @@ func (connection *VSphereConnection) login(ctx context.Context, client *vim25.Cl
 	connection.credentialsLock.Lock()
 	defer connection.credentialsLock.Unlock()
 
+	if connection.SessionManagerURL != "" && connection.SessionManagerToken != "" {
+		token, err := GetSharedToken(ctx, SharedTokenOptions{
+			URL:   connection.SessionManagerURL,
+			Token: connection.SessionManagerToken,
+		})
+		if err != nil {
+			klog.Errorf("error getting shared session token: %s", err)
+			return err
+		}
+		if err := m.CloneSession(ctx, token); err != nil {
+			klog.Errorf("error getting shared cloned session token: %s", err)
+			return err
+		}
+		return nil
+	}
+
 	signer, err := connection.Signer(ctx, client)
 	if err != nil {
 		return err
@@ -196,9 +214,11 @@ func (connection *VSphereConnection) NewClient(ctx context.Context) (*vim25.Clie
 
 // UpdateCredentials updates username and password.
 // Note: Updated username and password will be used when there is no session active
-func (connection *VSphereConnection) UpdateCredentials(username string, password string) {
+func (connection *VSphereConnection) UpdateCredentials(username string, password string, sessionmgrURL string, sessionmgrToken string) {
 	connection.credentialsLock.Lock()
 	defer connection.credentialsLock.Unlock()
 	connection.Username = username
 	connection.Password = password
+	connection.SessionManagerURL = sessionmgrURL
+	connection.SessionManagerToken = sessionmgrToken
 }

--- a/pkg/common/vclib/vc_session_manager.go
+++ b/pkg/common/vclib/vc_session_manager.go
@@ -1,0 +1,87 @@
+package vclib
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// SharedSessionResponse is the expected structure for a session manager valid
+// token response
+type SharedSessionResponse struct {
+	Token string `json:"token"`
+}
+
+// SharedTokenOptions represents the options that can be used when calling vc session manager
+type SharedTokenOptions struct {
+	// URL is the session manager URL. Eg.: https://my-session-manager/session)
+	URL string
+	// Token is the authorization token that should be passed to session manager
+	Token string
+	// TrustedCertificates contains the certpool of certificates trusted by the client
+	TrustedCertificates *x509.CertPool
+	// InsecureSkipVerify defines if bad certificates requests should be ignored
+	InsecureSkipVerify bool
+	// Timeout defines the client timeout. Defaults to 5 seconds
+	Timeout time.Duration
+}
+
+// GetSharedToken executes an http request on session manager and gets the session manager
+// token that can be reused on govmomi sessions
+func GetSharedToken(ctx context.Context, options SharedTokenOptions) (string, error) {
+	if options.URL == "" {
+		return "", fmt.Errorf("URL of session manager cannot be empty")
+	}
+	if options.Token == "" {
+		return "", fmt.Errorf("token of session manager cannot be empty")
+	}
+
+	timeout := 5 * time.Second
+	if options.Timeout != 0 {
+		timeout = options.Timeout
+	}
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:            options.TrustedCertificates,
+			InsecureSkipVerify: options.InsecureSkipVerify,
+		},
+	}
+
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}
+
+	request, err := http.NewRequest(http.MethodGet, options.URL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed creating new http client: %w", err)
+	}
+	authToken := fmt.Sprintf("Bearer %s", options.Token)
+	request.Header.Add("Authorization", authToken)
+
+	resp, err := client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("failed calling vc session manager: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("invalid vc session manager response: %s", resp.Status)
+	}
+
+	token := &SharedSessionResponse{}
+	defer resp.Body.Close()
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(token); err != nil {
+		return "", fmt.Errorf("failed decoding vc session manager response: %w", err)
+	}
+
+	if token.Token == "" {
+		return "", fmt.Errorf("returned vc session token is empty")
+	}
+	return token.Token, nil
+}

--- a/pkg/common/vclib/vc_session_manager_test.go
+++ b/pkg/common/vclib/vc_session_manager_test.go
@@ -1,0 +1,170 @@
+package vclib_test
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/cloud-provider-vsphere/pkg/common/vclib"
+)
+
+const (
+	validToken    = "validtoken"
+	validResponse = "a-valid-response"
+)
+
+var (
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authZHdr := r.Header.Get("Authorization")
+		if authZHdr != fmt.Sprintf("Bearer %s", validToken) {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		if r.URL.Path == "/timeout" {
+			time.Sleep(15 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == "/invalid-token" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("not a json"))
+			return
+		}
+		if r.URL.Path == "/session" {
+			token := vclib.SharedSessionResponse{
+				Token: validResponse,
+			}
+			response, err := json.Marshal(&token)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(response)
+			return
+		}
+		if r.URL.Path == "/empty" {
+			token := vclib.SharedSessionResponse{
+				Token: "",
+			}
+			response, err := json.Marshal(&token)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(response)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+)
+
+func TestGetSharedToken(t *testing.T) {
+	ctx := context.Background()
+	t.Run("when options are invalid", func(t *testing.T) {
+		t.Run("should fail when no URL is sent", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{})
+			assert.ErrorContains(t, err, "URL of session manager cannot be empty")
+		})
+
+		t.Run("should fail when no token is passed", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL: "https://some-session-manager.tld/session",
+			})
+			assert.ErrorContains(t, err, "token of session manager cannot be empty")
+		})
+
+		t.Run("should fail when passed URL is invalid", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:   "https://some-session-manager.tld:xxxxx/session",
+				Token: "anything",
+			})
+			assert.ErrorContains(t, err, "invalid port")
+		})
+	})
+
+	t.Run("when using a valid session manager", func(t *testing.T) {
+		server := httptest.NewTLSServer(handler)
+
+		certpool := x509.NewCertPool()
+		certpool.AddCert(server.Certificate())
+		t.Cleanup(server.Close)
+
+		t.Run("should respect the timeout", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/timeout", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+				Timeout:             5 * time.Millisecond,
+			})
+			assert.ErrorContains(t, err, "context deadline exceeded")
+		})
+		t.Run("should fail when calling an invalid path", func(t *testing.T) {
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 server.URL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "404 Not Found")
+		})
+		t.Run("should fail when an empty token is returned", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/empty", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "returned vc session token is empty")
+		})
+
+		t.Run("should fail when an invalid json is returned", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/invalid-token", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.ErrorContains(t, err, "failed decoding vc session manager response")
+		})
+
+		t.Run("should fail when no cert is passed and insecureskipverify is false", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:   reqURL,
+				Token: validToken,
+			})
+			assert.ErrorContains(t, err, "tls: failed to verify certificate: x509")
+		})
+
+		t.Run("should return a valid token for the right request and insecureskip=true", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                reqURL,
+				InsecureSkipVerify: true,
+				Token:              validToken,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+
+		t.Run("should return a valid token for the right request and cert", func(t *testing.T) {
+			reqURL := fmt.Sprintf("%s/session", server.URL)
+			token, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
+				URL:                 reqURL,
+				TrustedCertificates: certpool,
+				Token:               validToken,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, validResponse, token)
+		})
+	})
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**: This PR implements the capability to use a vCenter shared session rest API to provide new sessions for CPI

This capability can only be used on vSphere 8.0U3 or up, but as govmomi doesn't make a distinction today on its usage, it is up to the user/caller to enable or disable it

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: We are still going to discuss how to make this "capability" public to CPI and CSI, or have some "demo implementation" of this session manager server available on both projects.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support vCenter shared session API
```
