### PR TITLE
fix: change RoleBinding namespace to kube-system

### DIFF
--- a/charts/vsphere-cpi/templates/role-binding.yaml
+++ b/charts/vsphere-cpi/templates/role-binding.yaml
@@ -11,7 +11,7 @@ items:
       app: {{ template "cpi.name" . }}
       vsphere-cpi-infra: role-binding
       component: cloud-controller-manager
-    namespace: {{ .Release.Namespace }}
+    namespace: kube-system
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: Role


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This PR hardcodes the namespace of the `servicecatalog.k8s.io:apiserver-authentication-reader` _RoleBinding_ to `kube-system`.
Currently, the namespace is templated using `{{ .Release.Namespace }}`. However, the role being bound here is not created by the chart - it is one of the default roles included in Kubernetes in `kube-system` namespace.
Templating the binding to release namespace prevents a user from relying on the chart RBAC functionality when wanting to deploy the chart to a namespace different than `kube-system`.

E.g. when attempting to deploy the original chart to a `vsphere-system` namespace:
```
W0609 19:23:32.331275       1 requestheader_controller.go:204] Unable to get configmap/extension-apiserver-authentication in kube-system.  Usually fixed by 'kubectl create rolebinding -n kube-system ROLEBINDING_NAME --role=extension-apiserver-authentication-reader --serviceaccount=YOUR_NS:YOUR_SA'
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
