### PR TITLE
Update Supervisor API calls to use FQDN

### DIFF
--- a/pkg/cloudprovider/vsphereparavirtual/config.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config.go
@@ -129,10 +129,9 @@ func getRestConfig(svConfigPath string) (*rest.Config, error) {
 	}
 
 	return &rest.Config{
-		Host: "https://" + net.JoinHostPort(svEndpoint.Endpoint, svEndpoint.Port),
+		Host: "https://" + net.JoinHostPort(SupervisorAPIServerFQDN, svEndpoint.Port),
 		TLSClientConfig: rest.TLSClientConfig{
-			CAData:     rootCA,
-			ServerName: SupervisorAPIServerFQDN,
+			CAData: rootCA,
 		},
 		BearerToken: string(token),
 	}, nil

--- a/pkg/cloudprovider/vsphereparavirtual/config_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config_test.go
@@ -186,6 +186,7 @@ func TestGetNameSpace(t *testing.T) {
 func TestGetRestConfig(t *testing.T) {
 	tests := []struct {
 		fileExists bool
+		fqdn       string
 		endpoint   string
 		port       string
 		token      string
@@ -193,14 +194,16 @@ func TestGetRestConfig(t *testing.T) {
 	}{
 		{
 			fileExists: false,
-			endpoint:   "test.sv.proxy",
+			fqdn:       "supervisor.default.svc",
+			endpoint:   "192.163.1.100",
 			port:       "6443",
 			token:      "test-token",
 			ca:         "test-ca",
 		},
 		{
 			fileExists: true,
-			endpoint:   "test.sv.proxy",
+			fqdn:       "supervisor.default.svc",
+			endpoint:   "192.163.1.200",
 			port:       "6443",
 			token:      "test-token",
 			ca:         "test-ca",
@@ -240,7 +243,7 @@ func TestGetRestConfig(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Should succeed when a valid SV endpoint config is provided: %s", err)
 			}
-			if cfg.Host != "https://"+net.JoinHostPort(test.endpoint, test.port) {
+			if cfg.Host != "https://"+net.JoinHostPort(test.fqdn, test.port) {
 				t.Fatalf("incorrect Host: %s", cfg.Host)
 			}
 			if cfg.BearerToken != test.token {


### PR DESCRIPTION
**What this PR does / why we need it**:
Modifies the Supervisor API server REST calls to use the FQDN supervisor.default.svc instead of the Supervisor Endpoint IP address.
The current IP-based approach fails when the Supervisor has Nginx SNI Proxy enabled. Using the FQDN ensures compatibility regardless of whether Nginx SNI Proxy is enabled.



