### PR TITLE
Use a guaranteed missing file in shared token tests

### DIFF
--- a/pkg/common/vclib/vc_session_manager_test.go
+++ b/pkg/common/vclib/vc_session_manager_test.go
@@ -78,9 +78,10 @@ func TestGetSharedToken(t *testing.T) {
 
 		t.Run("should fail when no token is passed and SA token cannot be read", func(t *testing.T) {
 			_, err := vclib.GetSharedToken(ctx, vclib.SharedTokenOptions{
-				URL: "http://something.tld/lala",
+				URL:       "http://something.tld/lala",
+				TokenFile: "/var/run/secrets/test-token",
 			})
-			assert.ErrorContains(t, err, "failed reading token from service account: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory")
+			assert.ErrorContains(t, err, "failed reading token from service account: open /var/run/secrets/test-token: no such file or directory")
 		})
 
 		t.Run("should fail when passed URL is invalid", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Nolan Brubaker <nolan@nbrubaker.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

When the "should fail when no token is passed and SA token cannot be
read" test is run within a pod on a Kubernetes cluster, the test will
fail because the service account token file is present. This change
provides a path to a file that should not conflict with any others on
the system

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This was observed in OpenShift CI [jobs](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cloud-provider-vsphere/90/pull-ci-openshift-cloud-provider-vsphere-main-unit/1947279919289470976), and was fixed by applying this change,
seen by [this CI run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cloud-provider-vsphere/94/pull-ci-openshift-cloud-provider-vsphere-main-unit/1947377673869201408).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
