### PR TITLE
🐛 Unblock Service deletion when VirtualMachineService is not found

### DIFF
--- a/pkg/cloudprovider/vsphereparavirtual/loadbalancer.go
+++ b/pkg/cloudprovider/vsphereparavirtual/loadbalancer.go
@@ -68,9 +68,11 @@ func (l *loadBalancer) GetLoadBalancer(ctx context.Context, clusterName string, 
 		return nil, false, err
 	}
 
+	// When err is nil and vmService is nil, it indicates VirtualMachineService not found, but it's not an error.
+	// Return nil so that cloud provider could move on and delete the LB service.
 	if vmService == nil {
-		klog.Errorf("failed to get load balancer for %s: VirtualMachineService not found", namespacedName(service))
-		return nil, false, errors.Errorf("VirtualMachineService not found")
+		klog.V(1).Infof("VirtualMachineService not found %s", namespacedName(service))
+		return nil, false, nil
 	}
 
 	return toStatus(vmService), true, nil

--- a/pkg/cloudprovider/vsphereparavirtual/loadbalancer_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/loadbalancer_test.go
@@ -104,7 +104,7 @@ func TestGetLoadBalancer_VMServiceNotFound(t *testing.T) {
 
 	_, exists, err := lb.GetLoadBalancer(context.Background(), testClustername, testK8sService)
 	assert.Equal(t, exists, false)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGetLoadBalancer_VMServiceCreated(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently when virtualmachineservice is not found, an err is returned and cloud provider reports err and won't able to delete LB Service anymore. Actually CPI should return nil in this case.

https://github.com/kubernetes/cloud-provider/blob/master/controllers/service/controller.go#L378-L398

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1416

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Unblock Service deletion when VirtualMachineService is not found
```
