### PR TITLE
Fix: Tags client not returning tags when session manager is used

### DIFF
--- a/pkg/common/connectionmanager/zones.go
+++ b/pkg/common/connectionmanager/zones.go
@@ -294,7 +294,7 @@ func withTagsClient(ctx context.Context, connection *vclib.VSphereConnection, f 
 	c := rest.NewClient(connection.Client)
 	if connection.SessionManagerURL != "" {
 		c.SessionID(connection.Client.SessionCookie().Value)
-		return nil
+		return f(c)
 	}
 
 	signer, err := connection.Signer(ctx, connection.Client)
@@ -312,11 +312,6 @@ func withTagsClient(ctx context.Context, connection *vclib.VSphereConnection, f 
 	}
 
 	defer func() {
-		// When using shared session manager we don't need to logout
-		if connection.SessionManagerURL != "" {
-			return
-		}
-
 		if err := c.Logout(ctx); err != nil {
 			klog.Errorf("failed to logout: %v", err)
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When provisioning workload cluster with session manager enabled the resulting nodes were not getting the 
`topology.kubernetes.io/zone`  label. This meant that pods with affinity settings that relied on this label were never getting provisioned. I checked code and saw when fetching the tags used to populate this label from vsphere the function `withTagsClient` was returning early and not executing the user provided callback function

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
