### PR TITLE
Rename 'ca-file' to 'caFile' in configmap.yaml

### DIFF
--- a/charts/vsphere-cpi/templates/configmap.yaml
+++ b/charts/vsphere-cpi/templates/configmap.yaml
@@ -22,7 +22,7 @@ data:
       {{- if $config.thumbprint }}
       thumbprint: {{ $config.thumbprint }}
       {{- else if $config.caFile }}
-      ca-file: {{ $config.caFile }}
+      caFile: {{ $config.caFile }}
       {{- else }}
       # set insecure-flag to true if the vCenter uses a self-signed cert
       insecureFlag: true


### PR DESCRIPTION
Fix for issue #1628

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fixes the syntax for the CA File in the Helm Chart configmap template.  The syntax it replaces is appropriate for ini-style configuration files, not YAML-style.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1628

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
