### PR TITLE
Helm: allow vsphere.conf to be sourced from hostPath

### DIFF
--- a/charts/vsphere-cpi/templates/configmap.yaml
+++ b/charts/vsphere-cpi/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- $config := .Values.config -}}
+{{- if and $config.enabled (eq $config.source "configMap") }}
 {{- if .Values.global }}
 {{- if .Values.global.config }}
 {{- $config = mergeOverwrite (deepCopy .Values.config) .Values.global.config -}}
@@ -42,4 +43,5 @@ data:
     labels:
       region: {{ $config.region }}
       zone: {{ $config.zone }}
+{{- end -}}
 {{- end -}}

--- a/charts/vsphere-cpi/templates/daemonset.yaml
+++ b/charts/vsphere-cpi/templates/daemonset.yaml
@@ -4,6 +4,10 @@
 {{- $config = mergeOverwrite (deepCopy .Values.config) .Values.global.config -}}
 {{- end -}}
 {{- end -}}
+{{- if and (eq $config.source "hostPath") (not $config.hostPath.path) }}
+{{ fail "config.hostPath.path must be set when config.source=hostPath" }}
+{{- end }}
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -84,9 +88,13 @@ spec:
           {{- toYaml .Values.daemonset.resources | nindent 10 }}
         {{- end }}
       volumes:
-        - name: vsphere-config-volume
-          configMap:
-            name: {{ if $config.enabled }}{{- $config.name }}{{- else }}cloud-config{{- end }}
-      {{- if .Values.daemonset.extraVolumes }}
-        {{- toYaml .Values.daemonset.extraVolumes | nindent 8 }}
+      {{- if eq $config.source "hostPath" }}
+              - name: vsphere-config-volume
+                hostPath:
+                  path: {{ $config.hostPath.path }}
+                  type: {{ $config.hostPath.type }}
+      {{- else }}
+              - name: vsphere-config-volume
+                configMap:
+                  name: {{ if $config.enabled }}{{- $config.name }}{{- else }}cloud-config{{- end }}
       {{- end }}

--- a/charts/vsphere-cpi/values.yaml
+++ b/charts/vsphere-cpi/values.yaml
@@ -4,6 +4,9 @@
 
 config:
   enabled: false
+  # Source of vsphere.conf
+  # configMap (default) | hostPath
+  source: configMap
   name: vsphere-cloud-config
   vcenter: "vcenter.local"
   username: "user"
@@ -19,6 +22,10 @@ config:
     # The name of the Secret referred to in the vsphere-cloud-config ConfigMap
     # If your Kubernetes platform provides this secret, set create to false and adjust the secret name
     name: vsphere-cloud-secret
+  hostPath:
+    path: /etc/kubernetes/vsphere.conf
+    type: File
+
 ## Specify if a Pod Security Policy for kube-state-metrics must be created
 ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 podSecurityPolicy:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds an optional Helm configuration to allow vsphere.conf to be sourced from a hostPath volume.

This is useful for bootstrap and constrained environments where the configuration file already exists on the node and creating a ConfigMap/Secret is not desirable. The default behavior using a ConfigMap remains unchanged.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1460

**Special notes for your reviewer**:
The change is fully backward compatible (config.source=configMap remains the default).

When config.source=hostPath, the ConfigMap is not created and the DaemonSet mounts the file directly from the node filesystem.

Helm validation is included to prevent misconfiguration.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
