### PR TITLE
Allow supervisor hostname override

### DIFF
--- a/pkg/cloudprovider/vsphereparavirtual/config/config.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config/config.go
@@ -49,6 +49,8 @@ const (
 	SupervisorServiceAccountNameEnv string = "SUPERVISOR_CLUSTER_SERVICEACCOUNT_SECRET_NAME"
 	// SupervisorAPIServerFQDN reads supervisor service API server's fully qualified domain name from env
 	SupervisorAPIServerFQDN string = "supervisor.default.svc"
+	// InternalSupervisorHostnameOverrideEnv allows overriding the default supervisor hostname
+	InternalSupervisorHostnameOverrideEnv string = "INTERNAL_SUPERVISOR_HOSTNAME_OVERRIDE"
 )
 
 // SupervisorEndpoint is the supervisor cluster endpoint
@@ -131,8 +133,14 @@ func GetRestConfig(svConfigPath string) (*rest.Config, error) {
 		return nil, err
 	}
 
+	supervisorHostname := SupervisorAPIServerFQDN
+	if override := os.Getenv(InternalSupervisorHostnameOverrideEnv); override != "" {
+		klog.V(4).Infof("Using supervisor hostname override: %s", override)
+		supervisorHostname = override
+	}
+
 	return &rest.Config{
-		Host: "https://" + net.JoinHostPort(SupervisorAPIServerFQDN, svEndpoint.Port),
+		Host: "https://" + net.JoinHostPort(supervisorHostname, svEndpoint.Port),
 		TLSClientConfig: rest.TLSClientConfig{
 			CAData: rootCA,
 		},

--- a/pkg/cloudprovider/vsphereparavirtual/config/config.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config/config.go
@@ -43,6 +43,8 @@ const (
 	SupervisorClusterAccessNamespaceFile = "namespace"
 	// SupervisorAPIServerPortEnv reads supervisor service endpoint info from env
 	SupervisorAPIServerPortEnv string = "SUPERVISOR_APISERVER_PORT"
+	// SupervisorAPIServerHostnameEnv reads supervisor API server hostname from env, defaults to supervisor.default.svc
+	SupervisorAPIServerHostnameEnv string = "SUPERVISOR_APISERVER_HOSTNAME"
 	// SupervisorAPIServerEndpointIPEnv reads supervisor API server endpoint IP from env
 	SupervisorAPIServerEndpointIPEnv string = "SUPERVISOR_APISERVER_ENDPOINT_IP"
 	// SupervisorServiceAccountNameEnv reads supervisor service account name from env
@@ -57,6 +59,8 @@ type SupervisorEndpoint struct {
 	Endpoint string
 	// supervisor cluster proxy service  port
 	Port string
+	// hostname for supervisor cluster, defaults to supervisor.default.svc
+	Hostname string
 }
 
 // ReadOwnerRef read the OwnerReference config file
@@ -88,10 +92,16 @@ func readSupervisorConfig() (*SupervisorEndpoint, error) {
 
 	}
 
+	supervisorHostname := os.Getenv(SupervisorAPIServerHostnameEnv)
+	if supervisorHostname == "" {
+		supervisorHostname = SupervisorAPIServerFQDN
+	}
+
 	klog.V(6).Infof("Configured with remote apiserver %s:%s", remoteVip, remotePort)
 	return &SupervisorEndpoint{
 		Endpoint: remoteVip,
 		Port:     remotePort,
+		Hostname: supervisorHostname,
 	}, nil
 
 }
@@ -132,7 +142,7 @@ func GetRestConfig(svConfigPath string) (*rest.Config, error) {
 	}
 
 	return &rest.Config{
-		Host: "https://" + net.JoinHostPort(SupervisorAPIServerFQDN, svEndpoint.Port),
+		Host: "https://" + net.JoinHostPort(svEndpoint.Hostname, svEndpoint.Port),
 		TLSClientConfig: rest.TLSClientConfig{
 			CAData: rootCA,
 		},

--- a/pkg/cloudprovider/vsphereparavirtual/config/config_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config/config_test.go
@@ -109,31 +109,60 @@ func TestReadOwnerRef(t *testing.T) {
 }
 
 func TestReadSupervisorConfig(t *testing.T) {
-	endpoint := "test.sv.proxy"
-	port := "6443"
-
-	err := os.Setenv(SupervisorAPIServerEndpointIPEnv, endpoint)
-	if err != nil {
-		t.Errorf("Should be able to set env var: %s", err)
+	tests := []struct {
+		name             string
+		endpoint         string
+		port             string
+		hostname         string
+		expectedHostname string
+	}{
+		{
+			name:             "hostname env var not set defaults to SupervisorAPIServerFQDN",
+			endpoint:         "test.sv.proxy",
+			port:             "6443",
+			hostname:         "",
+			expectedHostname: SupervisorAPIServerFQDN,
+		},
+		{
+			name:             "hostname env var set uses custom hostname",
+			endpoint:         "test.sv.proxy",
+			port:             "6443",
+			hostname:         "custom.supervisor.svc",
+			expectedHostname: "custom.supervisor.svc",
+		},
 	}
 
-	err = os.Setenv(SupervisorAPIServerPortEnv, port)
-	if err != nil {
-		t.Errorf("Should be able to set env var: %s", err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := os.Setenv(SupervisorAPIServerEndpointIPEnv, test.endpoint)
+			if err != nil {
+				t.Errorf("Should be able to set env var: %s", err)
+			}
+			err = os.Setenv(SupervisorAPIServerPortEnv, test.port)
+			if err != nil {
+				t.Errorf("Should be able to set env var: %s", err)
+			}
+			err = os.Setenv(SupervisorAPIServerHostnameEnv, test.hostname)
+			if err != nil {
+				t.Errorf("Should be able to set env var: %s", err)
+			}
+			defer os.Setenv(SupervisorAPIServerEndpointIPEnv, "") // clean up
+			defer os.Setenv(SupervisorAPIServerPortEnv, "")       // clean up
+			defer os.Setenv(SupervisorAPIServerHostnameEnv, "")   // clean up
+
+			svEndpoint, _ := readSupervisorConfig()
+
+			if svEndpoint.Endpoint != test.endpoint {
+				t.Fatalf("incorrect endpoint: %s", svEndpoint.Endpoint)
+			}
+			if svEndpoint.Port != test.port {
+				t.Fatalf("incorrect port: %s", svEndpoint.Port)
+			}
+			if svEndpoint.Hostname != test.expectedHostname {
+				t.Fatalf("incorrect hostname: got %s, want %s", svEndpoint.Hostname, test.expectedHostname)
+			}
+		})
 	}
-
-	defer os.Setenv(SupervisorAPIServerEndpointIPEnv, "") // clean up
-	defer os.Setenv(SupervisorAPIServerPortEnv, "")       // clean up
-
-	svEndpoint, _ := readSupervisorConfig()
-
-	if svEndpoint.Endpoint != endpoint {
-		t.Fatalf("incorrect endpoint: %s", svEndpoint.Endpoint)
-	}
-	if svEndpoint.Port != port {
-		t.Fatalf("incorrect port: %s", svEndpoint.Port)
-	}
-
 }
 
 func TestGetNameSpace(t *testing.T) {
@@ -185,24 +214,40 @@ func TestGetNameSpace(t *testing.T) {
 
 func TestGetRestConfig(t *testing.T) {
 	tests := []struct {
+		name       string
 		fileExists bool
 		fqdn       string
+		hostname   string
 		endpoint   string
 		port       string
 		token      string
 		ca         string
 	}{
 		{
+			name:       "missing credential files returns error",
 			fileExists: false,
 			fqdn:       "supervisor.default.svc",
+			hostname:   "",
 			endpoint:   "192.163.1.100",
 			port:       "6443",
 			token:      "test-token",
 			ca:         "test-ca",
 		},
 		{
+			name:       "hostname env var not set uses default FQDN",
 			fileExists: true,
 			fqdn:       "supervisor.default.svc",
+			hostname:   "",
+			endpoint:   "192.163.1.200",
+			port:       "6443",
+			token:      "test-token",
+			ca:         "test-ca",
+		},
+		{
+			name:       "hostname env var set uses custom hostname in rest config",
+			fileExists: true,
+			fqdn:       "custom.supervisor.svc",
+			hostname:   "custom.supervisor.svc",
 			endpoint:   "192.163.1.200",
 			port:       "6443",
 			token:      "test-token",
@@ -211,63 +256,66 @@ func TestGetRestConfig(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		dir, _ := os.Getwd()
+		t.Run(test.name, func(t *testing.T) {
+			dir, _ := os.Getwd()
 
-		if test.fileExists {
-			err := createTestFile(dir, SupervisorClusterAccessTokenFile, test.token)
-			defer os.Remove(dir + "/" + SupervisorClusterAccessTokenFile)
-			if err != nil {
-				t.Errorf("failed to create test token file, %s", err)
-			}
+			if test.fileExists {
+				err := createTestFile(dir, SupervisorClusterAccessTokenFile, test.token)
+				defer os.Remove(dir + "/" + SupervisorClusterAccessTokenFile)
+				if err != nil {
+					t.Errorf("failed to create test token file, %s", err)
+				}
 
-			err = createTestFile(dir, SupervisorClusterAccessCAFile, test.ca)
-			defer os.Remove(dir + "/" + SupervisorClusterAccessCAFile)
-			if err != nil {
-				t.Errorf("failed to create test ca file, %s", err)
-			}
+				err = createTestFile(dir, SupervisorClusterAccessCAFile, test.ca)
+				defer os.Remove(dir + "/" + SupervisorClusterAccessCAFile)
+				if err != nil {
+					t.Errorf("failed to create test ca file, %s", err)
+				}
 
-			err = os.Setenv(SupervisorAPIServerEndpointIPEnv, test.endpoint)
-			if err != nil {
-				t.Errorf("Should be able to set env var: %s", err)
-			}
+				err = os.Setenv(SupervisorAPIServerEndpointIPEnv, test.endpoint)
+				if err != nil {
+					t.Errorf("Should be able to set env var: %s", err)
+				}
+				err = os.Setenv(SupervisorAPIServerPortEnv, test.port)
+				if err != nil {
+					t.Errorf("Should be able to set env var: %s", err)
+				}
+				err = os.Setenv(SupervisorAPIServerHostnameEnv, test.hostname)
+				if err != nil {
+					t.Errorf("Should be able to set env var: %s", err)
+				}
+				defer os.Setenv(SupervisorAPIServerEndpointIPEnv, "") // clean up
+				defer os.Setenv(SupervisorAPIServerPortEnv, "")       // clean up
+				defer os.Setenv(SupervisorAPIServerHostnameEnv, "")   // clean up
 
-			err = os.Setenv(SupervisorAPIServerPortEnv, test.port)
-			if err != nil {
-				t.Errorf("Should be able to set env var: %s", err)
-			}
+				cfg, err := GetRestConfig(dir)
+				if err != nil {
+					t.Fatalf("Should succeed when a valid SV endpoint config is provided: %s", err)
+				}
+				if cfg.Host != "https://"+net.JoinHostPort(test.fqdn, test.port) {
+					t.Fatalf("incorrect Host: %s", cfg.Host)
+				}
+				if cfg.BearerToken != test.token {
+					t.Fatalf("incorrect Token: %s", cfg.BearerToken)
+				}
+			} else {
+				err := os.Setenv(SupervisorAPIServerEndpointIPEnv, test.endpoint)
+				if err != nil {
+					t.Errorf("Should be able to set env var: %s", err)
+				}
+				err = os.Setenv(SupervisorAPIServerPortEnv, test.port)
+				if err != nil {
+					t.Errorf("Should be able to set env var: %s", err)
+				}
+				defer os.Setenv(SupervisorAPIServerEndpointIPEnv, "") // clean up
+				defer os.Setenv(SupervisorAPIServerPortEnv, "")       // clean up
 
-			defer os.Setenv(SupervisorAPIServerEndpointIPEnv, "") // clean up
-			defer os.Setenv(SupervisorAPIServerPortEnv, "")       // clean up
-
-			cfg, err := GetRestConfig(dir)
-			if err != nil {
-				t.Fatalf("Should succeed when a valid SV endpoint config is provided: %s", err)
+				_, err = GetRestConfig(dir)
+				if err == nil {
+					t.Errorf("Should fail when an invalid supervisor config is provided")
+				}
 			}
-			if cfg.Host != "https://"+net.JoinHostPort(test.fqdn, test.port) {
-				t.Fatalf("incorrect Host: %s", cfg.Host)
-			}
-			if cfg.BearerToken != test.token {
-				t.Fatalf("incorrect Token: %s", cfg.BearerToken)
-			}
-		} else {
-			err := os.Setenv(SupervisorAPIServerEndpointIPEnv, test.endpoint)
-			if err != nil {
-				t.Errorf("Should be able to set env var: %s", err)
-			}
-
-			err = os.Setenv(SupervisorAPIServerPortEnv, test.port)
-			if err != nil {
-				t.Errorf("Should be able to set env var: %s", err)
-			}
-
-			defer os.Setenv(SupervisorAPIServerEndpointIPEnv, "") // clean up
-			defer os.Setenv(SupervisorAPIServerPortEnv, "")       // clean up
-
-			_, err = GetRestConfig(dir)
-			if err == nil {
-				t.Errorf("Should fail when an invalid supervisor config is provided")
-			}
-		}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Allows folks to configure an override for the hardcoded hostname, this enables cases like allowing CPI to speak with the API server through a VCF A proxy.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1709

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
