### PR TITLE
Prevent unwanted k8s.io version bumps by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,11 @@ updates:
   labels:
     - "ok-to-test"
   open-pull-requests-limit: 10
+  ignore:
+    # Ignore k8s modules as they are upgraded manually following the
+    # Kubernetes release cycle.
+    - dependency-name: "k8s.io/*"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
 
 ## Update dockerfile
 - target-branch: master
@@ -72,6 +77,9 @@ updates:
     prefix: ":seedling: (chore)"
   labels:
     - "ok-to-test"
+  ignore:
+    - dependency-name: "k8s.io/*"
+      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
 
 # ##################
 # release branch N
@@ -113,6 +121,10 @@ updates:
     - "ok-to-test"
   open-pull-requests-limit: 5
   ignore:
+    # Fully ignore k8s modules on release branches. All k8s dependency
+    # updates are done manually following the Kubernetes patch release
+    # schedule.
+    - dependency-name: "k8s.io/*"
     - dependency-name: "*"
       update-types:
         - "version-update:semver-major"
@@ -157,6 +169,7 @@ updates:
   labels:
     - "ok-to-test"
   ignore:
+    - dependency-name: "k8s.io/*"
     - dependency-name: "*"
       update-types:
         - "version-update:semver-major"
@@ -202,6 +215,7 @@ updates:
     - "ok-to-test"
   open-pull-requests-limit: 5
   ignore:
+    - dependency-name: "k8s.io/*"
     - dependency-name: "*"
       update-types:
         - "version-update:semver-major"
@@ -246,6 +260,7 @@ updates:
   labels:
     - "ok-to-test"
   ignore:
+    - dependency-name: "k8s.io/*"
     - dependency-name: "*"
       update-types:
         - "version-update:semver-major"
@@ -291,6 +306,7 @@ updates:
     - "ok-to-test"
   open-pull-requests-limit: 5
   ignore:
+    - dependency-name: "k8s.io/*"
     - dependency-name: "*"
       update-types:
         - "version-update:semver-major"
@@ -335,6 +351,7 @@ updates:
   labels:
     - "ok-to-test"
   ignore:
+    - dependency-name: "k8s.io/*"
     - dependency-name: "*"
       update-types:
         - "version-update:semver-major"


### PR DESCRIPTION
This addresses an incident where Dependabot automatically bumped k8s.io dependencies from v0.35.0-rc.0 to v0.36.0-alpha.0 on master before the release-1.35 branch was cut, causing the release branch to inherit wrong
dependency versions.

- On master: Add ignore rules for k8s.io/* and its transitive dependencies (go.etcd.io/*, google.golang.org/grpc) to block semver-minor and semver-major auto-bumps. This follows the cluster-api-provider-vsphere common practice where k8s minor version bumps are always done manually in coordination with the Kubernetes release cycle. Patch bumps (e.g. 0.35.1 -> 0.35.2) are still allowed on master.

- On release branches: Fully ignore k8s.io/* and its transitive dependencies including patch updates. As a Kubernetes core component, cloud-provider-vsphere release branches should follow the Kubernetes patch release schedule manually, not be auto-bumped by Dependabot. The existing "dependency-name: *" semver-minor/major
- ignore for all other dependencies is preserved.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
