### PR TITLE
fix to support k8s endpointslices

### DIFF
--- a/charts/vsphere-cpi/templates/role.yaml
+++ b/charts/vsphere-cpi/templates/role.yaml
@@ -73,6 +73,14 @@ rules:
       - watch
       - update
   - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - secrets

--- a/manifests/controller-manager/cloud-controller-manager-roles.yaml
+++ b/manifests/controller-manager/cloud-controller-manager-roles.yaml
@@ -70,6 +70,14 @@ items:
     - watch
     - update
   - apiGroups:
+    - "discovery.k8s.io"
+    resources:
+    - endpointslices
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
     - ""
     resources:
     - secrets

--- a/releases/v1.36/vsphere-cloud-controller-manager.yaml
+++ b/releases/v1.36/vsphere-cloud-controller-manager.yaml
@@ -176,6 +176,14 @@ rules:
       - watch
       - update
   - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - secrets


### PR DESCRIPTION
**What this PR does / why we need it:** Kubernetes v1.33 deprecated the core Endpoints API in favour of EndpointSlices, which require updates to Helm charts and API usage.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #[1716](https://github.com/kubernetes/cloud-provider-vsphere/issues/1716)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add RBAC permissions for EndpointSlices.
```
