### PR TITLE
update sig cloud provider alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,8 +2,10 @@
 
 aliases:
   sig-cloud-provider-leads:
-    - andrewsykim
+    - bridgetkromhout
     - cheftako
+    - elmiko
+    - joelspeed
   cloud-provider-vsphere-maintainers:
     - andrewsykim
     - divyenpatel


### PR DESCRIPTION


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

This change makes the owners alias for the sig current to 2026.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

the sig has been making an effort to update the owners files of the various cloud provider repositories and i wanted to make this one more current.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
