### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager_test.go
+++ b/pkg/cloudprovider/vsphere/nodemanager_test.go
@@ -159,7 +159,7 @@ func TestDiscoverNodeByNameWithNamesClash(t *testing.T) {
 	}
 
 	if err != vclib.ErrMultipleVMsFound {
-		t.Errorf("ErrMultipleVMsFound expected, another error occured: %s", err)
+		t.Errorf("ErrMultipleVMsFound expected, another error occurred: %s", err)
 	}
 }
 


### PR DESCRIPTION
Fixes a spelling typo in an error message in nodemanager_test.go.