### PR TITLE
✨ Add IPv6 and dual-stack support in CPI core

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -226,11 +226,6 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		return errors.New("VM Guest hostname is empty")
 	}
 
-	if len(oVM.Guest.Net) == 0 {
-		klog.V(4).Infof("oVM.Guest.Net is empty, skipping node discovery. This could be cauesd by vmtool not reporting correct IP address")
-		return errors.New("VM GuestNicInfo is empty")
-	}
-
 	tenantRef := vmDI.VcServer
 	if vmDI.TenantRef != "" {
 		tenantRef = vmDI.TenantRef
@@ -242,6 +237,11 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		ipFamilies = vcInstance.Cfg.IPFamilyPriority
 	} else {
 		klog.Warningf("Unable to find vcInstance for %s. Defaulting to ipv4.", tenantRef)
+	}
+
+	if len(oVM.Guest.Net) == 0 {
+		klog.V(4).Infof("oVM.Guest.Net is empty, skipping node discovery. This could be caused by vmtool not reporting correct IP address")
+		return errors.New("VM GuestNicInfo is empty")
 	}
 
 	var internalNetworkSubnets []*net.IPNet
@@ -349,7 +349,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		if len(oVM.Guest.Net) > 0 {
 			if discoveredInternal == nil && discoveredExternal == nil {
 				klog.V(4).Infof("oVM.Guest.Net=%v", oVM.Guest.Net)
-				return fmt.Errorf("unable to find suitable IP address for node %s with IP family %s", nodeID, ipFamilies)
+				return fmt.Errorf("unable to find suitable IP address for node %s with IP family %s", nodeID, ipFamily)
 			}
 		}
 	}

--- a/pkg/cloudprovider/vsphere/route/routeprovider.go
+++ b/pkg/cloudprovider/vsphere/route/routeprovider.go
@@ -195,9 +195,9 @@ func (p *routeProvider) checkStaticRouteRealizedState(routeID string) error {
 	}
 }
 
-// getNodeIPAddress gets node IP address
+// getNodeIPAddress gets node IP address for the specified IP family
 // The order is to choose node internal IP first, then external IP.
-// Return the first IP address as node IP.
+// Returns the first IP address matching the requested IP family.
 func (p *routeProvider) getNodeIPAddress(nodeName string, isIPv4 bool) (string, error) {
 	node, err := p.getNode(nodeName)
 	if err != nil {
@@ -205,6 +205,7 @@ func (p *routeProvider) getNodeIPAddress(nodeName string, isIPv4 bool) (string, 
 		return "", err
 	}
 
+	// Collect all IPs (InternalIP first, then ExternalIP for priority)
 	allIPs := make([]net.IP, 0, len(node.Status.Addresses))
 	for _, addr := range node.Status.Addresses {
 		if addr.Type == v1.NodeInternalIP {
@@ -222,15 +223,30 @@ func (p *routeProvider) getNodeIPAddress(nodeName string, isIPv4 bool) (string, 
 			}
 		}
 	}
+
 	if len(allIPs) == 0 {
 		return "", fmt.Errorf("node %s has neither InternalIP nor ExternalIP", nodeName)
 	}
+
+	// Find the first IP matching the requested family
+	ipFamily := "IPv6"
+	if isIPv4 {
+		ipFamily = "IPv4"
+	}
+
 	for _, ip := range allIPs {
 		if (ip.To4() != nil) == isIPv4 {
+			klog.V(4).Infof("successfully fetched %s address %s for node %s", ipFamily, ip.String(), nodeName)
 			return ip.String(), nil
 		}
 	}
-	return "", fmt.Errorf("node %s does not have the same IP family with podCIDR", nodeName)
+
+	// Provide more detailed error message
+	availableIPs := make([]string, len(allIPs))
+	for i, ip := range allIPs {
+		availableIPs[i] = ip.String()
+	}
+	return "", fmt.Errorf("node %s does not have any %s address (available IPs: %v)", nodeName, ipFamily, availableIPs)
 }
 
 // AddNode adds v1.Node in nodeMap

--- a/pkg/cloudprovider/vsphereparavirtual/cloud.go
+++ b/pkg/cloudprovider/vsphereparavirtual/cloud.go
@@ -71,6 +71,10 @@ var (
 	// with the Supervisor cluster. Defaults to v1alpha2 for backward compatibility.
 	// Controlled via the --vm-operator-api-version flag.
 	vmopAPIVersion string
+
+	// clusterIPFamily is the raw --cluster-ip-family flag; Initialize resolves it
+	// with ParseClusterIPFamily to one of: ipv4, ipv6, ipv4ipv6, or ipv6ipv4.
+	clusterIPFamily string
 )
 
 func init() {
@@ -100,9 +104,14 @@ func init() {
 	flag.StringVar(&podIPPoolType, "pod-ip-pool-type", "", "Specify if Pod IP address is Public or Private routable in VPC network. Valid values are Public and Private")
 	flag.BoolVar(&serviceAnnotationPropagationEnabled, "enable-service-annotation-propagation", false, "If true, will propagate the service annotation to resource in supervisor cluster.")
 	flag.StringVar(&vmopAPIVersion, "vm-operator-api-version", factory.V1alpha2, "the API version to use when communicating with VM Operator in supervisor mode. Valid values are: "+factory.V1alpha2+", "+factory.V1alpha5+", "+factory.V1alpha6)
+	flag.StringVar(&clusterIPFamily, "cluster-ip-family", "ipv4",
+		"Cluster IP family for NodeInternalIP ordering and Routable Pods. "+
+			"Valid values (case-insensitive): ipv4 (default), ipv6, ipv4ipv6, ipv6ipv4. "+
+			"Non-ipv4 values require --vm-operator-api-version >= v1alpha6. "+
+			"IPv6 or dual-stack with the route controller additionally requires --enable-vpc-mode=true.")
 }
 
-// Creates new Controller node interface and returns
+// newVSphereParavirtual creates a new VSphereParavirtual cloud provider from the given config.
 func newVSphereParavirtual(cfg *cpcfg.Config) (*VSphereParavirtual, error) {
 	cp := &VSphereParavirtual{
 		cfg: cfg,
@@ -144,6 +153,25 @@ func (cp *VSphereParavirtual) Initialize(clientBuilder cloudprovider.ControllerC
 		klog.Fatalf("Failed to get cluster namespace: %v", err)
 	}
 
+	resolvedClusterIPFamily, err := ParseClusterIPFamily(clusterIPFamily)
+	if err != nil {
+		klog.Fatalf("Invalid --cluster-ip-family: %v", err)
+	}
+	if err := validateIPFamilyConfig(resolvedClusterIPFamily, vmopAPIVersion); err != nil {
+		klog.Fatalf("Invalid flag combination: %v", err)
+	}
+
+	ipv6Enabled := resolvedClusterIPFamily == ClusterIPFamilyIPv6 ||
+		resolvedClusterIPFamily == ClusterIPFamilyIPv4IPv6 ||
+		resolvedClusterIPFamily == ClusterIPFamilyIPv6IPv4
+
+	// IPv6 (including dual stack) Routable Pods requires VPC mode; T1 networking does not
+	// support per-family IPAddressAllocation or StaticRoute CRs.
+	// This guard is scoped to RouteEnabled: IPv6 Node IP Report and Load Balancer do not
+	// depend on VPC mode and must continue to work when route controllers are disabled.
+	if RouteEnabled && ipv6Enabled && !vpcModeEnabled {
+		klog.Fatalf("--cluster-ip-family=%s with route controller enabled requires --enable-vpc-mode=true: IPv6 and dual stack routable pods are not supported on the legacy T1 networking mode", resolvedClusterIPFamily)
+	}
 	klog.Infof("Using VM Operator API version: %s", vmopAPIVersion)
 	vmopClient, err := factory.NewAdapter(vmopAPIVersion, kcfg)
 	if err != nil {
@@ -162,7 +190,8 @@ func (cp *VSphereParavirtual) Initialize(clientBuilder cloudprovider.ControllerC
 	}
 	cp.loadBalancer = lb
 
-	instances, err := NewInstances(clusterNS, vmopClient)
+	klog.Infof("Using cluster IP family: %s", resolvedClusterIPFamily)
+	instances, err := NewInstances(clusterNS, vmopClient, resolvedClusterIPFamily)
 	if err != nil {
 		klog.Errorf("Failed to init Instance: %v", err)
 	}

--- a/pkg/cloudprovider/vsphereparavirtual/cluster_ip_family.go
+++ b/pkg/cloudprovider/vsphereparavirtual/cluster_ip_family.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphereparavirtual
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/factory"
+)
+
+// ClusterIPFamilyIPv4 is the default: IPv4-first NodeInternalIP ordering; does
+// not require a VM Operator API with dual-stack VirtualMachineService fields.
+const ClusterIPFamilyIPv4 = "ipv4"
+
+// ClusterIPFamilyIPv6 is IPv6-first ordering and requires
+// --vm-operator-api-version >= v1alpha6 (dual-stack VirtualMachineService fields).
+const ClusterIPFamilyIPv6 = "ipv6"
+
+// ClusterIPFamilyIPv4IPv6 is dual-stack with IPv4 before IPv6 in the reported
+// NodeInternalIP list; requires --vm-operator-api-version >= v1alpha6.
+const ClusterIPFamilyIPv4IPv6 = "ipv4ipv6"
+
+// ClusterIPFamilyIPv6IPv4 is dual-stack with IPv6 before IPv4 (same primary
+// order as ClusterIPFamilyIPv6); requires --vm-operator-api-version >= v1alpha6.
+const ClusterIPFamilyIPv6IPv4 = "ipv6ipv4"
+
+// supportsDualStackVMService records, per --vm-operator-api-version, whether
+// that API persists the dual-stack fields on VirtualMachineService
+// (ipFamilies, ipFamilyPolicy). It must stay in sync with factory.NewAdapter:
+// every version accepted there must appear here. A new API version that
+// supports dual-stack VirtualMachineService fields should be added with the
+// value true; older or partial APIs should be added with false.
+// When adding a new supported version, add a case to TestVmopSupportsDualStackVMServiceAPI.
+var supportsDualStackVMService = map[string]bool{
+	factory.V1alpha2: false,
+	factory.V1alpha5: false,
+	factory.V1alpha6: true,
+}
+
+// ParseClusterIPFamily validates the --cluster-ip-family flag and returns a
+// canonical lowercase value: ipv4, ipv6, ipv4ipv6, or ipv6ipv4.
+func ParseClusterIPFamily(raw string) (string, error) {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	switch s {
+	case "ipv4":
+		return ClusterIPFamilyIPv4, nil
+	case "ipv6":
+		return ClusterIPFamilyIPv6, nil
+	case "ipv4ipv6":
+		return ClusterIPFamilyIPv4IPv6, nil
+	case "ipv6ipv4":
+		return ClusterIPFamilyIPv6IPv4, nil
+	default:
+		return "", fmt.Errorf("invalid --cluster-ip-family %q: must be one of %s, %s, %s, %s",
+			raw, ClusterIPFamilyIPv4, ClusterIPFamilyIPv6, ClusterIPFamilyIPv4IPv6, ClusterIPFamilyIPv6IPv4)
+	}
+}
+
+// vmopSupportsDualStackVMServiceAPI reports whether vmopAPIVersion is known
+// and persists VirtualMachineService dual-stack fields. An unknown version
+// returns false; add new versions to supportsDualStackVMService before
+// relying on this function.
+func vmopSupportsDualStackVMServiceAPI(version string) bool {
+	return supportsDualStackVMService[version]
+}
+
+// clusterIPFamilyRequiresDualStackVMOP reports whether the canonical family
+// needs VM Operator APIs that persist dual-stack LoadBalancer fields.
+func clusterIPFamilyRequiresDualStackVMOP(clusterIPFamily string) bool {
+	switch clusterIPFamily {
+	case ClusterIPFamilyIPv6, ClusterIPFamilyIPv4IPv6, ClusterIPFamilyIPv6IPv4:
+		return true
+	default:
+		return false
+	}
+}
+
+// validateIPFamilyConfig ensures ipv6 / ipv4ipv6 / ipv6ipv4 are only used with
+// a VM Operator API version that persists VirtualMachineService dual-stack
+// fields (see supportsDualStackVMService). ipv4 does not require dual-stack
+// VirtualMachineService fields.
+//
+// clusterIPFamily must be a canonical value returned from ParseClusterIPFamily.
+func validateIPFamilyConfig(clusterIPFamily, vmopAPIVersion string) error {
+	if !clusterIPFamilyRequiresDualStackVMOP(clusterIPFamily) {
+		return nil
+	}
+	if !vmopSupportsDualStackVMServiceAPI(vmopAPIVersion) {
+		return fmt.Errorf(
+			"--cluster-ip-family=%s requires --vm-operator-api-version >= %s (dual-stack VirtualMachineService fields), got %q; "+
+				"earlier API versions omit ipFamilies/ipFamilyPolicy and can silently provision IPv4-only load balancers",
+			clusterIPFamily, factory.V1alpha6, vmopAPIVersion,
+		)
+	}
+	return nil
+}

--- a/pkg/cloudprovider/vsphereparavirtual/cluster_ip_family_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/cluster_ip_family_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphereparavirtual
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/factory"
+)
+
+// TestVmopSupportsDualStackVMServiceAPI must be updated when vmopAPILevel gains
+// entries (e.g. a new VM Operator API with level >= 60 for dual-stack fields).
+func TestVmopSupportsDualStackVMServiceAPI(t *testing.T) {
+	testCases := []struct {
+		name string
+		ver  string
+		want bool
+	}{
+		{name: "v1alpha2 below threshold", ver: factory.V1alpha2, want: false},
+		{name: "v1alpha5 below threshold", ver: factory.V1alpha5, want: false},
+		{name: "v1alpha6 meets threshold", ver: factory.V1alpha6, want: true},
+		{name: "unknown version", ver: "unknown", want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, vmopSupportsDualStackVMServiceAPI(tc.ver))
+		})
+	}
+}
+
+func TestParseClusterIPFamily(t *testing.T) {
+	testCases := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "ipv4 canonical", raw: "ipv4", want: ClusterIPFamilyIPv4},
+		{name: "IPv4 case", raw: "IPv4", want: ClusterIPFamilyIPv4},
+		{name: "ipv6 with spaces", raw: "  ipv6 ", want: ClusterIPFamilyIPv6},
+		{name: "ipv4ipv6", raw: "ipv4ipv6", want: ClusterIPFamilyIPv4IPv6},
+		{name: "IPv4IPv6 mixed case", raw: "IPv4IPv6", want: ClusterIPFamilyIPv4IPv6},
+		{name: "ipv6ipv4", raw: "ipv6ipv4", want: ClusterIPFamilyIPv6IPv4},
+		{name: "IPv6IPv4 mixed case", raw: "IPv6IPv4", want: ClusterIPFamilyIPv6IPv4},
+		{name: "garbage", raw: "dual-stack", wantErr: true},
+		{name: "empty after trim", raw: "   ", wantErr: true},
+		{name: "typo v6", raw: "ip6", wantErr: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseClusterIPFamily(tc.raw)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// simulateInitializeIPFamilyChecks mirrors VSphereParavirtual.Initialize order:
+// parse flag value first, then validate against vm-operator-api-version.
+func simulateInitializeIPFamilyChecks(rawClusterIPFamily, vmopAPIVersion string) error {
+	normalized, err := ParseClusterIPFamily(rawClusterIPFamily)
+	if err != nil {
+		return err
+	}
+	return validateIPFamilyConfig(normalized, vmopAPIVersion)
+}
+
+// The following tests exercise the combined parse+validate flow, not the individual functions.
+func TestSimulateInitializeIPFamilyChecks_Order(t *testing.T) {
+	t.Run("illegal family fails at parse not at vmop gate", func(t *testing.T) {
+		err := simulateInitializeIPFamilyChecks("not-a-family", factory.V1alpha2)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --cluster-ip-family")
+	})
+
+	t.Run("ipv6 with v1alpha2 fails at validate after successful parse", func(t *testing.T) {
+		err := simulateInitializeIPFamilyChecks("IPv6", factory.V1alpha2)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ">= "+factory.V1alpha6)
+	})
+
+	t.Run("ipv6ipv4 with v1alpha5 fails validate", func(t *testing.T) {
+		err := simulateInitializeIPFamilyChecks("ipv6ipv4", factory.V1alpha5)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ">= "+factory.V1alpha6)
+	})
+
+	t.Run("ipv6ipv4 with v1alpha6 succeeds", func(t *testing.T) {
+		err := simulateInitializeIPFamilyChecks("IPv6IPv4", factory.V1alpha6)
+		assert.NoError(t, err)
+	})
+
+	t.Run("ipv6 with v1alpha6 succeeds", func(t *testing.T) {
+		err := simulateInitializeIPFamilyChecks("ipv6", factory.V1alpha6)
+		assert.NoError(t, err)
+	})
+
+	t.Run("ipv4 with v1alpha2 succeeds without needing v1alpha6", func(t *testing.T) {
+		err := simulateInitializeIPFamilyChecks("ipv4", factory.V1alpha2)
+		assert.NoError(t, err)
+	})
+}
+
+func TestValidateIPFamilyConfig(t *testing.T) {
+	testCases := []struct {
+		name            string
+		clusterIPFamily string
+		vmopAPIVersion  string
+		wantErr         bool
+	}{
+		{
+			name:            "ipv4 + v1alpha2 is always valid (default path)",
+			clusterIPFamily: ClusterIPFamilyIPv4,
+			vmopAPIVersion:  factory.V1alpha2,
+			wantErr:         false,
+		},
+		{
+			name:            "ipv4 + v1alpha5 is valid",
+			clusterIPFamily: ClusterIPFamilyIPv4,
+			vmopAPIVersion:  factory.V1alpha5,
+			wantErr:         false,
+		},
+		{
+			name:            "ipv4 + v1alpha6 is valid",
+			clusterIPFamily: ClusterIPFamilyIPv4,
+			vmopAPIVersion:  factory.V1alpha6,
+			wantErr:         false,
+		},
+		{
+			name:            "ipv6 + v1alpha6 is valid",
+			clusterIPFamily: ClusterIPFamilyIPv6,
+			vmopAPIVersion:  factory.V1alpha6,
+			wantErr:         false,
+		},
+		{
+			name:            "ipv4ipv6 + v1alpha6 is valid",
+			clusterIPFamily: ClusterIPFamilyIPv4IPv6,
+			vmopAPIVersion:  factory.V1alpha6,
+			wantErr:         false,
+		},
+		{
+			name:            "ipv6 + v1alpha2 is rejected",
+			clusterIPFamily: ClusterIPFamilyIPv6,
+			vmopAPIVersion:  factory.V1alpha2,
+			wantErr:         true,
+		},
+		{
+			name:            "ipv6 + v1alpha5 is rejected",
+			clusterIPFamily: ClusterIPFamilyIPv6,
+			vmopAPIVersion:  factory.V1alpha5,
+			wantErr:         true,
+		},
+		{
+			name:            "ipv4ipv6 + v1alpha2 is rejected",
+			clusterIPFamily: ClusterIPFamilyIPv4IPv6,
+			vmopAPIVersion:  factory.V1alpha2,
+			wantErr:         true,
+		},
+		{
+			name:            "ipv4ipv6 + v1alpha5 is rejected",
+			clusterIPFamily: ClusterIPFamilyIPv4IPv6,
+			vmopAPIVersion:  factory.V1alpha5,
+			wantErr:         true,
+		},
+		{
+			name:            "ipv6ipv4 + v1alpha6 is valid",
+			clusterIPFamily: ClusterIPFamilyIPv6IPv4,
+			vmopAPIVersion:  factory.V1alpha6,
+			wantErr:         false,
+		},
+		{
+			name:            "ipv6ipv4 + v1alpha2 is rejected",
+			clusterIPFamily: ClusterIPFamilyIPv6IPv4,
+			vmopAPIVersion:  factory.V1alpha2,
+			wantErr:         true,
+		},
+		{
+			name:            "unknown vmop version is treated as below v1alpha6 for dual-stack family",
+			clusterIPFamily: ClusterIPFamilyIPv6IPv4,
+			vmopAPIVersion:  "v1alpha99",
+			wantErr:         true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateIPFamilyConfig(tc.clusterIPFamily, tc.vmopAPIVersion)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/cloudprovider/vsphereparavirtual/instances.go
+++ b/pkg/cloudprovider/vsphereparavirtual/instances.go
@@ -19,6 +19,8 @@ package vsphereparavirtual
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -33,8 +35,9 @@ import (
 )
 
 type instances struct {
-	vmClient  vmop.Interface
-	namespace string
+	vmClient        vmop.Interface
+	namespace       string
+	clusterIPFamily string
 }
 
 // Compile-time assertion that instances implements cloudprovider.Instances.
@@ -60,6 +63,9 @@ var (
 	errBiosUUIDEmpty = errors.New("discovered Bios UUID is empty")
 )
 
+// checkError reports whether err is non-nil. It is used as a predicate by the
+// vmoperator informer machinery (see vmoperator.go). Prefer direct err != nil
+// checks in all other call sites.
 func checkError(err error) bool {
 	return err != nil
 }
@@ -76,35 +82,144 @@ func (i instances) discoverNodeByName(ctx context.Context, name types.NodeName) 
 	return discoverNodeByName(ctx, name, i.namespace, i.vmClient)
 }
 
-// NewInstances returns an implementation of cloudprovider.Instances
-func NewInstances(clusterNS string, vmClient vmop.Interface) (cloudprovider.Instances, error) {
+// NewInstances returns an implementation of cloudprovider.Instances.
+// clusterIPFamily must be a canonical value from ParseClusterIPFamily:
+// ClusterIPFamilyIPv4, ClusterIPFamilyIPv6, ClusterIPFamilyIPv4IPv6, or
+// ClusterIPFamilyIPv6IPv4. It controls the ordering of NodeInternalIP addresses
+// so the API server's first address matches the cluster's intended stack.
+func NewInstances(clusterNS string, vmClient vmop.Interface, clusterIPFamily string) (cloudprovider.Instances, error) {
 	return &instances{
-		vmClient:  vmClient,
-		namespace: clusterNS,
+		vmClient:        vmClient,
+		namespace:       clusterNS,
+		clusterIPFamily: clusterIPFamily,
 	}, nil
 }
 
-func createNodeAddresses(vm *vmoptypes.VirtualMachineInfo) []v1.NodeAddress {
-	if vm.PrimaryIP4 == "" && vm.PrimaryIP6 == "" {
+// isLinkLocalIP reports whether the given IP string is a link-local address.
+// Uses net.IP.IsLinkLocalUnicast() to correctly handle all RFC-4291 IPv6
+// link-local addresses (fe80::/10) and RFC-3927 IPv4 link-local addresses
+// (169.254.0.0/16) regardless of case or representation.
+func isLinkLocalIP(ip string) bool {
+	parsed := net.ParseIP(ip)
+	return parsed != nil && parsed.IsLinkLocalUnicast()
+}
+
+// createNodeAddresses builds the list of NodeAddresses for a VM.
+// clusterIPFamily must be canonical (see ParseClusterIPFamily).
+//
+// Address family filtering rules:
+//   - ipv4:      report IPv4 addresses only
+//   - ipv6:      report IPv6 addresses only
+//   - ipv4ipv6:  report both, IPv4 first
+//   - ipv6ipv4:  report both, IPv6 first
+func createNodeAddresses(vm *vmoptypes.VirtualMachineInfo, clusterIPFamily string) []v1.NodeAddress {
+	if vm.PrimaryIP4 == "" && vm.PrimaryIP6 == "" && len(vm.NetworkInterfaceAddresses) == 0 {
 		klog.V(4).Info("instance found, but no address yet")
 		return []v1.NodeAddress{}
 	}
 
-	address := vm.PrimaryIP4
-	if address == "" {
-		address = vm.PrimaryIP6
+	var nodeAddresses []v1.NodeAddress
+	// addedIPs tracks normalized IP strings to deduplicate addresses that are
+	// semantically equal but have different textual representations
+	// (e.g. "2001:db8::1" and "2001:0db8:0000::0001").
+	addedIPs := make(map[string]bool)
+	normalizeIP := func(ip string) string {
+		if parsed := net.ParseIP(ip); parsed != nil {
+			return parsed.String()
+		}
+		return ip
 	}
 
-	return []v1.NodeAddress{
-		{
-			Type:    v1.NodeInternalIP,
-			Address: address,
-		},
-		{
-			Type:    v1.NodeHostName,
-			Address: "",
-		},
+	// wantIPv4 / wantIPv6 gate which address families are reported.
+	// Single-stack families suppress the other family entirely; dual-stack
+	// families report both, with ordering determined by the flag value.
+	var wantIPv4, wantIPv6, ipv6First bool
+	switch clusterIPFamily {
+	case ClusterIPFamilyIPv4:
+		wantIPv4 = true
+	case ClusterIPFamilyIPv6:
+		wantIPv6 = true
+		ipv6First = true
+	case ClusterIPFamilyIPv4IPv6:
+		wantIPv4, wantIPv6 = true, true
+	case ClusterIPFamilyIPv6IPv4:
+		wantIPv4, wantIPv6 = true, true
+		ipv6First = true
+	default:
+		// Invariant: callers must pass a canonical value returned from
+		// ParseClusterIPFamily. Reaching this branch is a programming error.
+		panic(fmt.Sprintf(
+			"createNodeAddresses: invariant violated: clusterIPFamily %q is not canonical "+
+				"(must be one of %q/%q/%q/%q from ParseClusterIPFamily)",
+			clusterIPFamily,
+			ClusterIPFamilyIPv4, ClusterIPFamilyIPv6, ClusterIPFamilyIPv4IPv6, ClusterIPFamilyIPv6IPv4,
+		))
 	}
+
+	appendIP := func(ip string) {
+		nodeAddresses = append(nodeAddresses, v1.NodeAddress{
+			Type:    v1.NodeInternalIP,
+			Address: ip,
+		})
+		addedIPs[normalizeIP(ip)] = true
+	}
+
+	// Append primary IPs in cluster-preference order.
+	if ipv6First {
+		if wantIPv6 && vm.PrimaryIP6 != "" {
+			appendIP(vm.PrimaryIP6)
+		}
+		if wantIPv4 && vm.PrimaryIP4 != "" {
+			appendIP(vm.PrimaryIP4)
+		}
+	} else {
+		if wantIPv4 && vm.PrimaryIP4 != "" {
+			appendIP(vm.PrimaryIP4)
+		}
+		if wantIPv6 && vm.PrimaryIP6 != "" {
+			appendIP(vm.PrimaryIP6)
+		}
+	}
+
+	// Append additional interface addresses, filtered by family and deduped.
+	for _, ip := range vm.NetworkInterfaceAddresses {
+		if addedIPs[normalizeIP(ip)] {
+			continue
+		}
+		if isLinkLocalIP(ip) {
+			klog.V(6).Infof("Skipping link-local address: %s", ip)
+			continue
+		}
+		parsed := net.ParseIP(ip)
+		if parsed == nil {
+			continue
+		}
+		isIPv4 := parsed.To4() != nil
+		if (isIPv4 && !wantIPv4) || (!isIPv4 && !wantIPv6) {
+			continue
+		}
+		nodeAddresses = append(nodeAddresses, v1.NodeAddress{
+			Type:    v1.NodeInternalIP,
+			Address: ip,
+		})
+		addedIPs[normalizeIP(ip)] = true
+	}
+
+	// NodeHostName is intentionally left empty: in paravirtual mode kubelet sets
+	// the node hostname via --hostname-override or the OS hostname. The cloud
+	// provider does not know the in-guest hostname and must not override it.
+	nodeAddresses = append(nodeAddresses, v1.NodeAddress{
+		Type:    v1.NodeHostName,
+		Address: "",
+	})
+
+	if len(nodeAddresses) > 1 {
+		klog.V(2).Infof("VM %s: Reporting %d IP address(es) to API server", vm.Name, len(nodeAddresses)-1)
+	} else {
+		klog.Warningf("VM %s: No IP addresses found in network status", vm.Name)
+	}
+
+	return nodeAddresses
 }
 
 // NodeAddresses returns the addresses of the specified instance if one exists, otherwise nil
@@ -121,7 +236,7 @@ func (i *instances) NodeAddresses(ctx context.Context, name types.NodeName) ([]v
 		klog.V(4).Info("instances.NodeAddresses() InstanceNotFound ", name)
 		return nil, cloudprovider.InstanceNotFound
 	}
-	return createNodeAddresses(vm), err
+	return createNodeAddresses(vm, i.clusterIPFamily), err
 }
 
 // NodeAddressesByProviderID returns the addresses of the specified instance if one exists, otherwise nil
@@ -138,7 +253,7 @@ func (i *instances) NodeAddressesByProviderID(ctx context.Context, providerID st
 		klog.V(4).Info("instances.NodeAddressesByProviderID() InstanceNotFound ", providerID)
 		return nil, cloudprovider.InstanceNotFound
 	}
-	return createNodeAddresses(vm), nil
+	return createNodeAddresses(vm, i.clusterIPFamily), nil
 }
 
 // InstanceID returns the cloud provider ID of the named instance if one exists, otherwise an empty string

--- a/pkg/cloudprovider/vsphereparavirtual/instances_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/instances_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	vmopv1 "github.com/vmware-tanzu/vm-operator/api/v1alpha2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +36,7 @@ import (
 	adapterv2 "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/adapter/v1alpha2"
 	fakev2 "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/adapter/v1alpha2/fake"
 	clientv2 "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/provider/v1alpha2"
+	vmoptypes "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/types"
 )
 
 var (
@@ -71,25 +73,100 @@ func createTestVMWithVMIPAndHost(name, namespace, biosUUID string) *vmopv1.Virtu
 	}
 }
 
-func TestNewInstances(t *testing.T) {
-	testCases := []struct {
-		name        string
-		expectedErr error
-	}{
-		{
-			name:        "NewInstance: when everything is ok",
-			expectedErr: nil,
+func createTestVMWithIPv6(name, namespace, biosUUID string) *vmopv1.VirtualMachine {
+	return &vmopv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: vmopv1.VirtualMachineStatus{
+			BiosUUID: biosUUID,
+			Host:     "test-host",
+			Network: &vmopv1.VirtualMachineNetworkStatus{
+				PrimaryIP6: "2001:db8::1",
+			},
 		},
 	}
+}
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			fakeAdapter, _ := fakev2.NewAdapter()
-			_, err := NewInstances(testClusterNameSpace, fakeAdapter)
-			assert.NoError(t, err)
-			assert.Equal(t, testCase.expectedErr, err)
-		})
+func createTestVMWithDualStack(name, namespace, biosUUID string) *vmopv1.VirtualMachine {
+	return &vmopv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: vmopv1.VirtualMachineStatus{
+			BiosUUID: biosUUID,
+			Host:     "test-host",
+			Network: &vmopv1.VirtualMachineNetworkStatus{
+				PrimaryIP4: "1.2.3.4",
+				PrimaryIP6: "2001:db8::1",
+			},
+		},
 	}
+}
+
+func createTestVMWithMultipleIPs(name, namespace, biosUUID string) *vmopv1.VirtualMachine {
+	return &vmopv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: vmopv1.VirtualMachineStatus{
+			BiosUUID: biosUUID,
+			Host:     "test-host",
+			Network: &vmopv1.VirtualMachineNetworkStatus{
+				PrimaryIP4: "1.2.3.4",
+				PrimaryIP6: "2001:db8::1",
+				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceStatus{
+					{
+						IP: &vmopv1.VirtualMachineNetworkInterfaceIPStatus{
+							Addresses: []vmopv1.VirtualMachineNetworkInterfaceIPAddrStatus{
+								{Address: "1.2.3.4/24"},       // Primary IPv4 (will be deduplicated)
+								{Address: "10.0.0.5/24"},      // Secondary IPv4
+								{Address: "2001:db8::1/64"},   // Primary IPv6 (will be deduplicated)
+								{Address: "2001:db8::100/64"}, // Secondary IPv6
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createTestVMWithLinkLocalAddresses(name, namespace, biosUUID string) *vmopv1.VirtualMachine {
+	return &vmopv1.VirtualMachine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: vmopv1.VirtualMachineStatus{
+			BiosUUID: biosUUID,
+			Host:     "test-host",
+			Network: &vmopv1.VirtualMachineNetworkStatus{
+				PrimaryIP4: "1.2.3.4",
+				Interfaces: []vmopv1.VirtualMachineNetworkInterfaceStatus{
+					{
+						IP: &vmopv1.VirtualMachineNetworkInterfaceIPStatus{
+							Addresses: []vmopv1.VirtualMachineNetworkInterfaceIPAddrStatus{
+								{Address: "1.2.3.4/24"},
+								{Address: "fe80::1/64"},     // Link-local IPv6 (should be filtered)
+								{Address: "169.254.1.1/16"}, // Link-local IPv4 (should be filtered)
+								{Address: "10.0.0.5/24"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestNewInstances(t *testing.T) {
+	fakeAdapter, _ := fakev2.NewAdapter()
+	_, err := NewInstances(testClusterNameSpace, fakeAdapter, ClusterIPFamilyIPv4)
+	require.NoError(t, err)
 }
 
 func initTest(testVM *vmopv1.VirtualMachine) (*instances, *dynamicfake.FakeDynamicClient, error) {
@@ -98,8 +175,9 @@ func initTest(testVM *vmopv1.VirtualMachine) (*instances, *dynamicfake.FakeDynam
 	fc := dynamicfake.NewSimpleDynamicClient(scheme)
 	vmopAdapter := adapterv2.NewWithFakeClient(clientv2.NewWithDynamicClient(fc))
 	instance := &instances{
-		vmClient:  vmopAdapter,
-		namespace: testClusterNameSpace,
+		vmClient:        vmopAdapter,
+		namespace:       testClusterNameSpace,
+		clusterIPFamily: ClusterIPFamilyIPv4,
 	}
 	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(testVM)
 	if err != nil {
@@ -276,28 +354,116 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 	testCases := []struct {
 		name                string
 		testVM              *vmopv1.VirtualMachine
+		clusterIPFamily     string
 		expectedNodeAddress []v1.NodeAddress
 		expectedErr         error
 	}{
 		{
 			name:                "NodeAddressesByProviderID returns an empty address for found node with no IP",
 			testVM:              createTestVM(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily:     ClusterIPFamilyIPv4,
 			expectedNodeAddress: []v1.NodeAddress{},
 			expectedErr:         nil,
 		},
 		{
 			name:                "NodeAddressesByProviderID returns a NotFound error for a not found node",
 			testVM:              createTestVM(string(testVMName), testClusterNameSpace, "bogus"),
+			clusterIPFamily:     ClusterIPFamilyIPv4,
 			expectedNodeAddress: nil,
 			expectedErr:         cloudprovider.InstanceNotFound,
 		},
 		{
-			name:   "NodeAddressesByProviderID returns a valid address for a found node",
-			testVM: createTestVMWithVMIPAndHost(string(testVMName), testClusterNameSpace, testVMUUID),
+			name:            "NodeAddressesByProviderID returns a valid IPv4 address for a found node",
+			testVM:          createTestVMWithVMIPAndHost(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily: ClusterIPFamilyIPv4,
 			expectedNodeAddress: []v1.NodeAddress{
 				{
 					Type:    v1.NodeInternalIP,
 					Address: "1.2.3.4",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:            "NodeAddressesByProviderID returns a valid IPv6 address for a found node",
+			testVM:          createTestVMWithIPv6(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily: ClusterIPFamilyIPv6,
+			expectedNodeAddress: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "2001:db8::1",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:            "NodeAddressesByProviderID returns both IPv4 and IPv6 addresses for dual-stack node",
+			testVM:          createTestVMWithDualStack(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily: ClusterIPFamilyIPv4IPv6,
+			expectedNodeAddress: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "1.2.3.4",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "2001:db8::1",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:            "NodeAddressesByProviderID returns all valid IPs including secondary addresses",
+			testVM:          createTestVMWithMultipleIPs(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily: ClusterIPFamilyIPv4IPv6,
+			expectedNodeAddress: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "1.2.3.4",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "2001:db8::1",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.5",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "2001:db8::100",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:            "NodeAddressesByProviderID filters out link-local addresses",
+			testVM:          createTestVMWithLinkLocalAddresses(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily: ClusterIPFamilyIPv4,
+			expectedNodeAddress: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "1.2.3.4",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.5",
 				},
 				{
 					Type:    v1.NodeHostName,
@@ -312,6 +478,7 @@ func TestNodeAddressesByProviderID(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			instance, _, err := initTest(testCase.testVM)
 			assert.NoError(t, err)
+			instance.clusterIPFamily = testCase.clusterIPFamily
 			ret, err := instance.NodeAddressesByProviderID(context.Background(), testProviderID)
 			assert.Equal(t, testCase.expectedErr, err)
 			assert.Equal(t, testCase.expectedNodeAddress, ret)
@@ -351,28 +518,116 @@ func TestNodeAddresses(t *testing.T) {
 	testCases := []struct {
 		name                string
 		testVM              *vmopv1.VirtualMachine
+		clusterIPFamily     string
 		expectedNodeAddress []v1.NodeAddress
 		expectedErr         error
 	}{
 		{
 			name:                "NodeAddresses returns an empty address for found node with no IP",
 			testVM:              createTestVM(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily:     ClusterIPFamilyIPv4,
 			expectedNodeAddress: []v1.NodeAddress{},
 			expectedErr:         nil,
 		},
 		{
 			name:                "NodeAddresses returns a NotFound error for a not found node",
 			testVM:              createTestVM("bogus", testClusterNameSpace, testVMUUID),
+			clusterIPFamily:     ClusterIPFamilyIPv4,
 			expectedNodeAddress: nil,
 			expectedErr:         cloudprovider.InstanceNotFound,
 		},
 		{
-			name:   "NodeAddresses returns a valid address for a found node",
-			testVM: createTestVMWithVMIPAndHost(string(testVMName), testClusterNameSpace, testVMUUID),
+			name:            "NodeAddresses returns a valid IPv4 address for a found node",
+			testVM:          createTestVMWithVMIPAndHost(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily: ClusterIPFamilyIPv4,
 			expectedNodeAddress: []v1.NodeAddress{
 				{
 					Type:    v1.NodeInternalIP,
 					Address: "1.2.3.4",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:            "NodeAddresses returns a valid IPv6 address for a found node",
+			testVM:          createTestVMWithIPv6(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily: ClusterIPFamilyIPv6,
+			expectedNodeAddress: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "2001:db8::1",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:            "NodeAddresses returns both IPv4 and IPv6 addresses for dual-stack node",
+			testVM:          createTestVMWithDualStack(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily: ClusterIPFamilyIPv4IPv6,
+			expectedNodeAddress: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "1.2.3.4",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "2001:db8::1",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:            "NodeAddresses returns all valid IPs including secondary addresses",
+			testVM:          createTestVMWithMultipleIPs(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily: ClusterIPFamilyIPv4IPv6,
+			expectedNodeAddress: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "1.2.3.4",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "2001:db8::1",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.5",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "2001:db8::100",
+				},
+				{
+					Type:    v1.NodeHostName,
+					Address: "",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:            "NodeAddresses filters out link-local addresses",
+			testVM:          createTestVMWithLinkLocalAddresses(string(testVMName), testClusterNameSpace, testVMUUID),
+			clusterIPFamily: ClusterIPFamilyIPv4,
+			expectedNodeAddress: []v1.NodeAddress{
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "1.2.3.4",
+				},
+				{
+					Type:    v1.NodeInternalIP,
+					Address: "10.0.0.5",
 				},
 				{
 					Type:    v1.NodeHostName,
@@ -387,11 +642,144 @@ func TestNodeAddresses(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			instance, _, err := initTest(testCase.testVM)
 			assert.NoError(t, err)
+			instance.clusterIPFamily = testCase.clusterIPFamily
 			ret, err := instance.NodeAddresses(context.Background(), testVMName)
 			assert.Equal(t, testCase.expectedErr, err)
 			assert.Equal(t, testCase.expectedNodeAddress, ret)
 		})
 	}
+}
+
+func internalIPs(addrs []v1.NodeAddress) []string {
+	var ips []string
+	for _, a := range addrs {
+		if a.Type == v1.NodeInternalIP {
+			ips = append(ips, a.Address)
+		}
+	}
+	return ips
+}
+
+func TestIsLinkLocalIP(t *testing.T) {
+	testCases := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{name: "empty string is not link-local", ip: "", want: false},
+		{name: "unparseable string is not link-local", ip: "not-an-ip", want: false},
+		{name: "IPv4 link-local 169.254.x.x", ip: "169.254.1.1", want: true},
+		{name: "IPv4 non-link-local", ip: "10.0.0.1", want: false},
+		{name: "IPv6 link-local fe80::1", ip: "fe80::1", want: true},
+		{name: "IPv6 link-local upper boundary fe80::ffff", ip: "fe80::ffff", want: true},
+		{name: "IPv6 non-link-local 2001:db8::1", ip: "2001:db8::1", want: false},
+		{name: "loopback 127.0.0.1 is not link-local", ip: "127.0.0.1", want: false},
+		{name: "loopback ::1 is not link-local", ip: "::1", want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isLinkLocalIP(tc.ip)
+			if got != tc.want {
+				t.Errorf("isLinkLocalIP(%q) = %v, want %v", tc.ip, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCreateNodeAddressesUnexpectedFamilyPanics(t *testing.T) {
+	vm := &vmoptypes.VirtualMachineInfo{
+		Name:       "test-vm",
+		PrimaryIP4: "1.2.3.4",
+		PrimaryIP6: "2001:db8::1",
+	}
+	// Invariant: clusterIPFamily must be a canonical value from
+	// ParseClusterIPFamily. A non-canonical value indicates a programming
+	// error in the caller and must fail fast rather than silently picking
+	// a default ordering.
+	assert.PanicsWithValue(t,
+		`createNodeAddresses: invariant violated: clusterIPFamily "not-from-ParseClusterIPFamily" `+
+			`is not canonical (must be one of "ipv4"/"ipv6"/"ipv4ipv6"/"ipv6ipv4" from ParseClusterIPFamily)`,
+		func() {
+			createNodeAddresses(vm, "not-from-ParseClusterIPFamily")
+		},
+	)
+}
+
+func TestNodeAddressesIPFamilyOrdering(t *testing.T) {
+	dualStackVM := createTestVMWithDualStack(string(testVMName), testClusterNameSpace, testVMUUID)
+
+	t.Run("ipv4ipv6 dual-stack cluster places IPv4 address first via NodeAddresses", func(t *testing.T) {
+		instance, _, err := initTest(dualStackVM)
+		assert.NoError(t, err)
+		instance.clusterIPFamily = ClusterIPFamilyIPv4IPv6
+		addrs, err := instance.NodeAddresses(context.Background(), testVMName)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"1.2.3.4", "2001:db8::1"}, internalIPs(addrs))
+	})
+
+	t.Run("ipv6 single-stack cluster reports only IPv6 even when VM has both IPs", func(t *testing.T) {
+		instance, _, err := initTest(dualStackVM)
+		assert.NoError(t, err)
+		instance.clusterIPFamily = ClusterIPFamilyIPv6
+		addrs, err := instance.NodeAddresses(context.Background(), testVMName)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"2001:db8::1"}, internalIPs(addrs))
+	})
+
+	t.Run("ipv4ipv6 dual-stack cluster places IPv4 address first via NodeAddressesByProviderID", func(t *testing.T) {
+		instance, _, err := initTest(dualStackVM)
+		assert.NoError(t, err)
+		instance.clusterIPFamily = ClusterIPFamilyIPv4IPv6
+		addrs, err := instance.NodeAddressesByProviderID(context.Background(), testProviderID)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"1.2.3.4", "2001:db8::1"}, internalIPs(addrs))
+	})
+
+	t.Run("ipv6 single-stack cluster reports only IPv6 via NodeAddressesByProviderID even when VM has both IPs", func(t *testing.T) {
+		instance, _, err := initTest(dualStackVM)
+		assert.NoError(t, err)
+		instance.clusterIPFamily = ClusterIPFamilyIPv6
+		addrs, err := instance.NodeAddressesByProviderID(context.Background(), testProviderID)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"2001:db8::1"}, internalIPs(addrs))
+	})
+
+	t.Run("ipv6-primary cluster with IPv6-only VM returns single IPv6 address first", func(t *testing.T) {
+		ipv6OnlyVM := createTestVMWithIPv6(string(testVMName), testClusterNameSpace, testVMUUID)
+		instance, _, err := initTest(ipv6OnlyVM)
+		assert.NoError(t, err)
+		instance.clusterIPFamily = ClusterIPFamilyIPv6
+		addrs, err := instance.NodeAddresses(context.Background(), testVMName)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"2001:db8::1"}, internalIPs(addrs))
+	})
+
+	t.Run("ipv4ipv6 uses same primary ordering as ipv4", func(t *testing.T) {
+		instance, _, err := initTest(dualStackVM)
+		assert.NoError(t, err)
+		instance.clusterIPFamily = ClusterIPFamilyIPv4IPv6
+		addrs, err := instance.NodeAddresses(context.Background(), testVMName)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"1.2.3.4", "2001:db8::1"}, internalIPs(addrs))
+	})
+
+	t.Run("ipv6ipv4 uses same primary ordering as ipv6", func(t *testing.T) {
+		instance, _, err := initTest(dualStackVM)
+		assert.NoError(t, err)
+		instance.clusterIPFamily = ClusterIPFamilyIPv6IPv4
+		addrs, err := instance.NodeAddresses(context.Background(), testVMName)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"2001:db8::1", "1.2.3.4"}, internalIPs(addrs))
+	})
+
+	t.Run("ipv4 single-stack cluster reports only IPv4 even when VM has both IPs", func(t *testing.T) {
+		instance, _, err := initTest(dualStackVM)
+		assert.NoError(t, err)
+		instance.clusterIPFamily = ClusterIPFamilyIPv4
+		addrs, err := instance.NodeAddresses(context.Background(), testVMName)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"1.2.3.4"}, internalIPs(addrs))
+	})
 }
 
 func TestNodeAddressesInternalErr(t *testing.T) {

--- a/pkg/cloudprovider/vsphereparavirtual/route.go
+++ b/pkg/cloudprovider/vsphereparavirtual/route.go
@@ -89,11 +89,25 @@ func (r *routesProvider) ListRoutes(ctx context.Context, clusterName string) ([]
 	return r.routeManager.CreateCPRoutes(routes)
 }
 
+// crNameForRoute returns the StaticRoute CR name for a given Kubernetes node name
+// and destination CIDR. IPv4 CIDRs use the bare node name to remain compatible
+// with existing StaticRoute CRs created before dual-stack support; changing the
+// IPv4 naming scheme would orphan those CRs on upgrade. IPv6 CIDRs append
+// helper.SuffixIPv6 so dual-stack nodes can have one CR per address family
+// without name collision.
+func crNameForRoute(nodeName, destCIDR string) string {
+	if util.IsIPv4(destCIDR) {
+		return nodeName
+	}
+	return nodeName + helper.SuffixIPv6
+}
+
 // CreateRoute implements Routes.CreateRoute
 // Create a RouteSet or StaticRoute CR for a Node
 func (r *routesProvider) CreateRoute(ctx context.Context, clusterName string, nameHint string, route *cloudprovider.Route) error {
 	nodeName := string(route.TargetNode)
-	klog.V(6).Infof("Creating Route for node %s with hint %s in cluster %s", nodeName, nameHint, clusterName)
+	crName := crNameForRoute(nodeName, route.DestinationCIDR)
+	klog.V(6).Infof("Creating Route for node %s (CR name %s) with hint %s in cluster %s", nodeName, crName, nameHint, clusterName)
 
 	nodeIP, err := r.getNodeIPAddress(nodeName, util.IsIPv4(route.DestinationCIDR))
 	if err != nil {
@@ -116,66 +130,74 @@ func (r *routesProvider) CreateRoute(ctx context.Context, clusterName string, na
 	routeInfo := &helper.RouteInfo{
 		Labels:    labels,
 		Owner:     owners,
-		Name:      nodeName,
+		Name:      crName,
 		Cidr:      route.DestinationCIDR,
 		NodeIP:    nodeIP,
-		RouteName: helper.GetRouteName(nodeName, route.DestinationCIDR, clusterName),
+		RouteName: helper.GetRouteName(crName, route.DestinationCIDR, clusterName),
 	}
 	_, err = r.routeManager.CreateRouteCR(ctx, routeInfo)
 	if err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			klog.Errorf("Route CR %s is already existing: %v", nodeName, err)
+			klog.Errorf("Route CR %s is already existing: %v", crName, err)
 			return nil
 		}
-		klog.Errorf("creating Route CR for node %s failed: %s", nodeName, err)
+		klog.Errorf("creating Route CR for node %s failed: %s", crName, err)
 		return err
 	}
-	klog.V(6).Infof("Successfully created Route CR for node %s", nodeName)
-	return r.checkStaticRouteRealizedState(nodeName)
+	klog.V(6).Infof("Successfully created Route CR %s for node %s", crName, nodeName)
+	return r.checkStaticRouteRealizedState(crName)
 }
 
 // checkStaticRouteRealizedState checks static route realized state. The ready status is updated to Route CR by ncp/nsx-operator afterwards
 // The check happens every 1 second and the default timeout is 10 seconds
-func (r *routesProvider) checkStaticRouteRealizedState(routeSetName string) error {
+func (r *routesProvider) checkStaticRouteRealizedState(crName string) error {
 	timeout := time.After(helper.RealizedStateTimeout)
 	ticker := time.NewTicker(helper.RealizedStateSleepTime)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-timeout:
-			return fmt.Errorf("timed out waiting for static route %s", routeSetName)
+			return fmt.Errorf("timed out waiting for static route %s", crName)
 		case <-ticker.C:
-			if err := r.routeManager.WaitRouteCR(routeSetName); err == nil {
+			if err := r.routeManager.WaitRouteCR(crName); err == nil {
 				return nil
 			}
 		}
 	}
 }
 
-// DeleteRoute implements Routes.DeleteRouteCR
+// DeleteRoute implements Routes.DeleteRoute
 // Delete node's corresponding RouteSet or StaticRoute CR
 func (r *routesProvider) DeleteRoute(ctx context.Context, clusterName string, route *cloudprovider.Route) error {
-	routeSetName := string(route.TargetNode)
-	klog.V(6).Infof("Deleting Route CR %s in cluster %s", routeSetName, clusterName)
-	if err := r.routeManager.DeleteRouteCR(routeSetName); err != nil {
+	nodeName := string(route.TargetNode)
+	crName := crNameForRoute(nodeName, route.DestinationCIDR)
+	klog.V(6).Infof("Deleting Route CR %s in cluster %s", crName, clusterName)
+	if err := r.routeManager.DeleteRouteCR(crName); err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(6).Infof("Route CR %s already gone, treating as success", crName)
+			return nil
+		}
 		klog.ErrorS(helper.ErrDeleteRouteCR, fmt.Sprintf("%v", err))
+		return err
 	}
-	// routeset name equals node name
-	klog.V(6).Infof("Successfully deleted Route CR for node %s", routeSetName)
+	klog.V(6).Infof("Successfully deleted Route CR %s for node %s", crName, nodeName)
 	return nil
 }
 
-// getNodeIPAddress gets node IP address
-// IP family of node address and podCIDR should be the same
-// The order is to choose node internal IP first, then external IP
-// Return the first IP address as node IP
-func (r *routesProvider) getNodeIPAddress(nodeName string, isIPv4 bool) (string, error) {
+// getNodeIPAddress returns the first node address whose IP family matches the
+// requested family. wantIPv4 selects IPv4 (true) or IPv6 (false). Internal
+// addresses take precedence over external addresses; within each priority
+// tier the first matching address wins. For dual-stack nodes, callers invoke
+// this function once per route family and create a separate StaticRoute CR
+// for each address family.
+func (r *routesProvider) getNodeIPAddress(nodeName string, wantIPv4 bool) (string, error) {
 	node, err := r.nodeLister.Get(nodeName)
 	if err != nil {
 		klog.Errorf("getting node %s failed: %v", nodeName, err)
 		return "", err
 	}
 
+	// Collect all IPs (InternalIP first, then ExternalIP for priority)
 	allIPs := make([]net.IP, 0, len(node.Status.Addresses))
 	for _, addr := range node.Status.Addresses {
 		if addr.Type == v1.NodeInternalIP {
@@ -193,15 +215,27 @@ func (r *routesProvider) getNodeIPAddress(nodeName string, isIPv4 bool) (string,
 			}
 		}
 	}
+
 	if len(allIPs) == 0 {
 		return "", fmt.Errorf("node %s has neither InternalIP nor ExternalIP", nodeName)
 	}
+
+	wantFamily := "IPv6"
+	if wantIPv4 {
+		wantFamily = "IPv4"
+	}
+
 	for _, ip := range allIPs {
-		if (ip.To4() != nil) == isIPv4 {
-			klog.V(4).Infof("successfully fetching node %s IP address", node.Name)
+		isIPv4 := ip.To4() != nil
+		if isIPv4 == wantIPv4 {
+			klog.V(4).Infof("successfully fetched %s address %s for node %s", wantFamily, ip.String(), nodeName)
 			return ip.String(), nil
 		}
 	}
 
-	return "", fmt.Errorf("node %s does not have the same IP family with podCIDR", nodeName)
+	availableIPs := make([]string, len(allIPs))
+	for i, ip := range allIPs {
+		availableIPs[i] = ip.String()
+	}
+	return "", fmt.Errorf("node %s does not have any %s address (available IPs: %v)", nodeName, wantFamily, availableIPs)
 }

--- a/pkg/cloudprovider/vsphereparavirtual/route_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/route_test.go
@@ -295,3 +295,23 @@ func TestCheckStaticRouteRealizedState(t *testing.T) {
 	err = r.routeManager.DeleteRouteCR(fakeNode2.Name)
 	assert.NoError(t, err)
 }
+
+func TestCrNameForRoute(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodeName string
+		cidr     string
+		expected string
+	}{
+		{"IPv4 CIDR keeps bare node name", "node-1", "10.244.0.0/24", "node-1"},
+		{"IPv6 CIDR appends -ipv6 suffix", "node-1", "fd00::/80", "node-1" + helper.SuffixIPv6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := crNameForRoute(tt.nodeName, tt.cidr)
+			if got != tt.expected {
+				t.Errorf("crNameForRoute(%q, %q) = %q, want %q", tt.nodeName, tt.cidr, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/cloudprovider/vsphereparavirtual/routemanager/helper/helper.go
+++ b/pkg/cloudprovider/vsphereparavirtual/routemanager/helper/helper.go
@@ -23,6 +23,9 @@ const (
 	RealizedStateTimeout = 10 * time.Second
 	// RealizedStateSleepTime is the interval between realized state check
 	RealizedStateSleepTime = 1 * time.Second
+	// SuffixIPv6 is appended to the node name when naming an IPv6 StaticRoute CR,
+	// so that dual-stack nodes can have one CR per address family without name collision.
+	SuffixIPv6 = "-ipv6"
 )
 
 // RouteCR defines an interface that is used to represent different kinds of nsx.vmware.com route CR

--- a/pkg/cloudprovider/vsphereparavirtual/routemanager/staticroute/routemanager.go
+++ b/pkg/cloudprovider/vsphereparavirtual/routemanager/staticroute/routemanager.go
@@ -3,6 +3,7 @@ package staticroute
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	vpcapisv1 "github.com/vmware-tanzu/nsx-operator/pkg/apis/vpc/v1alpha1"
 	nsxclients "github.com/vmware-tanzu/nsx-operator/pkg/client/clientset/versioned"
@@ -14,6 +15,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/routemanager/helper"
+	"k8s.io/cloud-provider-vsphere/pkg/util"
 )
 
 // RouteManager defines a route manager working with static route CR
@@ -62,8 +64,15 @@ func (sr *RouteManager) CreateCPRoutes(staticroutes helper.RouteCRList) ([]*clou
 		// only return cloudprovider.RouteInfo if RouteSet CR status 'Ready' is true
 		condition := GetRouteCRCondition(&(staticroute.Status), vpcapisv1.Ready)
 		if condition != nil && condition.Status == v1.ConditionTrue {
-			// one RouteSet per node, so we can use nodeName as the name of RouteSet CR
+			// TargetNode must be the Kubernetes node name, not the CR name.
+			// For IPv6 routes, crNameForRoute appends helper.SuffixIPv6 to the node
+			// name. Strip the suffix only when the destination CIDR is IPv6, so that
+			// node names that legitimately end in "-ipv6" are not incorrectly truncated
+			// when they have an IPv4 route.
 			nodeName := staticroute.Name
+			if !util.IsIPv4(staticroute.Spec.Network) {
+				nodeName = strings.TrimSuffix(staticroute.Name, helper.SuffixIPv6)
+			}
 			cpRoute := &cloudprovider.Route{
 				Name:            staticroute.Name,
 				TargetNode:      types.NodeName(nodeName),

--- a/pkg/cloudprovider/vsphereparavirtual/vmoperator/adapter/v1alpha2/adapter.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmoperator/adapter/v1alpha2/adapter.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	vmop "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator"
+	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/networkutil"
 	clientv2 "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/provider/v1alpha2"
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/types"
 )
@@ -199,6 +200,16 @@ func vmToInfo(vm *vmopv1.VirtualMachine) *types.VirtualMachineInfo {
 	if vm.Status.Network != nil {
 		info.PrimaryIP4 = vm.Status.Network.PrimaryIP4
 		info.PrimaryIP6 = vm.Status.Network.PrimaryIP6
+		if vm.Status.Network.Interfaces != nil {
+			for _, iface := range vm.Status.Network.Interfaces {
+				if iface.IP == nil || iface.IP.Addresses == nil {
+					continue
+				}
+				for _, ipAddr := range iface.IP.Addresses {
+					info.NetworkInterfaceAddresses = append(info.NetworkInterfaceAddresses, networkutil.StripCIDRPrefix(ipAddr.Address))
+				}
+			}
+		}
 	}
 	return info
 }

--- a/pkg/cloudprovider/vsphereparavirtual/vmoperator/adapter/v1alpha5/adapter.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmoperator/adapter/v1alpha5/adapter.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	vmop "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator"
+	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/networkutil"
 	clientv5 "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/provider/v1alpha5"
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/types"
 )
@@ -200,6 +201,16 @@ func vmToInfo(vm *vmopv5.VirtualMachine) *types.VirtualMachineInfo {
 	if vm.Status.Network != nil {
 		info.PrimaryIP4 = vm.Status.Network.PrimaryIP4
 		info.PrimaryIP6 = vm.Status.Network.PrimaryIP6
+		if vm.Status.Network.Interfaces != nil {
+			for _, iface := range vm.Status.Network.Interfaces {
+				if iface.IP == nil || iface.IP.Addresses == nil {
+					continue
+				}
+				for _, ipAddr := range iface.IP.Addresses {
+					info.NetworkInterfaceAddresses = append(info.NetworkInterfaceAddresses, networkutil.StripCIDRPrefix(ipAddr.Address))
+				}
+			}
+		}
 	}
 	return info
 }

--- a/pkg/cloudprovider/vsphereparavirtual/vmoperator/adapter/v1alpha6/adapter.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmoperator/adapter/v1alpha6/adapter.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	vmop "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator"
+	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/networkutil"
 	clientv6 "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/provider/v1alpha6"
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/types"
 )
@@ -257,6 +258,16 @@ func vmToInfo(vm *vmopv6.VirtualMachine) *types.VirtualMachineInfo {
 	if vm.Status.Network != nil {
 		info.PrimaryIP4 = vm.Status.Network.PrimaryIP4
 		info.PrimaryIP6 = vm.Status.Network.PrimaryIP6
+		if vm.Status.Network.Interfaces != nil {
+			for _, iface := range vm.Status.Network.Interfaces {
+				if iface.IP == nil || iface.IP.Addresses == nil {
+					continue
+				}
+				for _, ipAddr := range iface.IP.Addresses {
+					info.NetworkInterfaceAddresses = append(info.NetworkInterfaceAddresses, networkutil.StripCIDRPrefix(ipAddr.Address))
+				}
+			}
+		}
 	}
 	return info
 }

--- a/pkg/cloudprovider/vsphereparavirtual/vmoperator/networkutil/strip.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmoperator/networkutil/strip.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package networkutil holds small helpers shared by VM Operator API adapters.
+package networkutil
+
+import "strings"
+
+// StripCIDRPrefix returns addr with a trailing "/prefix" removed when present.
+func StripCIDRPrefix(addr string) string {
+	if idx := strings.Index(addr, "/"); idx != -1 {
+		return addr[:idx]
+	}
+	return addr
+}

--- a/pkg/cloudprovider/vsphereparavirtual/vmoperator/networkutil/strip_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmoperator/networkutil/strip_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkutil
+
+import "testing"
+
+func TestStripCIDRPrefix(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty string", in: "", want: ""},
+		{name: "no prefix", in: "10.0.0.1", want: "10.0.0.1"},
+		{name: "ipv4 cidr", in: "10.0.0.1/24", want: "10.0.0.1"},
+		{name: "ipv6 cidr", in: "2001:db8::1/64", want: "2001:db8::1"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := StripCIDRPrefix(tc.in); got != tc.want {
+				t.Fatalf("StripCIDRPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cloudprovider/vsphereparavirtual/vmoperator/types/types.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmoperator/types/types.go
@@ -57,6 +57,9 @@ type VirtualMachineInfo struct {
 	PowerState PowerState
 	PrimaryIP4 string
 	PrimaryIP6 string
+	// NetworkInterfaceAddresses lists CIDR-stripped IPs from vm.Status.Network.Interfaces
+	// in discovery order. The CPI merges these with primaries, deduplicates, and filters link-local.
+	NetworkInterfaceAddresses []string
 }
 
 // VirtualMachineServicePort describes a single port exposed by a VirtualMachineService.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds IPv6 and dual-stack support to the vSphere CPI.

- --cluster-ip-family (paravirtual): controls NodeInternalIP ordering for IPv4-only, IPv6-only, and dual-stack clusters. Non-IPv4 requires --vm-operator-api-version >= v1alpha6; IPv6 with route controller additionally requires --enable-vpc-mode=true.
- Report all interface addresses (deduped, link-local filtered), not just the primary IP.
- Route controller: per-family CR naming (<node> for IPv4, <node>-ipv6 for IPv6); fix silent error discard in DeleteRoute; fix ListRoutes → DeleteRoute double-suffix bug.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

