### PR TITLE
[release-1.35] Update security scan job by adding go-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,16 @@ deps:
 ################################################################################
 # Ensure the version is injected into the binaries via a linker flag.
 export VERSION ?= $(shell git describe --always --dirty)
+GO_VERSION ?= 1.25.0
 
 .PHONY: version print-ccm-image
 
 version:
 	@echo $(VERSION)
+
+.PHONY: go-version
+go-version: ## Print the go version we use to compile our binaries and images
+	@echo $(GO_VERSION)
 
 ################################################################################
 ##                              BUILD BINARIES                                ##


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The release-1.35 Makefile was missing this target, causing the CI to install an older Go version incompatible with go.mod (go 1.25.0)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #1758

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
