### PR TITLE
Remove unused SUPERVISOR_APISERVER_ENDPOINT_IP env var requirement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,14 +99,14 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
-	golang.org/x/mod v0.35.0 // indirect
+	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
-	golang.org/x/tools v0.44.0 // indirect
+	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/grpc v1.79.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,8 +236,8 @@ golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93/go.mod h1:EPRbTFwzwjXj9NpYyy
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
-golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -276,8 +276,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
-golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
+golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
+golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
 golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnpsEAGHaNy0n/rJM=
 golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=

--- a/pkg/cloudprovider/vsphereparavirtual/config/config.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config/config.go
@@ -43,8 +43,6 @@ const (
 	SupervisorClusterAccessNamespaceFile = "namespace"
 	// SupervisorAPIServerPortEnv reads supervisor service endpoint info from env
 	SupervisorAPIServerPortEnv string = "SUPERVISOR_APISERVER_PORT"
-	// SupervisorAPIServerEndpointIPEnv reads supervisor API server endpoint IP from env
-	SupervisorAPIServerEndpointIPEnv string = "SUPERVISOR_APISERVER_ENDPOINT_IP"
 	// SupervisorServiceAccountNameEnv reads supervisor service account name from env
 	SupervisorServiceAccountNameEnv string = "SUPERVISOR_CLUSTER_SERVICEACCOUNT_SECRET_NAME"
 	// SupervisorAPIServerFQDN reads supervisor service API server's fully qualified domain name from env
@@ -53,8 +51,6 @@ const (
 
 // SupervisorEndpoint is the supervisor cluster endpoint
 type SupervisorEndpoint struct {
-	// supervisor cluster proxy service hostname
-	Endpoint string
 	// supervisor cluster proxy service  port
 	Port string
 }
@@ -74,12 +70,6 @@ func ReadOwnerRef(path string) (*metav1.OwnerReference, error) {
 }
 
 func readSupervisorConfig() (*SupervisorEndpoint, error) {
-	remoteVip := os.Getenv(SupervisorAPIServerEndpointIPEnv)
-	if remoteVip == "" {
-		// call os.Exit(1) for the pod to restart
-		klog.Fatalf("%s is missing in env vars", SupervisorAPIServerEndpointIPEnv)
-	}
-
 	remotePort := os.Getenv(SupervisorAPIServerPortEnv)
 
 	if remotePort == "" {
@@ -88,10 +78,9 @@ func readSupervisorConfig() (*SupervisorEndpoint, error) {
 
 	}
 
-	klog.V(6).Infof("Configured with remote apiserver %s:%s", remoteVip, remotePort)
+	klog.V(6).Infof("Configured with remote apiserver port %s", remotePort)
 	return &SupervisorEndpoint{
-		Endpoint: remoteVip,
-		Port:     remotePort,
+		Port: remotePort,
 	}, nil
 
 }

--- a/pkg/cloudprovider/vsphereparavirtual/config/config_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config/config_test.go
@@ -109,31 +109,37 @@ func TestReadOwnerRef(t *testing.T) {
 }
 
 func TestReadSupervisorConfig(t *testing.T) {
-	endpoint := "test.sv.proxy"
-	port := "6443"
-
-	err := os.Setenv(SupervisorAPIServerEndpointIPEnv, endpoint)
-	if err != nil {
-		t.Errorf("Should be able to set env var: %s", err)
+	tests := []struct {
+		name         string
+		portEnv      string
+		expectedPort string
+	}{
+		{
+			name:         "port is configured",
+			portEnv:      "6443",
+			expectedPort: "6443",
+		},
 	}
 
-	err = os.Setenv(SupervisorAPIServerPortEnv, port)
-	if err != nil {
-		t.Errorf("Should be able to set env var: %s", err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := os.Setenv(SupervisorAPIServerPortEnv, tc.portEnv)
+			if err != nil {
+				t.Errorf("Should be able to set env var: %s", err)
+			}
+
+			defer os.Unsetenv(SupervisorAPIServerPortEnv)
+
+			svEndpoint, err := readSupervisorConfig()
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if svEndpoint.Port != tc.expectedPort {
+				t.Fatalf("incorrect port: got %q, want %q", svEndpoint.Port, tc.expectedPort)
+			}
+		})
 	}
-
-	defer os.Setenv(SupervisorAPIServerEndpointIPEnv, "") // clean up
-	defer os.Setenv(SupervisorAPIServerPortEnv, "")       // clean up
-
-	svEndpoint, _ := readSupervisorConfig()
-
-	if svEndpoint.Endpoint != endpoint {
-		t.Fatalf("incorrect endpoint: %s", svEndpoint.Endpoint)
-	}
-	if svEndpoint.Port != port {
-		t.Fatalf("incorrect port: %s", svEndpoint.Port)
-	}
-
 }
 
 func TestGetNameSpace(t *testing.T) {
@@ -187,7 +193,6 @@ func TestGetRestConfig(t *testing.T) {
 	tests := []struct {
 		fileExists bool
 		fqdn       string
-		endpoint   string
 		port       string
 		token      string
 		ca         string
@@ -195,7 +200,6 @@ func TestGetRestConfig(t *testing.T) {
 		{
 			fileExists: false,
 			fqdn:       "supervisor.default.svc",
-			endpoint:   "192.163.1.100",
 			port:       "6443",
 			token:      "test-token",
 			ca:         "test-ca",
@@ -203,7 +207,6 @@ func TestGetRestConfig(t *testing.T) {
 		{
 			fileExists: true,
 			fqdn:       "supervisor.default.svc",
-			endpoint:   "192.163.1.200",
 			port:       "6443",
 			token:      "test-token",
 			ca:         "test-ca",
@@ -226,18 +229,12 @@ func TestGetRestConfig(t *testing.T) {
 				t.Errorf("failed to create test ca file, %s", err)
 			}
 
-			err = os.Setenv(SupervisorAPIServerEndpointIPEnv, test.endpoint)
-			if err != nil {
-				t.Errorf("Should be able to set env var: %s", err)
-			}
-
 			err = os.Setenv(SupervisorAPIServerPortEnv, test.port)
 			if err != nil {
 				t.Errorf("Should be able to set env var: %s", err)
 			}
 
-			defer os.Setenv(SupervisorAPIServerEndpointIPEnv, "") // clean up
-			defer os.Setenv(SupervisorAPIServerPortEnv, "")       // clean up
+			defer os.Unsetenv(SupervisorAPIServerPortEnv)
 
 			cfg, err := GetRestConfig(dir)
 			if err != nil {
@@ -250,18 +247,12 @@ func TestGetRestConfig(t *testing.T) {
 				t.Fatalf("incorrect Token: %s", cfg.BearerToken)
 			}
 		} else {
-			err := os.Setenv(SupervisorAPIServerEndpointIPEnv, test.endpoint)
+			err := os.Setenv(SupervisorAPIServerPortEnv, test.port)
 			if err != nil {
 				t.Errorf("Should be able to set env var: %s", err)
 			}
 
-			err = os.Setenv(SupervisorAPIServerPortEnv, test.port)
-			if err != nil {
-				t.Errorf("Should be able to set env var: %s", err)
-			}
-
-			defer os.Setenv(SupervisorAPIServerEndpointIPEnv, "") // clean up
-			defer os.Setenv(SupervisorAPIServerPortEnv, "")       // clean up
+			defer os.Unsetenv(SupervisorAPIServerPortEnv)
 
 			_, err = GetRestConfig(dir)
 			if err == nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Cleans up vsphereparavirtual configuration by removing the unused but previously strictly validated SUPERVISOR_APISERVER_ENDPOINT_IP environment variable. This variable went unused after API calls were migrated to use the FQDN rather than endpoint IP.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #1774

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
