### PR TITLE
✨Support token reload without restarting

### DIFF
--- a/cmd/vsphere-cloud-controller-manager/main.go
+++ b/cmd/vsphere-cloud-controller-manager/main.go
@@ -20,7 +20,7 @@ limitations under the License.
 package main
 
 import (
-	"crypto/sha256"
+	"bytes"
 	"flag"
 	goflag "flag"
 	"fmt"
@@ -330,18 +330,18 @@ type restartGuard struct {
 	// volume. It is empty when not running in paravirtual mode, in which case
 	// every non-Chmod event triggers a restart.
 	secretMountDir string
-	// baselines maps a restart-worthy file name to the content hash captured at
+	// baselines maps a restart-worthy file name to the raw content captured at
 	// startup.
-	baselines map[string][sha256.Size]byte
+	baselines map[string][]byte
 }
 
-// newRestartGuard captures the startup content hashes of the restart-worthy
+// newRestartGuard captures the startup raw contents of the restart-worthy
 // keys under secretMountDir. Pass an empty secretMountDir to restart on every
 // (non-Chmod) event.
 func newRestartGuard(secretMountDir string, restartKeys []string) *restartGuard {
 	g := &restartGuard{
 		secretMountDir: secretMountDir,
-		baselines:      make(map[string][sha256.Size]byte, len(restartKeys)),
+		baselines:      make(map[string][]byte, len(restartKeys)),
 	}
 	for _, k := range restartKeys {
 		data, err := os.ReadFile(filepath.Join(secretMountDir, k))
@@ -352,7 +352,7 @@ func newRestartGuard(secretMountDir string, restartKeys []string) *restartGuard 
 			klog.Warningf("unable to read baseline for %s under %s: %v", k, secretMountDir, err)
 			continue
 		}
-		g.baselines[k] = sha256.Sum256(data)
+		g.baselines[k] = data
 	}
 	return g
 }
@@ -382,7 +382,7 @@ func (g *restartGuard) restartKeyChanged() bool {
 			klog.Warningf("failed to re-read %s under %s, triggering restart: %v", name, g.secretMountDir, err)
 			return true
 		}
-		if sha256.Sum256(got) != want {
+		if !bytes.Equal(got, want) {
 			klog.Infof("detected change in %s, triggering restart", name)
 			return true
 		}

--- a/cmd/vsphere-cloud-controller-manager/main.go
+++ b/cmd/vsphere-cloud-controller-manager/main.go
@@ -20,12 +20,14 @@ limitations under the License.
 package main
 
 import (
+	"crypto/sha256"
 	"flag"
 	goflag "flag"
 	"fmt"
 	"math/rand"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -204,10 +206,19 @@ func main() {
 		klog.Infof("initialize notifier on configmap and service token update %s\n", cloudConfig)
 
 		pathsToMonitor := []string{cloudConfig}
+		// guard restarts on every (non-Chmod) event by default; in paravirtual
+		// mode it is narrowed so that token-only rotations of the supervisor
+		// credentials Secret do not restart the pod (client-go reloads the token
+		// from BearerTokenFile), while ca.crt/namespace changes still do.
+		guard := newRestartGuard("", nil)
 		if cloudProvider == vsphereparavirtual.RegisteredProviderName {
 			pathsToMonitor = append(pathsToMonitor, SupervisorServiceAccountPath, pvconfig.VsphereParavirtualCloudProviderConfigPath)
+			guard = newRestartGuard(SupervisorServiceAccountPath, []string{
+				pvconfig.SupervisorClusterAccessCAFile,
+				pvconfig.SupervisorClusterAccessNamespaceFile,
+			})
 		}
-		watch, stop, err := initializeWatch(pathsToMonitor)
+		watch, stop, err := initializeWatch(pathsToMonitor, guard)
 		if err != nil {
 			klog.Fatalf("fail to initialize watch on config map %s: %v\n", cloudConfig, err)
 		}
@@ -270,7 +281,7 @@ func shouldEnableRouteController(controllersFlag, cloudProviderFlag *pflag.Value
 // set up a filesystem watcher for the mounted files
 // which include cloud-config and projected service account.
 // reboot the app whenever there is an update via the returned stopCh.
-func initializeWatch(paths []string) (watch *fsnotify.Watcher, stopCh chan struct{}, err error) {
+func initializeWatch(paths []string, guard *restartGuard) (watch *fsnotify.Watcher, stopCh chan struct{}, err error) {
 	stopCh = make(chan struct{})
 	watch, err = fsnotify.NewWatcher()
 	if err != nil {
@@ -282,11 +293,11 @@ func initializeWatch(paths []string) (watch *fsnotify.Watcher, stopCh chan struc
 			case err := <-watch.Errors:
 				klog.Warningf("watcher receives err: %v\n", err)
 			case event := <-watch.Events:
-				if event.Op != fsnotify.Chmod {
+				if guard.shouldRestart(event) {
 					klog.Fatalf("restarting pod because received event %v\n", event)
 					stopCh <- struct{}{}
 				} else {
-					klog.V(5).Infof("watcher receives %s on the mounted file %s\n", event.Op.String(), event.Name)
+					klog.V(5).Infof("watcher receives %s on the mounted file %s, skipping restart\n", event.Op.String(), event.Name)
 				}
 			}
 		}
@@ -298,6 +309,96 @@ func initializeWatch(paths []string) (watch *fsnotify.Watcher, stopCh chan struc
 	}
 
 	return
+}
+
+// restartGuard decides whether a filesystem event should trigger a pod restart.
+//
+// The supervisor credentials (ca.crt, token, namespace) are delivered as a
+// single projected Secret volume. Kubernetes' atomic writer updates the whole
+// volume via a "..data" symlink swap, so fsnotify events never name an
+// individual key and every key appears to change at once. That makes filename
+// matching useless for skipping routine token rotation.
+//
+// Instead we compare the content of the keys that DO require a restart when they
+// change (ca.crt, namespace) against a baseline captured at startup. A
+// token-only rotation leaves those keys untouched and is skipped (client-go
+// reloads the bearer token from BearerTokenFile on its own); any change to a
+// restart-worthy key, or any event outside the credentials mount, triggers a
+// restart.
+type restartGuard struct {
+	// secretMountDir is the directory of the projected supervisor credentials
+	// volume. It is empty when not running in paravirtual mode, in which case
+	// every non-Chmod event triggers a restart.
+	secretMountDir string
+	// baselines maps a restart-worthy file name to the content hash captured at
+	// startup.
+	baselines map[string][sha256.Size]byte
+}
+
+// newRestartGuard captures the startup content hashes of the restart-worthy
+// keys under secretMountDir. Pass an empty secretMountDir to restart on every
+// (non-Chmod) event.
+func newRestartGuard(secretMountDir string, restartKeys []string) *restartGuard {
+	g := &restartGuard{
+		secretMountDir: secretMountDir,
+		baselines:      make(map[string][sha256.Size]byte, len(restartKeys)),
+	}
+	for _, k := range restartKeys {
+		data, err := os.ReadFile(filepath.Join(secretMountDir, k))
+		if err != nil {
+			// Without a baseline we cannot tell whether this key changed later,
+			// so we deliberately leave it unset; a subsequent read error or diff
+			// in restartKeyChanged will then fail safe by restarting.
+			klog.Warningf("unable to read baseline for %s under %s: %v", k, secretMountDir, err)
+			continue
+		}
+		g.baselines[k] = sha256.Sum256(data)
+	}
+	return g
+}
+
+// shouldRestart reports whether the given event must trigger a pod restart.
+func (g *restartGuard) shouldRestart(event fsnotify.Event) bool {
+	if event.Op == fsnotify.Chmod {
+		return false
+	}
+	// Events outside the credentials mount (e.g. cloud-config, ownerref) always
+	// trigger a restart, preserving the original behavior.
+	if !isUnder(event.Name, g.secretMountDir) {
+		return true
+	}
+	// Within the credentials mount, restart only when a restart-worthy key
+	// actually changed; token-only rotations are reloaded live by client-go.
+	return g.restartKeyChanged()
+}
+
+// restartKeyChanged re-reads the restart-worthy keys and reports whether any of
+// them differs from the baseline captured at startup. A read failure is treated
+// as a change so we fail safe by restarting.
+func (g *restartGuard) restartKeyChanged() bool {
+	for name, want := range g.baselines {
+		got, err := os.ReadFile(filepath.Join(g.secretMountDir, name))
+		if err != nil {
+			klog.Warningf("failed to re-read %s under %s, triggering restart: %v", name, g.secretMountDir, err)
+			return true
+		}
+		if sha256.Sum256(got) != want {
+			klog.Infof("detected change in %s, triggering restart", name)
+			return true
+		}
+	}
+	return false
+}
+
+// isUnder reports whether path is dir itself or a descendant of dir. A blank dir
+// matches nothing.
+func isUnder(path, dir string) bool {
+	if dir == "" {
+		return false
+	}
+	cleanDir := filepath.Clean(dir)
+	cleanPath := filepath.Clean(path)
+	return cleanPath == cleanDir || strings.HasPrefix(cleanPath, cleanDir+string(os.PathSeparator))
 }
 
 func initializeCloud(config *appconfig.CompletedConfig, cloudProvider string) cloudprovider.Interface {

--- a/cmd/vsphere-cloud-controller-manager/main_test.go
+++ b/cmd/vsphere-cloud-controller-manager/main_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+
+	pvconfig "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/config"
+)
+
+// writeFile is a test helper that writes content to dir/name.
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write %s: %v", name, err)
+	}
+}
+
+// newCredsDir creates a temp directory populated with the three supervisor
+// credential keys and returns the directory path.
+func newCredsDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeFile(t, dir, pvconfig.SupervisorClusterAccessCAFile, "ca-baseline")
+	writeFile(t, dir, pvconfig.SupervisorClusterAccessNamespaceFile, "ns-baseline")
+	writeFile(t, dir, pvconfig.SupervisorClusterAccessTokenFile, "token-baseline")
+	return dir
+}
+
+func restartKeys() []string {
+	return []string{
+		pvconfig.SupervisorClusterAccessCAFile,
+		pvconfig.SupervisorClusterAccessNamespaceFile,
+	}
+}
+
+func TestRestartGuard_ParavirtualMount(t *testing.T) {
+	t.Run("token-only rotation is skipped", func(t *testing.T) {
+		dir := newCredsDir(t)
+		guard := newRestartGuard(dir, restartKeys())
+
+		// Simulate an atomic-writer ..data swap that only changed the token.
+		writeFile(t, dir, pvconfig.SupervisorClusterAccessTokenFile, "token-rotated")
+		event := fsnotify.Event{Name: filepath.Join(dir, "..data"), Op: fsnotify.Create}
+
+		if guard.shouldRestart(event) {
+			t.Fatalf("token-only rotation should not trigger a restart")
+		}
+	})
+
+	t.Run("ca.crt change triggers restart", func(t *testing.T) {
+		dir := newCredsDir(t)
+		guard := newRestartGuard(dir, restartKeys())
+
+		writeFile(t, dir, pvconfig.SupervisorClusterAccessCAFile, "ca-rotated")
+		event := fsnotify.Event{Name: filepath.Join(dir, "..data"), Op: fsnotify.Create}
+
+		if !guard.shouldRestart(event) {
+			t.Fatalf("ca.crt change should trigger a restart")
+		}
+	})
+
+	t.Run("namespace change triggers restart", func(t *testing.T) {
+		dir := newCredsDir(t)
+		guard := newRestartGuard(dir, restartKeys())
+
+		writeFile(t, dir, pvconfig.SupervisorClusterAccessNamespaceFile, "ns-rotated")
+		event := fsnotify.Event{Name: filepath.Join(dir, "..data"), Op: fsnotify.Create}
+
+		if !guard.shouldRestart(event) {
+			t.Fatalf("namespace change should trigger a restart")
+		}
+	})
+
+	t.Run("missing restart key triggers restart", func(t *testing.T) {
+		dir := newCredsDir(t)
+		guard := newRestartGuard(dir, restartKeys())
+
+		if err := os.Remove(filepath.Join(dir, pvconfig.SupervisorClusterAccessCAFile)); err != nil {
+			t.Fatalf("failed to remove ca.crt: %v", err)
+		}
+		event := fsnotify.Event{Name: filepath.Join(dir, "..data"), Op: fsnotify.Create}
+
+		if !guard.shouldRestart(event) {
+			t.Fatalf("unreadable restart key should fail safe and trigger a restart")
+		}
+	})
+
+	t.Run("chmod is always ignored", func(t *testing.T) {
+		dir := newCredsDir(t)
+		guard := newRestartGuard(dir, restartKeys())
+
+		// Even with a real ca.crt change, a Chmod-only event is ignored.
+		writeFile(t, dir, pvconfig.SupervisorClusterAccessCAFile, "ca-rotated")
+		event := fsnotify.Event{Name: filepath.Join(dir, pvconfig.SupervisorClusterAccessCAFile), Op: fsnotify.Chmod}
+
+		if guard.shouldRestart(event) {
+			t.Fatalf("chmod events should never trigger a restart")
+		}
+	})
+
+	t.Run("event outside the credentials mount triggers restart", func(t *testing.T) {
+		dir := newCredsDir(t)
+		guard := newRestartGuard(dir, restartKeys())
+
+		event := fsnotify.Event{Name: "/config/cloud-config", Op: fsnotify.Write}
+
+		if !guard.shouldRestart(event) {
+			t.Fatalf("changes outside the credentials mount should trigger a restart")
+		}
+	})
+}
+
+func TestRestartGuard_DefaultRestartsOnAnyChange(t *testing.T) {
+	// An empty secretMountDir (non-paravirtual mode) restarts on every non-Chmod
+	// event and ignores Chmod.
+	guard := newRestartGuard("", nil)
+
+	tests := []struct {
+		name  string
+		event fsnotify.Event
+		want  bool
+	}{
+		{"write triggers restart", fsnotify.Event{Name: "/config/cloud-config", Op: fsnotify.Write}, true},
+		{"create triggers restart", fsnotify.Event{Name: "/config/cloud-config", Op: fsnotify.Create}, true},
+		{"chmod is ignored", fsnotify.Event{Name: "/config/cloud-config", Op: fsnotify.Chmod}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := guard.shouldRestart(tt.event); got != tt.want {
+				t.Fatalf("shouldRestart(%+v) = %v, want %v", tt.event, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsUnder(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		dir  string
+		want bool
+	}{
+		{"file directly under dir", "/etc/cloud/ccm-provider/..data", "/etc/cloud/ccm-provider", true},
+		{"dir itself", "/etc/cloud/ccm-provider", "/etc/cloud/ccm-provider", true},
+		{"unrelated path", "/config/cloud-config", "/etc/cloud/ccm-provider", false},
+		{"prefix but not a child", "/etc/cloud/ccm-provider-extra/token", "/etc/cloud/ccm-provider", false},
+		{"empty dir matches nothing", "/etc/cloud/ccm-provider/..data", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUnder(tt.path, tt.dir); got != tt.want {
+				t.Fatalf("isUnder(%q, %q) = %v, want %v", tt.path, tt.dir, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cloudprovider/vsphereparavirtual/config/config.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config/config.go
@@ -116,9 +116,11 @@ func GetRestConfig(svConfigPath string) (*rest.Config, error) {
 	}
 
 	tokenFile := svConfigPath + "/" + SupervisorClusterAccessTokenFile
-	token, err := os.ReadFile(tokenFile)
-
-	if err != nil {
+	// Validate the token is readable at startup so we fail fast with a clear
+	// error. The content is intentionally discarded: we hand the path to
+	// client-go via BearerTokenFile so it reloads the (potentially short-lived,
+	// periodically refreshed) token from disk without requiring a pod restart.
+	if _, err := os.ReadFile(tokenFile); err != nil {
 		klog.Errorf("Failed to read token from %s: %v", tokenFile, err)
 		return nil, err
 	}
@@ -136,7 +138,7 @@ func GetRestConfig(svConfigPath string) (*rest.Config, error) {
 		TLSClientConfig: rest.TLSClientConfig{
 			CAData: rootCA,
 		},
-		BearerToken: string(token),
+		BearerTokenFile: tokenFile,
 	}, nil
 }
 

--- a/pkg/cloudprovider/vsphereparavirtual/config/config_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/config/config_test.go
@@ -246,8 +246,14 @@ func TestGetRestConfig(t *testing.T) {
 			if cfg.Host != "https://"+net.JoinHostPort(test.fqdn, test.port) {
 				t.Fatalf("incorrect Host: %s", cfg.Host)
 			}
-			if cfg.BearerToken != test.token {
-				t.Fatalf("incorrect Token: %s", cfg.BearerToken)
+			// The token must be supplied as a file path (not an inlined static
+			// string) so client-go reloads it on rotation without a restart.
+			if cfg.BearerToken != "" {
+				t.Fatalf("BearerToken should be empty, got %q", cfg.BearerToken)
+			}
+			wantTokenFile := dir + "/" + SupervisorClusterAccessTokenFile
+			if cfg.BearerTokenFile != wantTokenFile {
+				t.Fatalf("incorrect BearerTokenFile: got %q, want %q", cfg.BearerTokenFile, wantTokenFile)
 			}
 		} else {
 			err := os.Setenv(SupervisorAPIServerEndpointIPEnv, test.endpoint)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In paravirtual mode, the CCM watches the mounted supervisor credentials and restarts the pod on any change. Since the credentials are delivered as a single projected Secret volume, routine token rotation triggered an unnecessary restart, even though client-go can reload the token on its own.

- Configures the supervisor rest.Config with BearerTokenFile instead of an inlined static BearerToken, so client-go transparently reloads the (short-lived, periodically refreshed) token from disk.
- Reworks the file watcher to skip restarts on token-only rotations. Because the projected volume updates atomically via a ..data symlink swap (fsnotify never names individual keys), the decision is content-based: a baseline hash of the restart-worthy keys (ca.crt, namespace) is captured at startup and re-checked on each event. Changes to those keys—or any change outside the credentials mount—still trigger a restart; an unreadable key fails safe by restarting.
- Adds unit tests for the watcher decision logic (token-only rotation, ca.crt/namespace changes, missing key, chmod, out-of-mount events) and updates the rest-config test for BearerTokenFile.

Backward compatible with the current non-expiring token and forward compatible with the planned short-lived token.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1779 

**Special notes for your reviewer**:
Manual Verification Complete

Step 1: Feature Deployment
- Update the CPI deployment to utilize the specific build containing the short-lived token feature.

Step 2: Basic Functionality Validation
- Provision a sample unprivileged LoadBalancer service deployment to verify normal end-to-end routing behavior.

Step 3: Resource Generation and Connectivity Verification
- Verify that the guest cluster LoadBalancer service successfully receives a valid external IP.
- Confirm that the corresponding VirtualMachineService resource is successfully generated in the Supervisor namespace.
- Validate traffic flow via a curl test against the external IP, ensuring the expected payload is returned.

Step 4: Token Rotation and Refresh Testing
- Manually delete the ProviderServiceAccount 's corresponding service account on the Supervisor plane to simulate a token rotation event.
- Monitor the system and verify that the resource successfully regenerates and issues a refreshed token.

Step 5: Temporary Disruption Observation
- During the transient window between service account deletion and recreation, the CPI pod expectedly reported brief Unauthorized API errors.

Note: This represents the expected systemic delay before service account regeneration.

Step 6: Recovery Validation
- Once the newly refreshed token synchronized down to the guest cluster, the CPI pod successfully authenticated, and all Unauthorized errors ceased.
- Concluded that recovery occurs gracefully without requiring a pod restart.

Step 7: Post-Rotation Lifecycle Verification
- Cycle the sample LoadBalancer service (delete and recreate) to ensure operational continuity post-rotation.
- Observed the expected asynchronous event loop timing (initial VirtualMachineService IP not found warnings while the infrastructure was provisioning), followed quickly by a successful EnsuredLoadBalancer status confirmation.

Step 8: Pod Restart Testing
- Manually modify the token secret's ca.crt field in the guest cluster to an invalid value to simulate a corrupted state.
- Confirm that the CPI pod automatically triggers a restart loop as expected when the ca.crt field change is detected.

Step 9: Environmental Recovery
- Revert the token secret's ca.crt field back to its original valid value.
- Confirm that the CPI pod restarts, successfully recovers its authenticated state, and returns to a healthy Running status.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
