### PR TITLE
✨Remove the use of the cryptographically weak MD5 hash

### DIFF
--- a/hack/images/ci/conformance.sh
+++ b/hack/images/ci/conformance.sh
@@ -81,7 +81,12 @@ export TF_VAR_vsphere_network="sddc-cgw-network-3"
 
 # The cluster name is a combination of the build ID and the first seven
 # characters of a hash of the job ID.
-CLUSTER_NAME="prow-$(echo "${BUILD_ID:-1}-${PROW_JOB_ID:-$(date +%s)}" | { md5sum 2>/dev/null || md5; } | awk '{print $1}' | cut -c-7)"
+if command -v python3 >/dev/null 2>&1; then
+  SUFFIX=$(python3 -c "h = 2166136261; [h := ((h ^ b) * 16777619) & 0xffffffff for b in b\"${BUILD_ID:-1}-${PROW_JOB_ID:-$(date +%s)}\"]; print(f\"{h:08x}\")" | cut -c-7)
+else
+  SUFFIX=$(echo "${BUILD_ID:-1}-${PROW_JOB_ID:-$(date +%s)}" | { sha256sum 2>/dev/null || shasum -a 256; } | awk '{print $1}' | cut -c-7)
+fi
+CLUSTER_NAME="prow-${SUFFIX}"
 
 # Write information about the build out to disk.
 cat <<EOF >"${ARTIFACTS-}/build-info.json"

--- a/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice.go
@@ -18,7 +18,7 @@ package vmservice
 
 import (
 	"context"
-	"crypto/md5" // #nosec
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"reflect"
@@ -29,6 +29,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	vmop "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator"
 	vmoptypes "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual/vmoperator/types"
@@ -106,13 +107,48 @@ func NewVMService(vmClient vmop.Interface, ns string, ownerRef *metav1.OwnerRefe
 }
 
 func (s *vmService) hashString(str string) string {
-	// #nosec
-	hash := md5.New()
+	// SHA-256 is used as a FIPS-approved, well-distributed hash to derive a
+	// deterministic name suffix. The output is later truncated to
+	// MaxCheckSumLen; this is not a security-sensitive use.
+	hash := sha256.New()
 	if _, err := hash.Write([]byte(str)); err != nil {
 		log.Error(err, "create hash string failed")
 	}
 
 	return hex.EncodeToString(hash.Sum(nil))
+}
+
+// findLegacyVMService locates a VirtualMachineService that was created by an
+// older release using a different name-hashing scheme. It matches on the
+// identifying labels that the CPI has always stamped on every
+// VirtualMachineService, so the lookup is independent of how the name was
+// generated. Returns nil when no matching resource exists.
+//
+// Any List error (including a missing "list" RBAC permission) is logged and
+// treated as "no legacy resource found" so that the primary, name-based flow is
+// never blocked. In particular, a freshly created Service has no
+// VirtualMachineService yet and must still be able to proceed to Create.
+func (s *vmService) findLegacyVMService(ctx context.Context, service *v1.Service, clusterName string) *vmoptypes.VirtualMachineServiceInfo {
+	logger := log.WithValues("name", service.Name, "namespace", service.Namespace)
+
+	selector := labels.SelectorFromSet(labels.Set{
+		LabelClusterNameKey:      clusterName,
+		LabelServiceNameKey:      service.Name,
+		LabelServiceNameSpaceKey: service.Namespace,
+	}).String()
+
+	list, err := s.vmClient.VirtualMachineServices().List(ctx, s.namespace, vmoptypes.ListOptions{LabelSelector: selector})
+	if err != nil {
+		logger.Error(err, "failed to list VirtualMachineServices for legacy lookup; treating as not found")
+		return nil
+	}
+	if len(list) == 0 {
+		return nil
+	}
+	if len(list) > 1 {
+		logger.V(2).Info("multiple VirtualMachineServices matched the legacy label lookup; using the first", "count", len(list))
+	}
+	return list[0]
 }
 
 // GetVMServiceName returns VirtualMachineService name for a lb type of service
@@ -133,9 +169,17 @@ func (s *vmService) Get(ctx context.Context, service *v1.Service, clusterName st
 	logger := log.WithValues("name", service.Name, "namespace", service.Namespace)
 	logger.V(2).Info("Attempting to get VirtualMachineService")
 
-	vmService, err := s.vmClient.VirtualMachineServices().Get(ctx, s.namespace, s.GetVMServiceName(service, clusterName))
+	name := s.GetVMServiceName(service, clusterName)
+	vmService, err := s.vmClient.VirtualMachineServices().Get(ctx, s.namespace, name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			// Fallback for resources created by an older release that used a
+			// different name-hashing scheme. Located via the always-present
+			// identifying labels rather than by recomputing the legacy name.
+			if legacy := s.findLegacyVMService(ctx, service, clusterName); legacy != nil {
+				logger.V(2).Info("VirtualMachineService not found by name; found legacy resource via labels", "legacyName", legacy.Name)
+				return legacy, nil
+			}
 			return nil, nil
 		}
 		logger.Error(ErrGetVMService, fmt.Sprintf("%v", err))
@@ -304,8 +348,27 @@ func (s *vmService) Delete(ctx context.Context, service *v1.Service, clusterName
 	logger := log.WithValues("name", service.Name, "namespace", service.Namespace)
 	logger.V(2).Info("Attempting to delete VirtualMachineService")
 
-	err := s.vmClient.VirtualMachineServices().Delete(ctx, s.namespace, s.GetVMServiceName(service, clusterName))
+	name := s.GetVMServiceName(service, clusterName)
+	err := s.vmClient.VirtualMachineServices().Delete(ctx, s.namespace, name)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Fallback: a resource created by an older release lives under a
+			// different name. Locate it via the identifying labels and delete it.
+			legacy := s.findLegacyVMService(ctx, service, clusterName)
+			if legacy == nil {
+				return nil
+			}
+			logger.V(2).Info("VirtualMachineService not found by name; deleting legacy resource found via labels", "legacyName", legacy.Name)
+			if derr := s.vmClient.VirtualMachineServices().Delete(ctx, s.namespace, legacy.Name); derr != nil {
+				if apierrors.IsNotFound(derr) {
+					return nil
+				}
+				logger.Error(ErrDeleteVMService, fmt.Sprintf("failed to delete legacy VirtualMachineService: %v", derr))
+				return derr
+			}
+			logger.V(2).Info("Successfully deleted legacy VirtualMachineService")
+			return nil
+		}
 		logger.Error(ErrDeleteVMService, fmt.Sprintf("%v", err))
 		return err
 	}

--- a/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice.go
@@ -122,13 +122,16 @@ func (s *vmService) hashString(str string) string {
 // older release using a different name-hashing scheme. It matches on the
 // identifying labels that the CPI has always stamped on every
 // VirtualMachineService, so the lookup is independent of how the name was
-// generated. Returns nil when no matching resource exists.
+// generated. Returns (nil, nil) when no matching resource exists.
 //
-// Any List error (including a missing "list" RBAC permission) is logged and
-// treated as "no legacy resource found" so that the primary, name-based flow is
-// never blocked. In particular, a freshly created Service has no
-// VirtualMachineService yet and must still be able to proceed to Create.
-func (s *vmService) findLegacyVMService(ctx context.Context, service *v1.Service, clusterName string) *vmoptypes.VirtualMachineServiceInfo {
+// The lookup fails closed: any List error (including a missing "list" RBAC
+// permission) is returned to the caller rather than being swallowed. Swallowing
+// the error would make an unreadable legacy resource look like "not found",
+// causing the caller to create a duplicate VirtualMachineService under the new
+// name-hashing scheme. A genuine empty result is not an error, so a freshly
+// created Service (which has no VirtualMachineService yet) still returns
+// (nil, nil) and can proceed to Create.
+func (s *vmService) findLegacyVMService(ctx context.Context, service *v1.Service, clusterName string) (*vmoptypes.VirtualMachineServiceInfo, error) {
 	logger := log.WithValues("name", service.Name, "namespace", service.Namespace)
 
 	selector := labels.SelectorFromSet(labels.Set{
@@ -139,16 +142,16 @@ func (s *vmService) findLegacyVMService(ctx context.Context, service *v1.Service
 
 	list, err := s.vmClient.VirtualMachineServices().List(ctx, s.namespace, vmoptypes.ListOptions{LabelSelector: selector})
 	if err != nil {
-		logger.Error(err, "failed to list VirtualMachineServices for legacy lookup; treating as not found")
-		return nil
+		logger.Error(err, "failed to list VirtualMachineServices for legacy lookup")
+		return nil, err
 	}
 	if len(list) == 0 {
-		return nil
+		return nil, nil
 	}
 	if len(list) > 1 {
 		logger.V(2).Info("multiple VirtualMachineServices matched the legacy label lookup; using the first", "count", len(list))
 	}
-	return list[0]
+	return list[0], nil
 }
 
 // GetVMServiceName returns VirtualMachineService name for a lb type of service
@@ -176,7 +179,16 @@ func (s *vmService) Get(ctx context.Context, service *v1.Service, clusterName st
 			// Fallback for resources created by an older release that used a
 			// different name-hashing scheme. Located via the always-present
 			// identifying labels rather than by recomputing the legacy name.
-			if legacy := s.findLegacyVMService(ctx, service, clusterName); legacy != nil {
+			//
+			// Fail closed: if the legacy lookup itself errors, surface the error
+			// instead of returning "not found". Returning nil here would make the
+			// caller create a duplicate VirtualMachineService under the new name.
+			legacy, legacyErr := s.findLegacyVMService(ctx, service, clusterName)
+			if legacyErr != nil {
+				logger.Error(ErrGetVMService, fmt.Sprintf("legacy lookup failed: %v", legacyErr))
+				return nil, legacyErr
+			}
+			if legacy != nil {
 				logger.V(2).Info("VirtualMachineService not found by name; found legacy resource via labels", "legacyName", legacy.Name)
 				return legacy, nil
 			}
@@ -354,7 +366,15 @@ func (s *vmService) Delete(ctx context.Context, service *v1.Service, clusterName
 		if apierrors.IsNotFound(err) {
 			// Fallback: a resource created by an older release lives under a
 			// different name. Locate it via the identifying labels and delete it.
-			legacy := s.findLegacyVMService(ctx, service, clusterName)
+			//
+			// Fail closed: if the legacy lookup errors, surface the error rather
+			// than reporting a successful delete. Returning nil could orphan a
+			// legacy VirtualMachineService that we simply failed to read.
+			legacy, legacyErr := s.findLegacyVMService(ctx, service, clusterName)
+			if legacyErr != nil {
+				logger.Error(ErrDeleteVMService, fmt.Sprintf("legacy lookup failed: %v", legacyErr))
+				return legacyErr
+			}
 			if legacy == nil {
 				return nil
 			}

--- a/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice.go
@@ -82,12 +82,13 @@ var excludedAnnotations = []string{
 
 // A list of possible error messages
 var (
-	ErrCreateVMService     = errors.New("failed to create VirtualMachineService")
-	ErrUpdateVMService     = errors.New("failed to update VirtualMachineService")
-	ErrGetVMService        = errors.New("failed to get VirtualMachineService")
-	ErrDeleteVMService     = errors.New("failed to delete VirtualMachineService")
-	ErrVMServiceIPNotFound = errors.New("VirtualMachineService IP not found")
-	ErrNodePortNotFound    = errors.New("NodePort not found")
+	ErrCreateVMService          = errors.New("failed to create VirtualMachineService")
+	ErrUpdateVMService          = errors.New("failed to update VirtualMachineService")
+	ErrGetVMService             = errors.New("failed to get VirtualMachineService")
+	ErrDeleteVMService          = errors.New("failed to delete VirtualMachineService")
+	ErrVMServiceIPNotFound      = errors.New("VirtualMachineService IP not found")
+	ErrNodePortNotFound         = errors.New("NodePort not found")
+	ErrMultipleLegacyVMServices = errors.New("multiple VirtualMachineServices matched the legacy label lookup")
 )
 
 var (
@@ -107,7 +108,7 @@ func NewVMService(vmClient vmop.Interface, ns string, ownerRef *metav1.OwnerRefe
 }
 
 func (s *vmService) hashString(str string) string {
-	// SHA-256 is used as a FIPS-approved, well-distributed hash to derive a
+	// SHA-256 is used as a FIPS-compliant, well-distributed hash to derive a
 	// deterministic name suffix. The output is later truncated to
 	// MaxCheckSumLen; this is not a security-sensitive use.
 	hash := sha256.New()
@@ -149,7 +150,8 @@ func (s *vmService) findLegacyVMService(ctx context.Context, service *v1.Service
 		return nil, nil
 	}
 	if len(list) > 1 {
-		logger.V(2).Info("multiple VirtualMachineServices matched the legacy label lookup; using the first", "count", len(list))
+		logger.Error(ErrMultipleLegacyVMServices, "multiple VirtualMachineServices matched the legacy label lookup", "count", len(list))
+		return nil, ErrMultipleLegacyVMServices
 	}
 	return list[0], nil
 }

--- a/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice_test.go
@@ -176,6 +176,62 @@ func TestGetVMService(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestGetVMService_LegacyFallback(t *testing.T) {
+	testK8sService, vms, _ := initTest(testServiceAnnotationPropagationEnabled)
+	k8sService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testK8sServiceName,
+			Namespace: testK8sServiceNameSpace,
+		},
+	}
+
+	// Simulate a VirtualMachineService created by an older release: it lives
+	// under a name that does NOT match the current (SHA-256-based) scheme, but it
+	// carries the identifying labels that the CPI has always stamped on every
+	// VirtualMachineService.
+	legacyName := "legacy-" + testClustername + "-deadbeef"
+	ports, _ := findPorts(testK8sService)
+	legacyInfo := &vmoptypes.VirtualMachineServiceInfo{
+		Name:      legacyName,
+		Namespace: testClusterNameSpace,
+		Labels: map[string]string{
+			LabelClusterNameKey:      testClustername,
+			LabelServiceNameKey:      testK8sServiceName,
+			LabelServiceNameSpaceKey: testK8sServiceNameSpace,
+		},
+		Spec: vmoptypes.VirtualMachineServiceSpec{
+			Type:  vmoptypes.VirtualMachineServiceTypeLoadBalancer,
+			Ports: ports,
+			Selector: map[string]string{
+				ClusterSelectorKey: testClustername,
+				NodeSelectorKey:    NodeRole,
+			},
+		},
+	}
+	_, err := vms.(*vmService).vmClient.VirtualMachineServices().Create(context.Background(), legacyInfo)
+	assert.NoError(t, err)
+
+	// Sanity check: the legacy resource is not reachable by the current name.
+	currentName := vms.GetVMServiceName(k8sService, testClustername)
+	assert.NotEqual(t, legacyName, currentName)
+
+	// Get must fall back to the label-based lookup and find the legacy resource.
+	vmServiceObj, err := vms.Get(context.Background(), k8sService, testClustername)
+	assert.NoError(t, err)
+	assert.NotNil(t, vmServiceObj)
+	assert.Equal(t, legacyName, vmServiceObj.Name)
+
+	// Delete must likewise fall back and remove the legacy resource.
+	err = vms.Delete(context.Background(), k8sService, testClustername)
+	assert.NoError(t, err)
+
+	// Verify it is indeed deleted.
+	deletedObj, err := vms.(*vmService).vmClient.VirtualMachineServices().Get(context.Background(), testClusterNameSpace, legacyName)
+	assert.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err))
+	assert.Nil(t, deletedObj)
+}
+
 func TestCreateVMService(t *testing.T) {
 	testK8sService, vms, _ := initTest(testServiceAnnotationPropagationEnabled)
 	ports, _ := findPorts(testK8sService)

--- a/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice_test.go
@@ -269,6 +269,73 @@ func TestDeleteVMService_LegacyLookupError(t *testing.T) {
 	assert.True(t, apierrors.IsForbidden(err))
 }
 
+func TestGetVMService_LegacyMultipleMatches(t *testing.T) {
+	testK8sService, vms, _ := initTest(testServiceAnnotationPropagationEnabled)
+
+	// Create two legacy VirtualMachineServices with the same identifying labels.
+	ports, _ := findPorts(testK8sService)
+	for i := 1; i <= 2; i++ {
+		legacyName := fmt.Sprintf("legacy-%s-%d", testClustername, i)
+		legacyInfo := &vmoptypes.VirtualMachineServiceInfo{
+			Name:      legacyName,
+			Namespace: testClusterNameSpace,
+			Labels: map[string]string{
+				LabelClusterNameKey:      testClustername,
+				LabelServiceNameKey:      testK8sServiceName,
+				LabelServiceNameSpaceKey: testK8sServiceNameSpace,
+			},
+			Spec: vmoptypes.VirtualMachineServiceSpec{
+				Type:  vmoptypes.VirtualMachineServiceTypeLoadBalancer,
+				Ports: ports,
+				Selector: map[string]string{
+					ClusterSelectorKey: testClustername,
+					NodeSelectorKey:    NodeRole,
+				},
+			},
+		}
+		_, err := vms.(*vmService).vmClient.VirtualMachineServices().Create(context.Background(), legacyInfo)
+		assert.NoError(t, err)
+	}
+
+	// Get must fail and return ErrMultipleLegacyVMServices.
+	vmServiceObj, err := vms.Get(context.Background(), testK8sService, testClustername)
+	assert.ErrorIs(t, err, ErrMultipleLegacyVMServices)
+	assert.Nil(t, vmServiceObj)
+}
+
+func TestDeleteVMService_LegacyMultipleMatches(t *testing.T) {
+	testK8sService, vms, _ := initTest(testServiceAnnotationPropagationEnabled)
+
+	// Create two legacy VirtualMachineServices with the same identifying labels.
+	ports, _ := findPorts(testK8sService)
+	for i := 1; i <= 2; i++ {
+		legacyName := fmt.Sprintf("legacy-%s-%d", testClustername, i)
+		legacyInfo := &vmoptypes.VirtualMachineServiceInfo{
+			Name:      legacyName,
+			Namespace: testClusterNameSpace,
+			Labels: map[string]string{
+				LabelClusterNameKey:      testClustername,
+				LabelServiceNameKey:      testK8sServiceName,
+				LabelServiceNameSpaceKey: testK8sServiceNameSpace,
+			},
+			Spec: vmoptypes.VirtualMachineServiceSpec{
+				Type:  vmoptypes.VirtualMachineServiceTypeLoadBalancer,
+				Ports: ports,
+				Selector: map[string]string{
+					ClusterSelectorKey: testClustername,
+					NodeSelectorKey:    NodeRole,
+				},
+			},
+		}
+		_, err := vms.(*vmService).vmClient.VirtualMachineServices().Create(context.Background(), legacyInfo)
+		assert.NoError(t, err)
+	}
+
+	// Delete must fail and return ErrMultipleLegacyVMServices.
+	err := vms.Delete(context.Background(), testK8sService, testClustername)
+	assert.ErrorIs(t, err, ErrMultipleLegacyVMServices)
+}
+
 func TestCreateVMService(t *testing.T) {
 	testK8sService, vms, _ := initTest(testServiceAnnotationPropagationEnabled)
 	ports, _ := findPorts(testK8sService)

--- a/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice_test.go
+++ b/pkg/cloudprovider/vsphereparavirtual/vmservice/vmservice_test.go
@@ -232,6 +232,43 @@ func TestGetVMService_LegacyFallback(t *testing.T) {
 	assert.Nil(t, deletedObj)
 }
 
+func TestGetVMService_LegacyLookupError(t *testing.T) {
+	testK8sService, vms, fc := initTest(testServiceAnnotationPropagationEnabled)
+
+	// No VMService exists under the current name, so Get falls back to the
+	// label-based legacy lookup. Make that List fail (e.g. a missing "list" RBAC
+	// permission). The lookup must fail closed: Get returns the error rather than
+	// (nil, nil), which would otherwise cause the caller to create a duplicate
+	// VMService under the new name-hashing scheme.
+	listErr := apierrors.NewForbidden(v1alpha1.Resource("virtualmachineservices"), "", fmt.Errorf("no list permission"))
+	fc.PrependReactor("list", "virtualmachineservices", func(clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, nil, listErr
+	})
+
+	vmServiceObj, err := vms.Get(context.Background(), testK8sService, testClustername)
+	assert.Error(t, err)
+	assert.Nil(t, vmServiceObj)
+	assert.True(t, apierrors.IsForbidden(err))
+}
+
+func TestDeleteVMService_LegacyLookupError(t *testing.T) {
+	testK8sService, vms, fc := initTest(testServiceAnnotationPropagationEnabled)
+
+	// No VMService exists under the current name, so Delete falls back to the
+	// label-based legacy lookup. Make that List fail. The lookup must fail closed:
+	// Delete returns the error rather than reporting a successful (no-op) delete,
+	// which would otherwise silently orphan a legacy VMService we merely failed to
+	// read.
+	listErr := apierrors.NewForbidden(v1alpha1.Resource("virtualmachineservices"), "", fmt.Errorf("no list permission"))
+	fc.PrependReactor("list", "virtualmachineservices", func(clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, nil, listErr
+	})
+
+	err := vms.Delete(context.Background(), testK8sService, testClustername)
+	assert.Error(t, err)
+	assert.True(t, apierrors.IsForbidden(err))
+}
+
 func TestCreateVMService(t *testing.T) {
 	testK8sService, vms, _ := initTest(testServiceAnnotationPropagationEnabled)
 	ports, _ := findPorts(testK8sService)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Remove the use of the cryptographically weak MD5 hash (crypto/md5)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1783 

**Special notes for your reviewer**:
Test Verification Plan & Results

1. Baseline Setup: Provisioned a guest cluster using the paravirtual CPI without these changes applied.
2. Workload Deployment: Created a sample NGINX deployment and a LoadBalancer (LB) service on the guest cluster.
3. Supervisor Validation: Confirmed the sample service successfully initialized on the guest cluster, and verified that the corresponding VirtualMachineService and Service resources were correctly created on the Supervisor cluster.
4. Traffic Verification: Verified endpoint connectivity by executing a curl command against the LoadBalancer IP to confirm it was healthy.
5. Upgrade Trigger: Upgraded the CPI component to the build generated by this PR.
6. Post-Upgrade Stability: Confirmed that no duplicate or additional Service or VirtualMachineService resources were generated on the Supervisor. Verified existing resources continued to run as expected with no disruptions or changes to the LoadBalancer IP.
7. Teardown Validation: Deleted the sample NGINX service on the guest cluster and verified that the associated Service and VirtualMachineService resources on the Supervisor were cleanly deleted.
8. Migration Verification: Recreated the NGINX service on the guest cluster and confirmed that the newly generated Service and VirtualMachineService resources correctly adopted the new naming pattern.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
9. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Replaced MD5 with SHA-256 for VirtualMachineService names with a backward-compatible label fallback; upgrading requires adding the list verb to the CPI's virtualmachineservices RBAC.
```
