### PR TITLE
Add Helm index entry for v1.36.0 chart

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,6 +2,25 @@ apiVersion: v1
 entries:
   vsphere-cpi:
   - apiVersion: v2
+    appVersion: 1.36.0
+    created: "2026-07-17T14:26:56.015573+03:30"
+    description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)
+    digest: 657f29b3409645592a6183c5199bb672dce7bb3b9e3ecbe70df7564d5e722752
+    home: https://github.com/kubernetes/cloud-provider-vsphere
+    icon: https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/master/docs/vmware_logo.png
+    keywords:
+    - vsphere
+    - vmware
+    - cloud
+    - provider
+    - cpi
+    name: vsphere-cpi
+    sources:
+    - https://github.com/kubernetes/cloud-provider-vsphere
+    urls:
+    - https://kubernetes.github.io/cloud-provider-vsphere/charts/vsphere-cpi-1.36.0.tgz
+    version: 1.36.0
+  - apiVersion: v2
     appVersion: 1.35.1
     created: "2026-03-30T14:19:29.836942697+08:00"
     description: A Helm chart for vSphere Cloud Provider Interface Manager (CPI)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Adds the missing `vsphere-cpi` chart `1.36.0` entry to `gh-pages/index.yaml` so Helm clients can discover the chart package that already exists at `charts/vsphere-cpi-1.36.0.tgz`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1795

**Special notes for your reviewer**:
The chart package was already added in `a27075b`; this PR only adds the corresponding Helm repository index metadata. Validated with `helm search repo`, `helm pull`, checksum comparison, and `helm template`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
