### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/auto-release-helm-chart.yml
+++ b/.github/workflows/auto-release-helm-chart.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # This step uses Github's checkout-action: https://github.com/actions/checkout
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag=v7.0.0
         with:
           fetch-depth: 0
 
@@ -32,13 +32,13 @@ jobs:
 
       # Install Helm
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@95ecf4967d92f8074e91c548e394f8ac547da403 # tag=v5.0.1
         with:
           version: v3.4.0
 
       # Run chart-releaser action (https://github.com/helm/chart-releaser-action)
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # tag=v1.7.0
         with:
           charts_dir: charts
         env:

--- a/.github/workflows/auto-sync-gh-pages.yml
+++ b/.github/workflows/auto-sync-gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # This step uses Github's checkout-action: https://github.com/actions/checkout
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag=v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/bump-k8s-dep.yml
+++ b/.github/workflows/bump-k8s-dep.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag=v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@0778a10ce47b5d450cf60fb94fafad4330008a35 # tag=v7.0.0
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/bump-test-k8s-dep.yml
+++ b/.github/workflows/bump-test-k8s-dep.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag=v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@0778a10ce47b5d450cf60fb94fafad4330008a35 # tag=v7.0.0
         with:
           go-version-file: 'test/e2e/go.mod'
 

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # This step uses Github's checkout-action: https://github.com/actions/checkout
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # tag=v7.0.0
         with:
           fetch-depth: 0
 
@@ -29,7 +29,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@0778a10ce47b5d450cf60fb94fafad4330008a35 # tag=v7.0.0
         with:
           go-version-file: 'go.mod'
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
All GitHub Actions must be pinned to a full-length 40-character commit SHA to comply with the security policy of the kubernetes organization.

- Pin actions/checkout to 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 (v7.0.0)
- Pin actions/setup-go to 0778a10ce47b5d450cf60fb94fafad4330008a35 (v7.0.0)
- Pin azure/setup-helm to 95ecf4967d92f8074e91c548e394f8ac547da403 (v5.0.1)
- Pin helm/chart-releaser-action to cae68fefc6b5f367a0275617c9f83181ba54714f (v1.7.0)
- 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
