### PR TITLE
🐛 fix node IP address parsing in test helper

### DIFF
--- a/test/e2e/cpi_vm_test.go
+++ b/test/e2e/cpi_vm_test.go
@@ -77,7 +77,7 @@ func getExternalIPFromNode(node *corev1.Node) (string, error) {
 	addresses := node.Status.Addresses
 	for _, address := range addresses {
 		if address.Type == corev1.NodeExternalIP {
-			return address.String(), nil
+			return address.Address, nil
 		}
 	}
 	return "", errors.New("external IP not found")
@@ -88,7 +88,7 @@ func getInternalIPFromNode(node *corev1.Node) (string, error) {
 	addresses := node.Status.Addresses
 	for _, address := range addresses {
 		if address.Type == corev1.NodeInternalIP {
-			return address.String(), nil
+			return address.Address, nil
 		}
 	}
 	return "", errors.New("internal IP not found")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In the getInternalIPFromNode and getExternalIPFromNode helpers, returning address.String() returns the stringified Go/protobuf struct. Use address.Address to return the raw IP.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
