### PR TITLE
🐛 Handle timing race when fetching CAPI Machine and VM objects

### DIFF
--- a/test/e2e/cpi_vm_test.go
+++ b/test/e2e/cpi_vm_test.go
@@ -194,15 +194,31 @@ var _ = Describe("Restarting, recreating and deleting VMs", func() {
 		})
 
 		By("Get the machine object in bootstrap cluster", func() {
-			workerMachine, err = getWorkerMachine(workerNode.Name)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(workerMachine).ToNot(BeNil())
+			Eventually(func() error {
+				var err error
+				workerMachine, err = getWorkerMachine(workerNode.Name)
+				if err != nil {
+					return err
+				}
+				if workerMachine == nil {
+					return errors.New("worker machine is nil")
+				}
+				return nil
+			}, 5*time.Minute, 5*time.Second).Should(Succeed(), "failed to get machine object in bootstrap cluster")
 		})
 
 		By("Get corresponding VM object for node", func() {
-			workerVM, err = getWorkerVM(workerNode.Name)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(workerVM).ToNot(BeNil())
+			Eventually(func() error {
+				var err error
+				workerVM, err = getWorkerVM(workerNode.Name)
+				if err != nil {
+					return err
+				}
+				if workerVM == nil {
+					return errors.New("worker VM is nil")
+				}
+				return nil
+			}, 5*time.Minute, 5*time.Second).Should(Succeed(), "failed to get VM object for node")
 		})
 	})
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When running VM lifecycle specs sequentially, a newly recreated Node might register with the cluster before the CAPI controllers have finished updating its NodeRef mapping in the bootstrap cluster's Machine status. This causes an immediate "machine not found" error during BeforeEach.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
