### PR TITLE
Restore worker node state to fix e2e test flake

### DIFF
--- a/test/e2e/cpi_vm_test.go
+++ b/test/e2e/cpi_vm_test.go
@@ -373,19 +373,50 @@ var _ = Describe("Restarting, recreating and deleting VMs", func() {
 			return DoesNodeHasReadiness(workerNode, corev1.ConditionTrue)
 		}, 10*time.Minute).Should(BeTrue())
 
-		By("Powering off machine object")
-		task, err := workerVM.PowerOff(ctx)
-		Expect(err).ToNot(HaveOccurred(), "cannot power off vm")
+		By("Pause reconcile for workload cluster", func() {
+			updateClusterSpecPaused(ctx, workloadResult.Cluster.Name, workloadResult.Cluster.Namespace, "true")
+			Eventually(func() bool {
+				wldCluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
+					Getter:    proxy.GetClient(),
+					Namespace: workloadResult.Cluster.Namespace,
+					Name:      workloadResult.Cluster.Name,
+				})
 
-		err = task.Wait(ctx)
-		Expect(err).ToNot(HaveOccurred(), "cannot wait for vm to power off")
+				return ptr.Deref(wldCluster.Spec.Paused, false)
+			}, 180*time.Second, 10*time.Second).Should(BeTrue(), "Failed to pause the Workload Cluster")
+		})
 
-		By("Delete VM from VC")
-		task, err = workerVM.Destroy(ctx)
-		Expect(err).ToNot(HaveOccurred(), "cannot destroy vm")
+		By("Powering off machine object", func() {
+			task, err := workerVM.PowerOff(ctx)
+			Expect(err).ToNot(HaveOccurred(), "cannot power off vm")
 
-		err = task.Wait(ctx)
-		Expect(err).ToNot(HaveOccurred(), "cannot wait for vm to destroy")
+			err = task.Wait(ctx)
+			Expect(err).ToNot(HaveOccurred(), "cannot wait for vm to power off")
+		})
+
+		By("Wait for VM " + workerVM.Name() + " to go down")
+		Eventually(WaitForVMPowerState(workerVM.Name(), types.VirtualMachinePowerStatePoweredOff), 1*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("Delete VM from VC", func() {
+			task, err := workerVM.Destroy(ctx)
+			Expect(err).ToNot(HaveOccurred(), "cannot destroy vm")
+
+			err = task.Wait(ctx)
+			Expect(err).ToNot(HaveOccurred(), "cannot wait for vm to destroy")
+		})
+
+		By("Unpause reconcile for workload cluster", func() {
+			updateClusterSpecPaused(ctx, workloadResult.Cluster.Name, workloadResult.Cluster.Namespace, "false")
+			Eventually(func() bool {
+				wldCluster := framework.GetClusterByName(ctx, framework.GetClusterByNameInput{
+					Getter:    proxy.GetClient(),
+					Namespace: workloadResult.Cluster.Namespace,
+					Name:      workloadResult.Cluster.Name,
+				})
+
+				return ptr.Deref(wldCluster.Spec.Paused, false)
+			}, 180*time.Second, 10*time.Second).Should(BeFalse(), "Failed to unpause the Workload Cluster")
+		})
 
 		By("Eventually original node will be gone")
 		Eventually(func() bool {

--- a/test/e2e/cpi_vm_test.go
+++ b/test/e2e/cpi_vm_test.go
@@ -392,5 +392,17 @@ var _ = Describe("Restarting, recreating and deleting VMs", func() {
 			_, err := workloadClientset.CoreV1().Nodes().Get(ctx, workerNode.Name, metav1.GetOptions{})
 			return err != nil && apierrors.IsNotFound(err)
 		}, 5*time.Minute, 5*time.Second).Should(BeTrue())
+
+		By("Delete machine object")
+		err = deleteWorkerMachine(workerMachine.Name)
+		Expect(err).To(BeNil(), "cannot delete machine object")
+
+		By("Eventually new node will be created")
+		Eventually(func() error {
+			if workerNode, err = getWorkerNode(); err != nil {
+				return err
+			}
+			return nil
+		}, 10*time.Minute, 5*time.Second).Should(Succeed())
 	})
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Wait for the worker VM to reach PoweredOff state before destroying it from vCenter, and delete the CAPI Machine object afterwards to ensure Cluster API recreates a worker node for subsequent test specs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
