### PR TITLE
Fix flake to fetch worker node internal IP

### DIFF
--- a/test/e2e/cpi_install_test.go
+++ b/test/e2e/cpi_install_test.go
@@ -61,7 +61,9 @@ var _ = Describe("Deploy cloud provider vSphere with helm", func() {
 				return errors.New("CPI daemon list is empty")
 			}
 			daemon, err := findVSphereCPIDaemonsetInList(daemonList)
-			Expect(err).ShouldNot(HaveOccurred())
+			if err != nil {
+				return err
+			}
 
 			By("CPI daemon should be running")
 			if daemon.Status.NumberReady != daemon.Status.DesiredNumberScheduled {
@@ -74,17 +76,28 @@ var _ = Describe("Deploy cloud provider vSphere with helm", func() {
 	It("should have all CPI pods in the running state", func() {
 		Eventually(func() error {
 			pods, err := workloadClientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
-			Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				return err
+			}
+			foundPod := false
 			for _, pod := range pods.Items {
 				if strings.HasPrefix(pod.Name, daemonsetName) {
-					Expect(pod.Status.Phase).To(Equal(corev1.PodRunning))
+					foundPod = true
+					if pod.Status.Phase != corev1.PodRunning {
+						return fmt.Errorf("pod %s is in phase %s, expected Running", pod.Name, pod.Status.Phase)
+					}
 					for _, containerStatus := range pod.Status.ContainerStatuses {
-						Expect(containerStatus.Ready).To(BeTrue())
+						if !containerStatus.Ready {
+							return fmt.Errorf("container %s in pod %s is not ready", containerStatus.Name, pod.Name)
+						}
 					}
 				}
 			}
+			if !foundPod {
+				return fmt.Errorf("no pods found with prefix %s", daemonsetName)
+			}
 			return nil
-		}).Should(Succeed())
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
 	})
 
 	It("should apply nodes config and select correct internal IP for worker node", func() {
@@ -93,21 +106,21 @@ var _ = Describe("Deploy cloud provider vSphere with helm", func() {
 		var originalInternalIP string
 		var networkName string
 
-		By("Get the current active worker node from the cluster", func() {
+		By("Get the current active worker node and its internal IP from the cluster", func() {
 			Eventually(func() error {
 				var err error
 				workerNode, err = getWorkerNode()
 				if err != nil {
 					klog.Infof("waiting for worker node to be available: %v", err)
+					return err
 				}
-				return err
-			}, 10*time.Minute, 5*time.Second).Should(Succeed(), "timed out waiting for a worker node to be available")
-		})
-
-		By("Fetch the Node's Internal IP", func() {
-			var err error
-			originalInternalIP, err = getInternalIPFromNode(workerNode)
-			Expect(err).NotTo(HaveOccurred())
+				originalInternalIP, err = getInternalIPFromNode(workerNode)
+				if err != nil {
+					klog.Infof("waiting for worker node internal IP: %v", err)
+					return err
+				}
+				return nil
+			}, 10*time.Minute, 5*time.Second).Should(Succeed(), "timed out waiting for a worker node with internal IP to be available")
 			Expect(originalInternalIP).NotTo(BeEmpty(), "worker node has no internal IP")
 			klog.Infof("Worker node %s internal IP: %s", workerNode.Name, originalInternalIP)
 		})

--- a/test/e2e/cpi_vm_test.go
+++ b/test/e2e/cpi_vm_test.go
@@ -35,8 +35,11 @@ func getWorkerNode() (*corev1.Node, error) {
 	}
 
 	for _, node := range nodes.Items {
+		if node.DeletionTimestamp != nil {
+			continue
+		}
 		if _, ok := node.GetLabels()[ControlPlaneNodeLabel]; !ok {
-			// get the first worker node
+			// get the first active worker node
 			return &node, nil
 		}
 
@@ -186,8 +189,17 @@ var _ = Describe("Restarting, recreating and deleting VMs", func() {
 
 	BeforeEach(func() {
 		By("Get the name of worker node", func() {
-			workerNode, err = getWorkerNode()
-			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				var err error
+				workerNode, err = getWorkerNode()
+				if err != nil {
+					return err
+				}
+				if _, err = getInternalIPFromNode(workerNode); err != nil {
+					return err
+				}
+				return nil
+			}, 10*time.Minute, 5*time.Second).Should(Succeed(), "failed to get worker node with internal IP")
 
 			klog.Infof("The worker node for testing is %s\n", workerNode.Name)
 			originalWorkerNodeName = workerNode.Name
@@ -297,21 +309,34 @@ var _ = Describe("Restarting, recreating and deleting VMs", func() {
 
 		By("Assert that externalIP, internalIP and providerID are preserved after VM restarts", func() {
 			Eventually(func() error {
+				var err error
 				workerNode, err = getWorkerNode()
-				Expect(err).ToNot(HaveOccurred())
+				if err != nil {
+					return err
+				}
 
 				newExternalIP, err := getExternalIPFromNode(workerNode)
-				Expect(err).ToNot(HaveOccurred())
+				if err != nil {
+					return err
+				}
 
 				newInternalIP, err := getInternalIPFromNode(workerNode)
-				Expect(err).ToNot(HaveOccurred())
+				if err != nil {
+					return err
+				}
 
-				Expect(newExternalIP).To(Equal(externalIP))
-				Expect(newInternalIP).To(Equal(internalIP))
-				Expect(getProviderIDFromNode(workerNode)).To(Equal(providerID))
+				if newExternalIP != externalIP {
+					return fmt.Errorf("external IP changed: expected %s, got %s", externalIP, newExternalIP)
+				}
+				if newInternalIP != internalIP {
+					return fmt.Errorf("internal IP changed: expected %s, got %s", internalIP, newInternalIP)
+				}
+				if getProviderIDFromNode(workerNode) != providerID {
+					return fmt.Errorf("provider ID changed: expected %s, got %s", providerID, getProviderIDFromNode(workerNode))
+				}
 
 				return nil
-			}).Should(Succeed())
+			}, 5*time.Minute, 5*time.Second).Should(Succeed())
 		})
 	})
 
@@ -428,12 +453,17 @@ var _ = Describe("Restarting, recreating and deleting VMs", func() {
 		err = deleteWorkerMachine(workerMachine.Name)
 		Expect(err).To(BeNil(), "cannot delete machine object")
 
-		By("Eventually new node will be created")
-		Eventually(func() error {
-			if workerNode, err = getWorkerNode(); err != nil {
-				return err
-			}
-			return nil
-		}, 10*time.Minute, 5*time.Second).Should(Succeed())
+		By("Eventually new node will be created", func() {
+			Eventually(func() error {
+				var err error
+				if workerNode, err = getWorkerNode(); err != nil {
+					return err
+				}
+				if _, err = getInternalIPFromNode(workerNode); err != nil {
+					return err
+				}
+				return nil
+			}, 10*time.Minute, 5*time.Second).Should(Succeed(), "failed to get new worker node with internal IP")
+		})
 	})
 })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Filter out terminating nodes in getWorkerNode and ensure tests wait until the worker node's internal IP address is populated before proceeding. This fixes a race condition where getInternalIPFromNode failed immediately after node creation in cpi_install_test.go.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
