### PR TITLE
🌱 Bump gcb-docker-gcloud to a prod image

### DIFF
--- a/cloudbuild-nightly.yaml
+++ b/cloudbuild-nightly.yaml
@@ -1,11 +1,10 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-# See https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/gcb-docker-gcloud
 timeout: 2700s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2' # v20260205-38cfa9523f
+  - name: 'registry.k8s.io/releng/gcb-docker-gcloud@sha256:b2651f57b579d925a243e308c41546d4fd895f705de091a5a8a39060e6192604' # v20260806
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,11 +1,10 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
-# See https://console.cloud.google.com/gcr/images/k8s-staging-test-infra/global/gcb-docker-gcloud
 timeout: 2700s
 options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2' # v20260205-38cfa9523f
+  - name: 'registry.k8s.io/releng/gcb-docker-gcloud@sha256:b2651f57b579d925a243e308c41546d4fd895f705de091a5a8a39060e6192604' # v20260806
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Update gcb-docker-gcloud build image in cloudbuild.yaml and cloudbuild-nightly.yaml from staging (gcr.io/k8s-staging-test-infra/gcb-docker-gcloud) to production (registry.k8s.io/releng/gcb-docker-gcloud).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
